### PR TITLE
docs: Reformat design.md to 80 characters

### DIFF
--- a/internal/docs/design.md
+++ b/internal/docs/design.md
@@ -5,20 +5,20 @@ attempts to provide succinct rationales.
 
 ## Developers and Operators
 
-Go Cloud is designed with two different personas in mind: the developer and
-the operator. In the world of DevOps, these may be the same person. A developer
-may be directly deploying their application into production, especially on
-smaller teams. In a larger organization, these may be different teams entirely,
-but working closely together. Regardless, these two personas have two very
-different ways of looking at a Go program:
+Go Cloud is designed with two different personas in mind: the developer and the
+operator. In the world of DevOps, these may be the same person. A developer may
+be directly deploying their application into production, especially on smaller
+teams. In a larger organization, these may be different teams entirely, but
+working closely together. Regardless, these two personas have two very different
+ways of looking at a Go program:
 
 - The developer persona wants to write business logic that is agnostic of
-  underlying cloud provider. Their focus is on making software correct for the
-  requirements at hand.
+	underlying cloud provider. Their focus is on making software correct for the
+	requirements at hand.
 - The operator persona wants to incorporate the business logic into the
-  organization's policies and provision resources for the logic to run. Their
-  focus is making software run predictably and reliably with the resources at
-  hand.
+	organization's policies and provision resources for the logic to run. Their
+	focus is making software run predictably and reliably with the resources at
+	hand.
 
 Go Cloud uses Go interfaces at the boundary between these two personas: a
 developer is meant to use an interface, and an operator is meant to provide an
@@ -59,52 +59,55 @@ driver.Bucket implemented by awsblob.Bucket.](img/user-facing-type.png)
 This has a number of benefits:
 
 -  The user-facing type can perform higher level logic without making the
-   interface complex to implement. In the blob example, the user-facing type's
-   `NewWriter` method can do the content type detection and then pass the final
-   result to the driver type.
+	 interface complex to implement. In the blob example, the user-facing type's
+	 `NewWriter` method can do the content type detection and then pass the final
+	 result to the driver type.
 -  Methods can be added to the user-facing type without breaking compatibility.
-   Contrast with adding methods to an interface, which is a breaking change.
+	 Contrast with adding methods to an interface, which is a breaking change.
 -  As new operations on the driver are added as new optional interfaces, the
-   user-facing type can hide the need for type-assertions from the user.
+	 user-facing type can hide the need for type-assertions from the user.
 
 As a rule, if a method `Foo` has the same inputs and semantics in the
 user-facing type and the driver type, then the driver method may be called
 `Foo`, even though the return signatures may differ. Otherwise, the driver
 method name should be different to reduce confusion.
 
-[`runtimevar.Variable`]: https://godoc.org/github.com/google/go-cloud/runtimevar#Variable
-[`Bucket.NewWriter` method]: https://godoc.org/github.com/google/go-cloud/blob#Bucket.NewWriter
+[`runtimevar.Variable`]:
+https://godoc.org/github.com/google/go-cloud/runtimevar#Variable
+[`Bucket.NewWriter` method]:
+https://godoc.org/github.com/google/go-cloud/blob#Bucket.NewWriter
 [`database/sql`]: https://godoc.org/database/sql
 
 ## Errors
 
 -   The callee is expected to return `error`s with messages that include
-    information about the particular call, as opposed to the caller adding this
-    information. This aligns with common Go practice.
+		information about the particular call, as opposed to the caller adding this
+		information. This aligns with common Go practice.
 
 -   Prefer to keep details of returned `error`s unspecified. The most common
-    case is that the caller will only care whether an operation succeeds or not.
+		case is that the caller will only care whether an operation succeeds or not.
 
 -   If certain kinds of `error`s are interesting for the caller of a function or
-    non-interface method to distinguish, prefer to expose additional information
-    through the use of predicate functions like
-    [`os.IsNotExist`](https://golang.org/pkg/os/#IsNotExist). This allows the
-    internal representation of the `error` to change over time while being
-    simple to use.
+		non-interface method to distinguish, prefer to expose additional information
+		through the use of predicate functions like
+		[`os.IsNotExist`](https://golang.org/pkg/os/#IsNotExist). This allows the
+		internal representation of the `error` to change over time while being
+		simple to use.
 
 -   If it is important to distinguish different kinds of `error`s returned from
-    an interface method, then the `error` should implement extra methods and the
-    interface should document these assumptions. Just remember that each method
-    can be implemented independently: if one method is mutually exclusive with
-    another, it would be better to return a more complicated data type from one
-    methodthan to have separate methods.
+		an interface method, then the `error` should implement extra methods and the
+		interface should document these assumptions. Just remember that each method
+		can be implemented independently: if one method is mutually exclusive with
+		another, it would be better to return a more complicated data type from one
+		methodthan to have separate methods.
 
 -   Transient network errors should be handled by an interface's implementation
-    and not bubbled up as a distinguishible error through a generic interface.
-    Retry logic is best handled as low in the stack as possible to avoid
-    [cascading failure][]. APIs should try to surface "permanent" errors (e.g.
-    malformed request, bad permissions) where appropriate so that application
-    logic does not attempt to retry idempotent operations, but the
-    responsibility is largely on the library, not on the application.
+		and not bubbled up as a distinguishible error through a generic interface.
+		Retry logic is best handled as low in the stack as possible to avoid
+		[cascading failure][]. APIs should try to surface "permanent" errors (e.g.
+		malformed request, bad permissions) where appropriate so that application
+		logic does not attempt to retry idempotent operations, but the
+		responsibility is largely on the library, not on the application.
 
-[cascading failure]: https://landing.google.com/sre/book/chapters/addressing-cascading-failures.html
+[cascading failure]:
+https://landing.google.com/sre/book/chapters/addressing-cascading-failures.html


### PR DESCRIPTION
Just a quick clean up before I start editing, so the diff isn't wacky.