### PR TITLE
runtimevar: simplify context usage

### DIFF
--- a/runtimevar/example_test.go
+++ b/runtimevar/example_test.go
@@ -59,20 +59,15 @@ func Example() {
 
 	// Have a separate goroutine that waits for changes.
 	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				snap, err := v.Watch(ctx)
-				if err != nil {
-					// Handle errors.
-					log.Printf("Error: %v", err)
-					continue
-				}
-				// Use updated configuration accordingly.
-				log.Printf("Value: %+v", snap.Value.(*DBConfig))
+		for ctx.Err() == nil {
+			snap, err := v.Watch(ctx)
+			if err != nil {
+				// Handle errors.
+				log.Printf("Error: %v", err)
+				continue
 			}
+			// Use updated configuration accordingly.
+			log.Printf("Value: %+v", snap.Value.(*DBConfig))
 		}
 	}()
 }


### PR DESCRIPTION
According to the [context documentation](https://golang.org/pkg/context/#Context):
>        // If Done is not yet closed, Err returns nil.
>        // If Done is closed, Err returns a non-nil error explaining why
So using ctx.Err() seems better than selecting the ctx.Done() channel (easier to read and probably a bit faster)