### PR TITLE
Rename ProviderSet.Name to VarName, and ensure it is set when the ProviderSet is a package variable.

### DIFF
--- a/wire/cmd/wire/main.go
+++ b/wire/cmd/wire/main.go
@@ -217,8 +217,8 @@ func gather(info *wire.Info, key wire.ProviderSetID) (_ []outGroup, imports map[
 			continue
 		}
 		visited[curr] = struct{}{}
-		if curr.Name != "" && !(curr.PkgPath == key.ImportPath && curr.Name == key.VarName) {
-			imports[formatProviderSetName(curr.PkgPath, curr.Name)] = struct{}{}
+		if curr.VarName != "" && !(curr.PkgPath == key.ImportPath && curr.VarName == key.VarName) {
+			imports[formatProviderSetName(curr.PkgPath, curr.VarName)] = struct{}{}
 		}
 		for _, imp := range curr.Imports {
 			next = append(next, imp)

--- a/wire/internal/wire/analyze.go
+++ b/wire/internal/wire/analyze.go
@@ -248,10 +248,10 @@ func verifyArgsUsed(set *ProviderSet, used []*providerSetSrc) []error {
 			}
 		}
 		if !found {
-			if imp.Name == "" {
+			if imp.VarName == "" {
 				errs = append(errs, errors.New("unused provider set"))
 			} else {
-				errs = append(errs, fmt.Errorf("unused provider set %q", imp.Name))
+				errs = append(errs, fmt.Errorf("unused provider set %q", imp.VarName))
 			}
 		}
 	}

--- a/wire/internal/wire/analyze.go
+++ b/wire/internal/wire/analyze.go
@@ -429,12 +429,12 @@ func verifyAcyclic(providerMap *typeutil.Map, hasher typeutil.Hasher) []error {
 func bindingConflictError(fset *token.FileSet, pos token.Pos, typ types.Type, prevSet *ProviderSet) error {
 	typString := types.TypeString(typ, nil)
 	var err error
-	if prevSet.Name == "" {
+	if prevSet.VarName == "" {
 		err = fmt.Errorf("multiple bindings for %s (previous binding at %v)",
 			typString, fset.Position(prevSet.Pos))
 	} else {
 		err = fmt.Errorf("multiple bindings for %s (previous binding in %q.%s)",
-			typString, prevSet.PkgPath, prevSet.Name)
+			typString, prevSet.PkgPath, prevSet.VarName)
 	}
 	return notePosition(fset.Position(pos), err)
 }

--- a/wire/internal/wire/testdata/UnusedProviders/out.txt
+++ b/wire/internal/wire/testdata/UnusedProviders/out.txt
@@ -1,5 +1,5 @@
 ERROR
-unused provider set
+unused provider set "unusedSet"
 unused provider "provideUnused"
 unused value of type string
 unused interface binding to type foo.Fooer

--- a/wire/internal/wire/wire.go
+++ b/wire/internal/wire/wire.go
@@ -86,7 +86,7 @@ func generateInjectors(g *gen, pkgInfo *loader.PackageInfo) (injectorFiles []*as
 				g.p("// Injectors from %s:\n\n", name)
 				injectorFiles = append(injectorFiles, f)
 			}
-			set, errs := oc.processNewSet(pkgInfo, buildCall)
+			set, errs := oc.processNewSet(pkgInfo, buildCall, "")
 			if len(errs) > 0 {
 				ec.add(notePositionAll(g.prog.Fset.Position(fn.Pos()), errs)...)
 				continue


### PR DESCRIPTION
Fix #277 