### PR TITLE
samples/guestbook: add step to install kubectl to README

### DIFF
--- a/samples/guestbook/README.md
+++ b/samples/guestbook/README.md
@@ -65,10 +65,10 @@ If you want to run this sample on GCP, you need to create a project, download
 the gcloud SDK, install `kubectl` and log in.
 
 ``` shell
-# install kubectl
+# Install kubectl.
 gcloud components install kubectl
 
-# login
+# Opens a browser to log you into GCP.
 gcloud auth login
 ```
 


### PR DESCRIPTION
Provisioning infrastructure on GCP depends on kubectl. The README now
explicitly states the need for the Kubernetes client and shows how to
install it. By default, kubectl is not included in gcloud's default
components.