### PR TITLE
server/xrayserver: add X-Ray support

### DIFF
--- a/aws/awscloud/awscloud.go
+++ b/aws/awscloud/awscloud.go
@@ -19,11 +19,10 @@ import (
 	"net/http"
 
 	"github.com/google/go-cloud/aws"
-	"github.com/google/go-cloud/gcp"
 	"github.com/google/go-cloud/goose"
 	"github.com/google/go-cloud/mysql/rdsmysql"
 	"github.com/google/go-cloud/runtimevar/paramstore"
-	"github.com/google/go-cloud/server/sdserver"
+	"github.com/google/go-cloud/server/xrayserver"
 )
 
 // AWS is a Goose provider set that includes all Amazon Web Services interface
@@ -31,7 +30,6 @@ import (
 var AWS = goose.NewSet(
 	Services,
 	aws.DefaultSession,
-	gcp.DefaultIdentity, // needed for Stackdriver
 	goose.Value(http.DefaultClient),
 )
 
@@ -42,4 +40,4 @@ var AWS = goose.NewSet(
 var Services = goose.NewSet(
 	rdsmysql.Set,
 	paramstore.NewClient,
-	sdserver.Set)
+	xrayserver.Set)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.0.0-20180421005815-665cf5131b71
 	github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20180321230639-1e456b1c68cb
 	github.com/aws/aws-sdk-go v1.13.20
+	github.com/census-ecosystem/opencensus-go-exporter-aws v0.0.0-20180411051634-41633bc1ff6b
 	github.com/dnaeon/go-vcr v0.0.0-20180504081357-f8a7e8b9c630
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-sql-driver/mysql v0.0.0-20180308100310-1a676ac6e4dc

--- a/server/xrayserver/server.go
+++ b/server/xrayserver/server.go
@@ -1,0 +1,72 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package xrayserver provides the diagnostic hooks for a server using
+// AWS X-Ray.
+package xrayserver
+
+import (
+	"github.com/google/go-cloud/goose"
+	"github.com/google/go-cloud/requestlog"
+	"github.com/google/go-cloud/server"
+
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/service/xray"
+	"github.com/aws/aws-sdk-go/service/xray/xrayiface"
+	exporter "github.com/census-ecosystem/opencensus-go-exporter-aws"
+	"go.opencensus.io/trace"
+)
+
+// Set is a Goose provider set that provides the diagnostic hooks for
+// *server.Server. This set includes ServiceSet.
+var Set = goose.NewSet(
+	server.Set,
+	ServiceSet,
+	NewExporter,
+	goose.Bind(trace.Exporter(nil), (*exporter.Exporter)(nil)),
+	NopLogger{},
+	goose.Bind(requestlog.Logger(nil), NopLogger{}),
+)
+
+// ServiceSet is a Goose provider set that provides the AWS X-Ray service
+// client given an AWS session.
+var ServiceSet = goose.NewSet(
+	NewXRayClient,
+	goose.Bind(xrayiface.XRayAPI(nil), (*xray.XRay)(nil)),
+)
+
+// NewExporter returns a new X-Ray exporter.
+//
+// The second return value is a Goose cleanup function that calls Close
+// on the exporter, ignoring the error.
+func NewExporter(api xrayiface.XRayAPI) (*exporter.Exporter, func(), error) {
+	e, err := exporter.NewExporter(exporter.WithAPI(api))
+	if err != nil {
+		return nil, nil, err
+	}
+	return e, func() { e.Close() }, nil
+}
+
+// NewXRayClient returns a new AWS X-Ray client.
+func NewXRayClient(p client.ConfigProvider) *xray.XRay {
+	return xray.New(p)
+}
+
+// TODO(light): Find a real logger implementation.
+
+// NopLogger is a requestlog.Logger that does nothing.
+type NopLogger struct{}
+
+// Log does nothing.
+func (NopLogger) Log(*requestlog.Entry) {}


### PR DESCRIPTION
Removes need for GCP credentials in the `awscloud.AWS` provider set.