### PR TITLE
wire: speed up test execution

### DIFF
--- a/wire/internal/wire/wire_test.go
+++ b/wire/internal/wire/wire_test.go
@@ -68,6 +68,7 @@ func TestWire(t *testing.T) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
 				bctx := test.buildContext()
 				gen, errs := Generate(bctx, wd, test.pkg)
 				if len(gen) > 0 {
@@ -131,15 +132,13 @@ func TestWire(t *testing.T) {
 	})
 
 	t.Run("Determinism", func(t *testing.T) {
-		runs := 10
-		if testing.Short() {
-			runs = 3
-		}
+		const runs = 2
 		for _, test := range tests {
 			if test.wantError {
 				continue
 			}
 			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
 				bctx := test.buildContext()
 				gold, errs := Generate(bctx, wd, test.pkg)
 				if len(errs) > 0 {


### PR DESCRIPTION
1.  Runs subtests in parallel.
2.  Decreases the number of runs of the Determinism test to a constant 2.