### PR TITLE
samples/tutorial: add refactor step

### DIFF
--- a/samples/tutorial/main.go
+++ b/samples/tutorial/main.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Command upload saves files to blob storage on GCP and AWS.
 package main
 
@@ -8,11 +22,10 @@ import (
 	"log"
 )
 
-const bucketName = "my-cool-bucket"
-
 func main() {
 	// Define our input.
 	cloud := flag.String("cloud", "", "Cloud storage to use")
+	bucketName := flag.String("bucket", "go-cloud-bucket", "Name of bucket")
 	flag.Parse()
 	if flag.NArg() != 1 {
 		log.Fatal("Failed to provide file to upload")
@@ -21,7 +34,7 @@ func main() {
 
 	ctx := context.Background()
 	// Open a connection to the bucket.
-	b, err := setupGenericBucket(context.Background(), *cloud, bucketName)
+	b, err := setupBucket(context.Background(), *cloud, *bucketName)
 	if err != nil {
 		log.Fatalf("Failed to setup bucket: %s", err)
 	}

--- a/samples/tutorial/main.go
+++ b/samples/tutorial/main.go
@@ -6,14 +6,6 @@ import (
 	"flag"
 	"io/ioutil"
 	"log"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/google/go-cloud/blob"
-	"github.com/google/go-cloud/blob/gcsblob"
-	"github.com/google/go-cloud/blob/s3blob"
-	"github.com/google/go-cloud/gcp"
 )
 
 const bucketName = "my-cool-bucket"
@@ -29,18 +21,7 @@ func main() {
 
 	ctx := context.Background()
 	// Open a connection to the bucket.
-	var (
-		b   *blob.Bucket
-		err error
-	)
-	switch *cloud {
-	case "gcp":
-		b, err = setupGCP(ctx)
-	case "aws":
-		b, err = setupAWS(ctx)
-	default:
-		log.Fatalf("Failed to recognize cloud. Want gcp or aws, got: %s", *cloud)
-	}
+	b, err := setupGenericBucket(context.Background(), *cloud, bucketName)
 	if err != nil {
 		log.Fatalf("Failed to setup bucket: %s", err)
 	}
@@ -62,34 +43,4 @@ func main() {
 	if err := w.Close(); err != nil {
 		log.Fatalf("Failed to close: %s", err)
 	}
-}
-
-func setupGCP(ctx context.Context) (*blob.Bucket, error) {
-	// DefaultCredentials assumes a user has logged in with gcloud.
-	// See here for more information:
-	// https://cloud.google.com/docs/authentication/getting-started
-	creds, err := gcp.DefaultCredentials(ctx)
-	if err != nil {
-		return nil, err
-	}
-	c, err := gcp.NewHTTPClient(gcp.DefaultTransport(), gcp.CredentialsTokenSource(creds))
-	if err != nil {
-		return nil, err
-	}
-	// The bucket name must be globally unique.
-	return gcsblob.OpenBucket(ctx, bucketName, c)
-}
-
-func setupAWS(ctx context.Context) (*blob.Bucket, error) {
-	c := &aws.Config{
-		// Either hard-code the region or use AWS_REGION.
-		Region: aws.String("us-east-2"),
-		// credentials.NewEnvCredentials assumes two environment variables are
-		// present:
-		// 1. AWS_ACCESS_KEY_ID, and
-		// 2. AWS_SECRET_ACCESS_KEY.
-		Credentials: credentials.NewEnvCredentials(),
-	}
-	s := session.Must(session.NewSession(c))
-	return s3blob.OpenBucket(ctx, s, bucketName)
 }

--- a/samples/tutorial/setup.go
+++ b/samples/tutorial/setup.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/google/go-cloud/blob"
+	"github.com/google/go-cloud/blob/gcsblob"
+	"github.com/google/go-cloud/blob/s3blob"
+	"github.com/google/go-cloud/gcp"
+)
+
+func setupGenericBucket(ctx context.Context, cloud, bucket string) (*blob.Bucket, error) {
+	if cloud == "aws" {
+		return setupAWS(ctx, bucket)
+	}
+	if cloud == "gcp" {
+		return setupGCP(ctx, bucket)
+	}
+	return nil, fmt.Errorf("invalid cloud provider: %s", cloud)
+}
+
+func setupGCP(ctx context.Context, bucket string) (*blob.Bucket, error) {
+	// DefaultCredentials assumes a user has logged in with gcloud.
+	// See here for more information:
+	// https://cloud.google.com/docs/authentication/getting-started
+	creds, err := gcp.DefaultCredentials(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c, err := gcp.NewHTTPClient(gcp.DefaultTransport(), gcp.CredentialsTokenSource(creds))
+	if err != nil {
+		return nil, err
+	}
+	// The bucket name must be globally unique.
+	return gcsblob.OpenBucket(ctx, bucket, c)
+}
+
+func setupAWS(ctx context.Context, bucket string) (*blob.Bucket, error) {
+	c := &aws.Config{
+		// Either hard-code the region or use AWS_REGION.
+		Region: aws.String("us-east-2"),
+		// credentials.NewEnvCredentials assumes two environment variables are
+		// present:
+		// 1. AWS_ACCESS_KEY_ID, and
+		// 2. AWS_SECRET_ACCESS_KEY.
+		Credentials: credentials.NewEnvCredentials(),
+	}
+	s := session.Must(session.NewSession(c))
+	return s3blob.OpenBucket(ctx, s, bucket)
+}

--- a/samples/tutorial/setup.go
+++ b/samples/tutorial/setup.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -13,7 +27,8 @@ import (
 	"github.com/google/go-cloud/gcp"
 )
 
-func setupGenericBucket(ctx context.Context, cloud, bucket string) (*blob.Bucket, error) {
+// setupBucket creates a connection to a particular cloud provider's blob storage.
+func setupBucket(ctx context.Context, cloud, bucket string) (*blob.Bucket, error) {
 	if cloud == "aws" {
 		return setupAWS(ctx, bucket)
 	}
@@ -23,6 +38,7 @@ func setupGenericBucket(ctx context.Context, cloud, bucket string) (*blob.Bucket
 	return nil, fmt.Errorf("invalid cloud provider: %s", cloud)
 }
 
+// setupGCP creates a connection to Google Cloud Storage (GCS).
 func setupGCP(ctx context.Context, bucket string) (*blob.Bucket, error) {
 	// DefaultCredentials assumes a user has logged in with gcloud.
 	// See here for more information:
@@ -35,10 +51,10 @@ func setupGCP(ctx context.Context, bucket string) (*blob.Bucket, error) {
 	if err != nil {
 		return nil, err
 	}
-	// The bucket name must be globally unique.
 	return gcsblob.OpenBucket(ctx, bucket, c)
 }
 
+// setupAWS creates a connection to Simple Cloud Storage Service (S3).
 func setupAWS(ctx context.Context, bucket string) (*blob.Bucket, error) {
 	c := &aws.Config{
 		// Either hard-code the region or use AWS_REGION.


### PR DESCRIPTION
The refactor step further separates setup code from application code to
demonstrate a clear seam between the two and make any future changes to
the supported cloud providers straightforward.