### PR TITLE
all: use -record instead of -short to turn on recording in tests

### DIFF
--- a/blob/gcsblob/gcsblob_integration_test.go
+++ b/blob/gcsblob/gcsblob_integration_test.go
@@ -22,15 +22,13 @@ import (
 	"github.com/google/go-cloud/blob"
 	"github.com/google/go-cloud/blob/gcsblob"
 	"github.com/google/go-cloud/gcp"
+	"github.com/google/go-cloud/internal/testing/setup"
 )
 
-var (
-	record     = flag.Bool("record", false, "whether to run tests against cloud resources and record the interactions")
-	testBucket = flag.String("gcs-bucket", "pledged-solved-practically", "GCS bucket name used for testing")
-)
+var testBucket = flag.String("gcs-bucket", "pledged-solved-practically", "GCS bucket name used for testing")
 
 func TestReadOfNonExistentFile(t *testing.T) {
-	if !*record {
+	if !*setup.Record {
 		// TODO(shantuo): use replay once
 		// https://github.com/google/go-cloud/issues/49 is fixed.
 		t.Skip("Skipping integration test in short mode")
@@ -56,7 +54,7 @@ func TestReadOfNonExistentFile(t *testing.T) {
 }
 
 func TestDeleteNonExistentFile(t *testing.T) {
-	if !*record {
+	if !*setup.Record {
 		// TODO(shantuo): use replay once
 		// https://github.com/google/go-cloud/issues/49 is fixed.
 		t.Skip("Skipping integration test in short mode")

--- a/blob/gcsblob/gcsblob_integration_test.go
+++ b/blob/gcsblob/gcsblob_integration_test.go
@@ -24,11 +24,12 @@ import (
 	"github.com/google/go-cloud/gcp"
 )
 
+var record = flag.Bool("record", false, "whether to record")
 var testBucket = flag.String("gcs-bucket", "pledged-solved-practically", "GCS bucket name used for testing")
 
 func TestReadOfNonExistentFile(t *testing.T) {
-	if testing.Short() {
-		// TODO(shantuo): use replay for short mode once
+	if !*record {
+		// TODO(shantuo): use replay once
 		// https://github.com/google/go-cloud/issues/49 is fixed.
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -53,8 +54,8 @@ func TestReadOfNonExistentFile(t *testing.T) {
 }
 
 func TestDeleteNonExistentFile(t *testing.T) {
-	if testing.Short() {
-		// TODO(shantuo): use replay for short mode once
+	if !*record {
+		// TODO(shantuo): use replay once
 		// https://github.com/google/go-cloud/issues/49 is fixed.
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/blob/gcsblob/gcsblob_integration_test.go
+++ b/blob/gcsblob/gcsblob_integration_test.go
@@ -24,8 +24,10 @@ import (
 	"github.com/google/go-cloud/gcp"
 )
 
-var record = flag.Bool("record", false, "whether to record")
-var testBucket = flag.String("gcs-bucket", "pledged-solved-practically", "GCS bucket name used for testing")
+var (
+	record     = flag.Bool("record", false, "whether to run tests against cloud resources and record the interactions")
+	testBucket = flag.String("gcs-bucket", "pledged-solved-practically", "GCS bucket name used for testing")
+)
 
 func TestReadOfNonExistentFile(t *testing.T) {
 	if !*record {

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -239,7 +239,7 @@ func TestHTTPClientOpt(t *testing.T) {
 func newGCSClient(ctx context.Context, logf func(string, ...interface{}), filepath string) (*gcp.HTTPClient, func(), error) {
 
 	mode := recorder.ModeRecording
-	if testing.Short() {
+	if !*record {
 		mode = recorder.ModeReplaying
 	}
 	r, done, err := replay.NewGCSRecorder(logf, mode, filepath)

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/google/go-cloud/gcp"
 	"github.com/google/go-cloud/internal/testing/replay"
+	"github.com/google/go-cloud/internal/testing/setup"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
@@ -239,7 +240,7 @@ func TestHTTPClientOpt(t *testing.T) {
 func newGCSClient(ctx context.Context, logf func(string, ...interface{}), filepath string) (*gcp.HTTPClient, func(), error) {
 
 	mode := recorder.ModeRecording
-	if !*record {
+	if !*setup.Record {
 		mode = recorder.ModeReplaying
 	}
 	r, done, err := replay.NewGCSRecorder(logf, mode, filepath)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go v0.0.0-20180608230132-da2b80561ef3 h1:QJr3IGTxuO1LmZCE815pJKQmLFTRQRCOk9Xg9+W6yAI=
+cloud.google.com/go v0.0.0-20180608230132-da2b80561ef3/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.25.0 h1:6vD6xZTc8Jo6To8gHxFDRVsMvWFDgY3rugNszcDalN8=
 cloud.google.com/go v0.25.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 contrib.go.opencensus.io/exporter/stackdriver v0.0.0-20180421005815-665cf5131b71 h1:/Q5os0lx9Ia5bNqQ1lO+jZV9gVFYEbDZ77a0seit0fc=

--- a/internal/testing/setup/setup.go
+++ b/internal/testing/setup/setup.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cloud/internal/testing/replay"
 )
 
-var record = flag.Bool("record", false, "whether to record")
+var record = flag.Bool("record", false, "whether to run tests against cloud resources and record the interactions")
 
 // NewAWSSession creates a new session for testing against AWS.
 // If the test is short, the session reads a replay file and runs the test as a replay,

--- a/internal/testing/setup/setup.go
+++ b/internal/testing/setup/setup.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"flag"
 	"net/http"
 	"testing"
 
@@ -11,15 +12,17 @@ import (
 	"github.com/google/go-cloud/internal/testing/replay"
 )
 
+var record = flag.Bool("record", false, "whether to record")
+
 // NewAWSSession creates a new session for testing against AWS.
 // If the test is short, the session reads a replay file and runs the test as a replay,
 // which never makes an outgoing HTTP call and uses fake credentials.
 // If the test is not short, the test will call out to AWS, and the results recorded
 // as a new replay file.
 func NewAWSSession(t *testing.T, region, filename string) (sess *session.Session, done func()) {
-	mode := recorder.ModeRecording
-	if testing.Short() {
-		mode = recorder.ModeReplaying
+	mode := recorder.ModeReplaying
+	if *record {
+		mode = recorder.ModeRecording
 	}
 	r, done, err := replay.NewAWSRecorder(t.Logf, mode, filename)
 	if err != nil {
@@ -32,7 +35,7 @@ func NewAWSSession(t *testing.T, region, filename string) (sess *session.Session
 
 	// Provide fake creds if running in replay mode.
 	var creds *credentials.Credentials
-	if testing.Short() {
+	if !*record {
 		creds = credentials.NewStaticCredentials("FAKE_ID", "FAKE_SECRET", "FAKE_TOKEN")
 	}
 

--- a/internal/testing/setup/setup.go
+++ b/internal/testing/setup/setup.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cloud/internal/testing/replay"
 )
 
-var record = flag.Bool("record", false, "whether to run tests against cloud resources and record the interactions")
+var Record = flag.Bool("record", false, "whether to run tests against cloud resources and record the interactions")
 
 // NewAWSSession creates a new session for testing against AWS.
 // If the test is short, the session reads a replay file and runs the test as a replay,
@@ -21,7 +21,7 @@ var record = flag.Bool("record", false, "whether to run tests against cloud reso
 // as a new replay file.
 func NewAWSSession(t *testing.T, region, filename string) (sess *session.Session, done func()) {
 	mode := recorder.ModeReplaying
-	if *record {
+	if *Record {
 		mode = recorder.ModeRecording
 	}
 	r, done, err := replay.NewAWSRecorder(t.Logf, mode, filename)
@@ -35,7 +35,7 @@ func NewAWSSession(t *testing.T, region, filename string) (sess *session.Session
 
 	// Provide fake creds if running in replay mode.
 	var creds *credentials.Credentials
-	if !*record {
+	if !*Record {
 		creds = credentials.NewStaticCredentials("FAKE_ID", "FAKE_SECRET", "FAKE_TOKEN")
 	}
 

--- a/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
+++ b/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/go-cloud/gcp"
 	"github.com/google/go-cloud/internal/testing/replay"
+	"github.com/google/go-cloud/internal/testing/setup"
 	"github.com/google/go-cloud/runtimevar"
 	"github.com/google/go-cloud/runtimevar/driver"
 	"github.com/google/go-cmp/cmp"
@@ -43,10 +44,7 @@ const (
 	description = "Config for test variables created by runtimeconfigurator_test.go"
 )
 
-var (
-	projectID = flag.String("project", "", "GCP project ID (string, not project number) to run tests against")
-	record    = flag.Bool("record", false, "whether to run tests against cloud resources and record the interactions")
-)
+var projectID = flag.String("project", "", "GCP project ID (string, not project number) to run tests against")
 
 // Ensure that watcher implements driver.Watcher.
 var _ driver.Watcher = &watcher{}
@@ -259,7 +257,7 @@ func newConfigClient(ctx context.Context, logf func(string, ...interface{}), fil
 	}
 
 	mode := recorder.ModeReplaying
-	if *record {
+	if *setup.Record {
 		mode = recorder.ModeRecording
 	}
 

--- a/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
+++ b/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
@@ -43,8 +43,10 @@ const (
 	description = "Config for test variables created by runtimeconfigurator_test.go"
 )
 
-var projectID = flag.String("project", "", "GCP project ID (string, not project number) to run tests against")
-var record = flag.Bool("record", false, "whether to record")
+var (
+	projectID = flag.String("project", "", "GCP project ID (string, not project number) to run tests against")
+	record    = flag.Bool("record", false, "whether to run tests against cloud resources and record the interactions")
+)
 
 // Ensure that watcher implements driver.Watcher.
 var _ driver.Watcher = &watcher{}

--- a/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
+++ b/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/go-cloud/gcp"
+	"github.com/google/go-cloud/internal/testing/replay"
 	"github.com/google/go-cloud/runtimevar"
 	"github.com/google/go-cloud/runtimevar/driver"
-	"github.com/google/go-cloud/internal/testing/replay"
 	"github.com/google/go-cmp/cmp"
 	pb "google.golang.org/genproto/googleapis/cloud/runtimeconfig/v1beta1"
 	"google.golang.org/grpc"
@@ -44,6 +44,7 @@ const (
 )
 
 var projectID = flag.String("project", "", "GCP project ID (string, not project number) to run tests against")
+var record = flag.Bool("record", false, "whether to record")
 
 // Ensure that watcher implements driver.Watcher.
 var _ driver.Watcher = &watcher{}
@@ -255,9 +256,9 @@ func newConfigClient(ctx context.Context, logf func(string, ...interface{}), fil
 		return nil, nil, err
 	}
 
-	mode := recorder.ModeRecording
-	if testing.Short() {
-		mode = recorder.ModeReplaying
+	mode := recorder.ModeReplaying
+	if *record {
+		mode = recorder.ModeRecording
 	}
 
 	rOpts, done, err := replay.NewGCPDialOptions(logf, mode, filepath, scrubber)


### PR DESCRIPTION
This partially addresses issue #214.
