### PR TITLE
Rename confusing interface methods

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -111,7 +111,7 @@ func (w *Writer) Close() error {
 // open tries to detect the MIME type of p and write it to the blob.
 func (w *Writer) open(p []byte) (n int, err error) {
 	ct := http.DetectContentType(p)
-	if w.w, err = w.bucket.NewWriter(w.ctx, w.key, ct, w.opt); err != nil {
+	if w.w, err = w.bucket.NewTypedWriter(w.ctx, w.key, ct, w.opt); err != nil {
 		return 0, err
 	}
 	w.buf = nil
@@ -172,7 +172,7 @@ func (b *Bucket) NewWriter(ctx context.Context, key string, opt *WriterOptions) 
 				return nil, err
 			}
 			ct := mime.FormatMediaType(t, p)
-			w, err = b.b.NewWriter(ctx, key, ct, dopt)
+			w, err = b.b.NewTypedWriter(ctx, key, ct, dopt)
 			return &Writer{w: w}, err
 		}
 	}

--- a/blob/blob_test.go
+++ b/blob/blob_test.go
@@ -183,7 +183,7 @@ func (b *bucketSpy) NewRangeReader(ctx context.Context, key string, offset, leng
 	return readerStub{}, nil
 }
 
-func (b *bucketSpy) NewWriter(ctx context.Context, key string, contentType string, opt *driver.WriterOptions) (driver.Writer, error) {
+func (b *bucketSpy) NewTypedWriter(ctx context.Context, key string, contentType string, opt *driver.WriterOptions) (driver.Writer, error) {
 	b.writeContentType = contentType
 	return writerStub{}, nil
 }

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -78,7 +78,7 @@ type Bucket interface {
 	// an error whose BlobError method returns NotFound.
 	NewRangeReader(ctx context.Context, key string, offset, length int64) (Reader, error)
 
-	// NewWriter returns Writer that writes to an object associated with key.
+	// NewTypedWriter returns Writer that writes to an object associated with key.
 	//
 	// A new object will be created unless an object with this key already exists.
 	// Otherwise any previous object with the same name will be replaced.
@@ -89,7 +89,7 @@ type Bucket interface {
 	// empty.
 	//
 	// The caller must call Close on the returned Writer when done writing.
-	NewWriter(ctx context.Context, key string, contentType string, opt *WriterOptions) (Writer, error)
+	NewTypedWriter(ctx context.Context, key string, contentType string, opt *WriterOptions) (Writer, error)
 
 	// Delete deletes the object associated with key. If the specified object does
 	// not exist, NewRangeReader must return an error whose BlobError method

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -141,7 +141,7 @@ func (r reader) Attrs() *driver.ObjectAttrs {
 	}
 }
 
-func (b *bucket) NewWriter(ctx context.Context, key string, contentType string, opt *driver.WriterOptions) (driver.Writer, error) {
+func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType string, opt *driver.WriterOptions) (driver.Writer, error) {
 	relpath, err := resolvePath(key)
 	if err != nil {
 		return nil, fmt.Errorf("open file blob %s: %v", key, err)

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -78,7 +78,7 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 	return &reader{Reader: r}, err
 }
 
-// NewWriter returns Writer that writes to an object associated with key.
+// NewTypedWriter returns Writer that writes to an object associated with key.
 //
 // A new object will be created unless an object with this key already exists.
 // Otherwise any previous object with the same name will be replaced.
@@ -88,7 +88,7 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 // A WriterOptions can be given to change the default behavior of the Writer.
 //
 // The caller must call Close on the returned Writer when done writing.
-func (b *bucket) NewWriter(ctx context.Context, key string, contentType string, opts *driver.WriterOptions) (driver.Writer, error) {
+func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType string, opts *driver.WriterOptions) (driver.Writer, error) {
 	if err := validateObjectChar(key); err != nil {
 		return nil, err
 	}

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -218,7 +218,7 @@ func (b *bucket) newMetadataReader(ctx context.Context, key string) (driver.Read
 	}, nil
 }
 
-// NewWriter returns a writer that writes to an object associated with key.
+// NewTypedWriter returns a writer that writes to an object associated with key.
 //
 // A new object will be created unless an object with this key already exists.
 // Otherwise any previous object with the same name will be replaced.
@@ -228,7 +228,7 @@ func (b *bucket) newMetadataReader(ctx context.Context, key string) (driver.Read
 // A WriterOptions can be given to change the default behavior of the writer.
 //
 // The caller must call Close on the returned writer when done writing.
-func (b *bucket) NewWriter(ctx context.Context, key string, contentType string, opts *driver.WriterOptions) (driver.Writer, error) {
+func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType string, opts *driver.WriterOptions) (driver.Writer, error) {
 	w := &writer{
 		bucket:      b.name,
 		ctx:         ctx,

--- a/go.mod
+++ b/go.mod
@@ -17,19 +17,16 @@ module github.com/google/go-cloud
 replace cloud.google.com/go v0.23.0 => cloud.google.com/go v0.0.0-20180608230132-da2b80561ef3
 
 require (
-	cloud.google.com/go v0.23.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.0.0-20180421005815-665cf5131b71
 	github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20180321230639-1e456b1c68cb
 	github.com/aws/aws-sdk-go v1.13.20
 	github.com/aws/aws-xray-sdk-go v1.0.0-rc.5
 	github.com/census-ecosystem/opencensus-go-exporter-aws v0.0.0-20180411051634-41633bc1ff6b
-	github.com/davecgh/go-spew v1.1.0
 	github.com/dnaeon/go-vcr v0.0.0-20180504081357-f8a7e8b9c630
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-ini/ini v1.37.0
 	github.com/go-sql-driver/mysql v0.0.0-20180308100310-1a676ac6e4dc
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/golang/protobuf v1.1.0
 	github.com/google/go-cmp v0.2.0
 	github.com/googleapis/gax-go v1.0.0
 	github.com/gopherjs/gopherjs v0.0.0-20180424202546-8dffc02ea1cb
@@ -37,7 +34,6 @@ require (
 	github.com/gorilla/mux v1.6.1
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/jtolds/gls v0.0.0-20170503224851-77f18212c9c7
-	github.com/pmezard/go-difflib v1.0.0
 	github.com/smartystreets/assertions v0.0.0-20180301161246-7678a5452ebe
 	github.com/smartystreets/goconvey v0.0.0-20180222194500-ef6db91d284a
 	github.com/smartystreets/gunit v0.0.0-20180314194857-6f0d6275bdcd
@@ -45,14 +41,11 @@ require (
 	go.opencensus.io v0.12.0
 	golang.org/x/net v0.0.0-20180702212446-ed29d75add3d
 	golang.org/x/oauth2 v0.0.0-20180603041954-1e0a3fa8ba9a
-	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
 	golang.org/x/sys v0.0.0-20180329131831-378d26f46672
-	golang.org/x/text v0.3.0
 	golang.org/x/tools v0.0.0-20180314180217-d853e8088c62
 	google.golang.org/api v0.0.0-20180606215403-8e9de5a6de6d
 	google.golang.org/appengine v1.1.0
 	google.golang.org/genproto v0.0.0-20180627194029-ff3583edef7d
 	google.golang.org/grpc v1.13.0
 	gopkg.in/ini.v1 v1.37.0
-	gopkg.in/yaml.v2 v2.2.1
 )

--- a/runtimevar/driver/driver.go
+++ b/runtimevar/driver/driver.go
@@ -39,21 +39,21 @@ type Variable struct {
 // dictate the type of Variable.Value and a decoding function.  The Watcher provider can use the
 // runtimevar.Decoder to facilitate the decoding logic.
 type Watcher interface {
-	// Watch blocks until the variable changes, the Context's Done channel closes or an
+	// WatchVariable blocks until the variable changes, the Context's Done channel closes or an
 	// error occurs.
 	//
 	// If the variable has changed, then method should return a Variable object with the
 	// new value.
 	//
 	// It is recommended that an implementation should avoid returning the same error of the
-	// previous Watch call if the implementation can detect such and treat as no changes had
-	// incurred instead.  A sample case is when the variable is deleted, Watch should return an
-	// error upon initial detection.  A succeeding Watch call may decide to block until
+	// previous WatchVariable call if the implementation can detect such and treat as no changes had
+	// incurred instead.  A sample case is when the variable is deleted, WatchVariable should return an
+	// error upon initial detection.  A succeeding WatchVariable call may decide to block until
 	// the variable source is restored.
 	//
 	// To stop this function from blocking, caller can passed in Context object constructed via
 	// WithCancel and call the cancel function.
-	Watch(context.Context) (Variable, error)
+	WatchVariable(context.Context) (Variable, error)
 	// Close cleans up any resources used by the Watcher object.
 	Close() error
 }

--- a/runtimevar/filevar/filevar.go
+++ b/runtimevar/filevar/filevar.go
@@ -97,11 +97,11 @@ type watcher struct {
 	updateTime time.Time
 }
 
-// Watch blocks until the file changes, the Context's Done channel closes or an error occurs.  It
+// WatchVariable blocks until the file changes, the Context's Done channel closes or an error occurs.  It
 // will return an error if the configuration file is deleted, however, if it has previously returned
-// an error due to missing configuration file, the next Watch call will block until the file has
+// an error due to missing configuration file, the next WatchVariable call will block until the file has
 // been recreated.
-func (w *watcher) Watch(ctx context.Context) (driver.Variable, error) {
+func (w *watcher) WatchVariable(ctx context.Context) (driver.Variable, error) {
 	zeroVar := driver.Variable{}
 	// Check for Context cancellation first before proceeding.
 	select {

--- a/runtimevar/paramstore/paramstore.go
+++ b/runtimevar/paramstore/paramstore.go
@@ -89,10 +89,10 @@ type watcher struct {
 	lastVersion int64
 }
 
-// Watch begins watching the given parameter and waiting for it to change.
+// WatchVariable begins watching the given parameter and waiting for it to change.
 // The function will block until either the parameter changes, or the context
 // is canceled.
-func (w *watcher) Watch(ctx context.Context) (driver.Variable, error) {
+func (w *watcher) WatchVariable(ctx context.Context) (driver.Variable, error) {
 	return internal.Pinger(ctx, w.ping, w.waitTime)
 }
 

--- a/runtimevar/runtimeconfigurator/runtimeconfigurator.go
+++ b/runtimevar/runtimeconfigurator/runtimeconfigurator.go
@@ -148,9 +148,9 @@ func (w *watcher) Close() error {
 	return nil
 }
 
-// Watch blocks until the variable changes, the Context's Done channel closes or an error occurs. It
-// implements the driver.Watcher.Watch method.
-func (w *watcher) Watch(ctx context.Context) (driver.Variable, error) {
+// WatchVariable blocks until the variable changes, the Context's Done channel closes or an error occurs. It
+// implements the driver.Watcher.WatchVariable method.
+func (w *watcher) WatchVariable(ctx context.Context) (driver.Variable, error) {
 	return internal.Pinger(ctx, w.ping, w.waitTime)
 }
 

--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -68,7 +68,7 @@ func New(w driver.Watcher) *Variable {
 // To stop this function from blocking, caller can passed in Context object constructed via
 // WithCancel and call the cancel function.
 func (c *Variable) Watch(ctx context.Context) (Snapshot, error) {
-	variable, err := c.watcher.Watch(ctx)
+	variable, err := c.watcher.WatchVariable(ctx)
 	if err != nil {
 		// Mask underlying errors.
 		return Snapshot{}, fmt.Errorf("Variable.Watch: %v", err)

--- a/runtimevar/runtimevar_test.go
+++ b/runtimevar/runtimevar_test.go
@@ -41,7 +41,7 @@ func (fw *fakeWatcher) Close() error {
 	return nil
 }
 
-func (fw *fakeWatcher) Watch(context.Context) (driver.Variable, error) {
+func (fw *fakeWatcher) WatchVariable(context.Context) (driver.Variable, error) {
 	return fw.dc, nil
 }
 


### PR DESCRIPTION
This PR renames interface methods that collide with the method names we want in the concrete types, but have different signatures. This is confusing and makes it look like the concrete type is supposed to implement the interface, but doesn't.

Where there was no signature clash, no change was made even if the function names were the same.

Fixes #136 