### PR TITLE
wire: Fix typo in README.md ProvideBaz example.

### DIFF
--- a/wire/README.md
+++ b/wire/README.md
@@ -77,8 +77,8 @@ type Baz struct {
 
 // ProvideBaz returns a value if Bar is not zero.
 func ProvideBaz(ctx context.Context, bar Bar) (Baz, error) {
-	if bar == 0 {
-		return 0, errors.New("cannot provide baz when bar is zero")
+	if bar.X == 0 {
+		return Baz{}, errors.New("cannot provide baz when bar is zero")
 	}
 	return Baz{X: bar.X}, nil
 }


### PR DESCRIPTION
This is a small typo I noticed in the wire readme file.