### PR TITLE
blob: add modification time to driver.ObjectAttrs

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -54,6 +54,7 @@ func (r *Reader) Size() int64 {
 }
 
 // ModTime returns the modification time of the blob object.
+// This is optional and will be time.Time zero value if unknown.
 func (r *Reader) ModTime() time.Time {
 	return r.r.Attrs().ModTime
 }

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"mime"
 	"net/http"
+	"time"
 
 	"github.com/google/go-cloud/blob/driver"
 )
@@ -52,7 +53,12 @@ func (r *Reader) Size() int64 {
 	return r.r.Attrs().Size
 }
 
-// Writer implements io.WriteCloser to write a blob. It must be closed after
+// ModTime returns the modification time of the blob object.
+func (r *Reader) ModTime() time.Time {
+	return r.r.Attrs().ModTime
+}
+
+// Writer implements io.WriteCloser to write to blob. It must be closed after
 // all writes are done.
 type Writer struct {
 	w driver.Writer

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -67,7 +67,7 @@ type ObjectAttrs struct {
 	Size int64
 	// ContentType is the MIME type of the blob object. It must not be empty.
 	ContentType string
-	// ModTime is the modified time of the blob object.
+	// ModTime is the modified time of the blob object. Will be time.Time zero value if unknown.
 	ModTime time.Time
 }
 

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"context"
 	"io"
+	"time"
 )
 
 // ErrorKind is a code to indicate the kind of failure.
@@ -66,6 +67,8 @@ type ObjectAttrs struct {
 	Size int64
 	// ContentType is the MIME type of the blob object. It must not be empty.
 	ContentType string
+	// ModTime is the modified time of the blob object.
+	ModTime time.Time
 }
 
 // Bucket provides read, write and delete operations on objects within it on the

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -68,18 +68,11 @@ func (r *reader) Attrs() *driver.ObjectAttrs {
 func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length int64) (driver.Reader, error) {
 	bkt := b.client.Bucket(b.name)
 	obj := bkt.Object(key)
-	attrs, err := obj.Attrs(ctx)
-	if err != nil {
-		if isErrNotExist(err) {
-			return nil, gcsError{bucket: b.name, key: key, msg: err.Error(), kind: driver.NotFound}
-		}
-		return nil, gcsError{bucket: b.name, key: key, msg: err.Error(), kind: driver.GenericError}
-	}
 	r, err := obj.NewRangeReader(ctx, offset, length)
 	if isErrNotExist(err) {
 		return nil, gcsError{bucket: b.name, key: key, msg: err.Error(), kind: driver.NotFound}
 	}
-	return &reader{Reader: r, modTime: attrs.Updated}, err
+	return &reader{Reader: r}, err
 }
 
 // NewTypedWriter returns Writer that writes to an object associated with key.

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"strings"
+	"time"
 
 	"github.com/google/go-cloud/blob"
 	"github.com/google/go-cloud/blob/driver"
@@ -54,6 +55,7 @@ type reader struct {
 	body        io.ReadCloser
 	size        int64
 	contentType string
+	modTime     time.Time
 }
 
 func (r *reader) Read(p []byte) (int, error) {
@@ -69,6 +71,7 @@ func (r *reader) Attrs() *driver.ObjectAttrs {
 	return &driver.ObjectAttrs{
 		Size:        r.size,
 		ContentType: r.contentType,
+		ModTime:     r.modTime,
 	}
 }
 
@@ -189,6 +192,7 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 		body:        resp.Body,
 		contentType: aws.StringValue(resp.ContentType),
 		size:        aws.Int64Value(resp.ContentLength),
+		modTime:     aws.TimeValue(resp.LastModified),
 	}, nil
 }
 
@@ -208,6 +212,7 @@ func (b *bucket) newMetadataReader(ctx context.Context, key string) (driver.Read
 		body:        emptyBody,
 		contentType: aws.StringValue(resp.ContentType),
 		size:        aws.Int64Value(resp.ContentLength),
+		modTime:     aws.TimeValue(resp.LastModified),
 	}, nil
 }
 


### PR DESCRIPTION
At [Sajari](https://github.com/sajari) we have been doing something similar to [blob](https://godoc.org/github.com/google/go-cloud/blob) with our own [storage](https://github.com/sajari/storage) pkg for quite some time now.

I started working on [migrating](https://github.com/sajari/storage/pull/5) our [storage](https://github.com/sajari/storage) pkg to use [go-cloud/blob](https://godoc.org/github.com/google/go-cloud/blob) underneath, and noticed that modification time was not a part of the [`driver.ObjectAttrs`](https://github.com/google/go-cloud/blob/master/blob/driver/driver.go#L64) struct. This is something that we use internally and is a part of our [`storage.File`](https://github.com/sajari/storage/blob/master/storage.go#L15) struct. 

This adds ModTime to [`driver.ObjectAttrs`](https://github.com/google/go-cloud/blob/master/blob/driver/driver.go#L64) and adds it to the current driver implementations.