### PR TITLE
runtimevar/runtimeconfigurator: separate gRPC dial from client construction

### DIFF
--- a/gcp/gcpcloud/gcpcloud.go
+++ b/gcp/gcpcloud/gcpcloud.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/go-cloud/gcp"
 	"github.com/google/go-cloud/goose"
 	"github.com/google/go-cloud/mysql/cloudmysql"
+	"github.com/google/go-cloud/runtimevar/runtimeconfigurator"
 	"github.com/google/go-cloud/server/sdserver"
 )
 
@@ -30,8 +31,9 @@ var GCP = goose.NewSet(Services, gcp.DefaultIdentity)
 // Google Cloud Platform services in this repository, but does not include
 // credentials. Individual services may require additional configuration.
 var Services = goose.NewSet(
-	gcp.DefaultTransport,
-	gcp.NewHTTPClient,
 	cloudmysql.CertSourceSet,
 	cloudmysql.Open,
+	gcp.DefaultTransport,
+	gcp.NewHTTPClient,
+	runtimeconfigurator.Set,
 	sdserver.Set)

--- a/runtimevar/runtimeconfigurator/example_test.go
+++ b/runtimevar/runtimeconfigurator/example_test.go
@@ -18,9 +18,27 @@ import (
 	"context"
 	"log"
 
+	"github.com/google/go-cloud/gcp"
 	"github.com/google/go-cloud/runtimevar"
 	"github.com/google/go-cloud/runtimevar/runtimeconfigurator"
 )
+
+func ExampleNewClient() {
+	ctx := context.Background()
+	creds, err := gcp.DefaultCredentials(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	stub, cleanup, err := runtimeconfigurator.Dial(ctx, creds.TokenSource)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer cleanup()
+	client := runtimeconfigurator.NewClient(stub)
+
+	// Now use the client.
+	_ = client
+}
 
 func ExampleClient_NewVariable() {
 	// Assume client was created at server startup.

--- a/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
+++ b/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
@@ -78,12 +78,9 @@ func setUp(t *testing.T, fs *fakeServer) (*Client, func()) {
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}
-	client := &Client{
-		conn:   conn,
-		client: pb.NewRuntimeConfigManagerClient(conn),
-	}
+	client := NewClient(pb.NewRuntimeConfigManagerClient(conn))
 	return client, func() {
-		client.Close()
+		conn.Close()
 		s.Stop()
 	}
 }


### PR DESCRIPTION
This allows Runtime Configurator to be injectable from `gcpcloud.Services`.

Fixes #10