### PR TITLE
all: Enable the linter in Travis for modifications only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
 script:
   - "vgo test -short -race ./..."
   - "vgo vendor"
-  - "golangci-lint run --new-from-rev="$TRAVIS_BRANCH" --print-welcome=false $(find . -type d ! -path \"./.git*\" ! -path \"./tests*\" ! -path \"./vendor*\" ! -path \"./goose/internal/goose/testdata*\" ! -path \"*_demo*\")"
+  - "golangci-lint run --new-from-rev=\"$TRAVIS_BRANCH\" --print-welcome=false $(find . -type d ! -path \"./.git*\" ! -path \"./tests*\" ! -path \"./vendor*\" ! -path \"./goose/internal/goose/testdata*\" ! -path \"*_demo*\")"


### PR DESCRIPTION
Issue #41 made it look like that perhaps fixing lint errors that we in
the codebase now is not necessarily valuable anymore (it forced the
conversation in #43 that needed to happen, so doing the work was
helpful in itself, but it doesn't have to be the code itself).

This enables the lint check only for files that have changed since the
master branch, so hopefully should be limited to just those in the
current PR.