### PR TITLE
README: clarify install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Installation is easy, but does require `vgo`. `vgo` is not yet stable, and so bu
 
 ```shell
 $ go get -u golang.org/x/vgo
-$ vgo get -u github.com/google/go-cloud
+$ git clone https://github.com/google/go-cloud.git
+$ cd go-cloud
+$ vgo install ./wire/cmd/gowire
 ```
 Go Cloud builds at the latest stable release of Go. Previous Go versions may compile but are not supported.
 

--- a/samples/guestbook/README.md
+++ b/samples/guestbook/README.md
@@ -23,8 +23,8 @@ You will need to install the following software to run this sample:
 ## Building
 
 `gowire` is not compatible with `vgo` yet, so you must run `vgo mod -vendor`
-first to download all the dependencies in `go.mod`. Running `gowire`
-generates the Wire code.
+first to download all the dependencies in `go.mod`. Running `gowire` generates
+the Wire code. Run the following in the `samples/guestbook` directory:
 
 ```shell
 # First time, for gowire.


### PR DESCRIPTION
- Use `git clone` instead of `vgo get`.
- Add step to install gowire.
- Clarify that Guestbook build instructions must be run in sample directory.

Fixes #170