### PR TITLE
travis: Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,4 @@ go: "1.10.x"
 install:
   - "go get -u golang.org/x/vgo"
 script:
-  - "vgo test -covermode=atomic -short -race -coverprofile=coverage.out ./..."
-jobs:
-  include:
-    - os: linux
-stages:
-  - test
+  - "vgo test -short -race ./..."


### PR DESCRIPTION
This change adds a .travis.yml file so that we can start validating pull requests.

Does not run against an OS X build. We can worry about supported platforms and such down the road.

I would like to reenable checking for the copyright header at some point, but I still need to figure out how best to do that.

Fixes #12.