### PR TITLE
In README, install go-cloud to $GOPATH.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Installation is easy, but does require `vgo`. `vgo` is not yet stable, and so bu
 
 ```shell
 $ go get -u golang.org/x/vgo
-$ git clone https://github.com/google/go-cloud.git
-$ cd go-cloud
+$ go get -u github.com/google/go-cloud
+$ cd $(go list -f '{{.Dir}}' github.com/google/go-cloud)
 $ vgo install ./wire/cmd/gowire
 ```
 Go Cloud builds at the latest stable release of Go. Previous Go versions may compile but are not supported.


### PR DESCRIPTION
Otherwise gowire fails on the samples.

This mitigates https://github.com/google/go-cloud/issues/208.
