### PR TITLE
internal/docs: update the design decisions doc to have Living Document/Blob justification

### DIFF
--- a/internal/docs/design.md
+++ b/internal/docs/design.md
@@ -51,9 +51,8 @@ language while focusing on their respective areas of expertise.
 
 The distinction between developer and operator becomes more blurred when
 investigating testing. Integration tests might well want to create and destroy
-resources. We expect to recommend [Terraform](http://terraform.io) for such
-cases, but we have not investigated the actual workflow for this at the time of
-writing.
+resources. We recommend [Terraform](http://terraform.io) for such cases, but
+we have not investigated the CI workflow for this at the time of writing.
 
 ## Drivers and User-Facing Types
 


### PR DESCRIPTION
As discussed offline, this PR modifies the design decisions doc to add a section about the doc being a Living Document, and also expands upon the Blob example to mention unavoidable platform-specific complexities.

Fixes #175.

GitHub seems to be showing the diff weirdly, making it look like lines have changed that don't seem to have done to me. Not sure what to do about that :/