### PR TITLE
travis: disable Mac builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os:
   - linux
-  - osx
 
 language: go
 go_import_path: github.com/google/go-cloud


### PR DESCRIPTION
This is a temporary measure to work around some transient Travis Mac builder failures we're observing. I expect to revert it next week.