### PR TITLE
Wire: fix typo in README: App -> Baz

### DIFF
--- a/wire/README.md
+++ b/wire/README.md
@@ -177,7 +177,7 @@ import (
 	"example.com/foobarbaz"
 )
 
-func initializeApp(ctx context.Context) (foobarbaz.Baz, error) {
+func initializeBaz(ctx context.Context) (foobarbaz.Baz, error) {
 	foo := foobarbaz.ProvideFoo()
 	bar := foobarbaz.ProvideBar(foo)
 	baz, err := foobarbaz.ProvideBaz(ctx, bar)

--- a/wire/README.md
+++ b/wire/README.md
@@ -142,7 +142,7 @@ import (
 	"example.com/foobarbaz"
 )
 
-func initializeApp(ctx context.Context) (foobarbaz.Baz, error) {
+func initializeBaz(ctx context.Context) (foobarbaz.Baz, error) {
 	wire.Build(foobarbaz.MegaSet)
 	return foobarbaz.Baz{}, nil
 }


### PR DESCRIPTION
A function called initializeApp was returning a foobarbaz.Baz.