### PR TITLE
testing: Stop touching replay files if not recording

### DIFF
--- a/testing/replay/replay.go
+++ b/testing/replay/replay.go
@@ -87,6 +87,9 @@ func NewAWSRecorder(logf func(string, ...interface{}), mode recorder.Mode, filen
 	})
 	return r, func() {
 		r.Stop()
+		if mode != recorder.ModeRecording {
+			return
+		}
 		if err := fixAWSHeaders(path); err != nil {
 			fmt.Println(err)
 		}


### PR DESCRIPTION
Replay files are being touched for header fixing when no recording is
taking place. This means that runs are full of junk changes to the
replay files that don't mean anything. This change fixes that problem by
only fixing headers if the test is being run in a recording mode.

Fixes #38