### PR TITLE
Add examples of regions and zones in variables.tf

### DIFF
--- a/samples/guestbook/gcp/variables.tf
+++ b/samples/guestbook/gcp/variables.tf
@@ -19,12 +19,12 @@ variable "project" {
 
 variable "region" {
   type        = "string"
-  description = "GCP region to create database and storage in. See https://cloud.google.com/compute/docs/regions-zones/ for valid values."
+  description = "GCP region to create database and storage in, for example 'us-central1'. See https://cloud.google.com/compute/docs/regions-zones/ for valid values."
 }
 
 variable "zone" {
   type        = "string"
-  description = "GCP zone to create the GKE cluster in. See https://cloud.google.com/compute/docs/regions-zones/ for valid values."
+  description = "GCP zone to create the GKE cluster in, for example 'us-central1-a'. See https://cloud.google.com/compute/docs/regions-zones/ for valid values."
 }
 
 variable "server_service_account_name" {


### PR DESCRIPTION
Without an example, the regions-zones page makes it seem like the zone should be something like "a", but that doesn't work. It has to be something like 'us-central1-a', so it should help to show an example of that.