### PR TITLE
samples/guestbook: replace panic(wire.Build(...)) with wire.Build(...), return

### DIFF
--- a/samples/guestbook/inject_aws.go
+++ b/samples/guestbook/inject_aws.go
@@ -45,7 +45,7 @@ func setupAWS(ctx context.Context, flags *cliFlags) (*application, func(), error
 		awsMOTDVar,
 		awsSQLParams,
 	)
-	return nil, func() {}, nil
+	return nil, nil, nil
 }
 
 // awsBucket is a Wire provider function that returns the S3 bucket based on the

--- a/samples/guestbook/inject_aws.go
+++ b/samples/guestbook/inject_aws.go
@@ -38,14 +38,14 @@ import (
 func setupAWS(ctx context.Context, flags *cliFlags) (*application, func(), error) {
 	// This will be filled in by Wire with providers from the provider sets in
 	// wire.Build.
-
-	panic(wire.Build(
+	wire.Build(
 		awscloud.AWS,
 		applicationSet,
 		awsBucket,
 		awsMOTDVar,
 		awsSQLParams,
-	))
+	)
+	return nil, func() {}, nil
 }
 
 // awsBucket is a Wire provider function that returns the S3 bucket based on the

--- a/samples/guestbook/inject_gcp.go
+++ b/samples/guestbook/inject_gcp.go
@@ -45,7 +45,7 @@ func setupGCP(ctx context.Context, flags *cliFlags) (*application, func(), error
 		gcpMOTDVar,
 		gcpSQLParams,
 	)
-	return nil, func() {}, nil
+	return nil, nil, nil
 }
 
 // gcpBucket is a Wire provider function that returns the GCS bucket based on

--- a/samples/guestbook/inject_gcp.go
+++ b/samples/guestbook/inject_gcp.go
@@ -38,14 +38,14 @@ import (
 func setupGCP(ctx context.Context, flags *cliFlags) (*application, func(), error) {
 	// This will be filled in by Wire with providers from the provider sets in
 	// wire.Build.
-
-	panic(wire.Build(
+	wire.Build(
 		gcpcloud.GCP,
 		applicationSet,
 		gcpBucket,
 		gcpMOTDVar,
 		gcpSQLParams,
-	))
+	)
+	return nil, func() {}, nil
 }
 
 // gcpBucket is a Wire provider function that returns the GCS bucket based on

--- a/samples/guestbook/inject_local.go
+++ b/samples/guestbook/inject_local.go
@@ -50,7 +50,7 @@ func setupLocal(ctx context.Context, flags *cliFlags) (*application, func(), err
 		localBucket,
 		localRuntimeVar,
 	)
-	return nil, func() {}, nil
+	return nil, nil, nil
 }
 
 // localBucket is a Wire provider function that returns a directory-based bucket

--- a/samples/guestbook/inject_local.go
+++ b/samples/guestbook/inject_local.go
@@ -41,8 +41,7 @@ import (
 func setupLocal(ctx context.Context, flags *cliFlags) (*application, func(), error) {
 	// This will be filled in by Wire with providers from the provider sets in
 	// wire.Build.
-
-	panic(wire.Build(
+	wire.Build(
 		wire.Value(requestlog.Logger(nil)),
 		wire.Value(trace.Exporter(nil)),
 		server.Set,
@@ -50,7 +49,8 @@ func setupLocal(ctx context.Context, flags *cliFlags) (*application, func(), err
 		dialLocalSQL,
 		localBucket,
 		localRuntimeVar,
-	))
+	)
+	return nil, func() {}, nil
 }
 
 // localBucket is a Wire provider function that returns a directory-based bucket

--- a/wire/cmd/wire/main.go
+++ b/wire/cmd/wire/main.go
@@ -42,7 +42,7 @@ func main() {
 	switch {
 	case len(os.Args) == 2 && (os.Args[1] == "help" || os.Args[1] == "-h" || os.Args[1] == "-help" || os.Args[1] == "--help"):
 		fmt.Fprintln(os.Stderr, usage)
-		os.Exit(2)
+		os.Exit(0)
 	case len(os.Args) == 1 || len(os.Args) == 2 && os.Args[1] == "gen":
 		err = generate(".")
 	case len(os.Args) == 2 && os.Args[1] == "show":

--- a/wire/cmd/wire/main.go
+++ b/wire/cmd/wire/main.go
@@ -35,9 +35,14 @@ import (
 	"golang.org/x/tools/go/types/typeutil"
 )
 
+const usage = "usage: wire [gen] [PKG] | wire show [...] | wire check [...]"
+
 func main() {
 	var err error
 	switch {
+	case len(os.Args) == 2 && (os.Args[1] == "help" || os.Args[1] == "-h" || os.Args[1] == "-help" || os.Args[1] == "--help"):
+		fmt.Fprintln(os.Stderr, usage)
+		os.Exit(2)
 	case len(os.Args) == 1 || len(os.Args) == 2 && os.Args[1] == "gen":
 		err = generate(".")
 	case len(os.Args) == 2 && os.Args[1] == "show":
@@ -53,7 +58,7 @@ func main() {
 	case len(os.Args) == 3 && os.Args[1] == "gen":
 		err = generate(os.Args[2])
 	default:
-		fmt.Fprintln(os.Stderr, "usage: wire [gen] [PKG] | wire show [...] | wire check [...]")
+		fmt.Fprintln(os.Stderr, usage)
 		os.Exit(64)
 	}
 	if err != nil {


### PR DESCRIPTION
Fixes #242 
