### PR TITLE
internal/contributebot/webhook: add App Engine listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /vendor/
 
 # Populated config files
+internal/contributebot/webhook/app.yaml
 tests/gcp/app/gcp-test.yaml
 
 # Cryptographic keys

--- a/internal/contributebot/README.md
+++ b/internal/contributebot/README.md
@@ -1,0 +1,5 @@
+# Contribute Bot
+
+Contribute Bot is a small service (written using Go Cloud!) that performs
+automated checks on issues and pull requests to help keep contributions
+organized and easy to triage for maintainers.

--- a/internal/contributebot/README.md
+++ b/internal/contributebot/README.md
@@ -3,3 +3,13 @@
 Contribute Bot is a small service (written using Go Cloud!) that performs
 automated checks on issues and pull requests to help keep contributions
 organized and easy to triage for maintainers.
+
+Contribute Bot has two servers: a webhook endpoint and an event listener. The
+webhook endpoint publishes events to a Cloud Pub/Sub topic that are eventually
+processed by the event listener. GitHub has a [10 second webhook response time
+limit][github-async] combined with a [5000 request/hour API rate
+limit][github-ratelimit], so this adds buffering with the assumption that
+incoming events are bursty.
+
+[github-async]: https://developer.github.com/v3/guides/best-practices-for-integrators/#favor-asynchronous-work-over-synchronous
+[github-ratelimit]: https://developer.github.com/v3/#rate-limiting

--- a/internal/contributebot/go.mod
+++ b/internal/contributebot/go.mod
@@ -1,0 +1,11 @@
+module github.com/google/go-cloud/internal/contributebot
+
+require (
+	github.com/golang/protobuf v1.1.0 // indirect
+	github.com/google/go-github v15.0.0+incompatible
+	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 // indirect
+	golang.org/x/net v0.0.0-20180801234040-f4c29de78a2a // indirect
+	golang.org/x/oauth2 v0.0.0-20180724155351-3d292e4d0cdc
+	google.golang.org/api v0.0.0-20180802201733-6c5c3d4ff961
+	google.golang.org/appengine v1.1.0
+)

--- a/internal/contributebot/go.sum
+++ b/internal/contributebot/go.sum
@@ -1,0 +1,14 @@
+github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
+github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-github v15.0.0+incompatible h1:jlPg2Cpsxb/FyEV/MFiIE9tW/2RAevQNZDPeHbf5a94=
+github.com/google/go-github v15.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 h1:zLTLjkaOFEFIOxY5BWLFLwh+cL8vOBW4XJ2aqLE/Tf0=
+github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+golang.org/x/net v0.0.0-20180801234040-f4c29de78a2a h1:8fCF9zjAir2SP3N+axz9xs+0r4V8dqPzqsWO10t8zoo=
+golang.org/x/net v0.0.0-20180801234040-f4c29de78a2a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20180724155351-3d292e4d0cdc h1:3ElrZeO6IBP+M8kgu5YFwRo92Gqr+zBg3aooYQ6ziqU=
+golang.org/x/oauth2 v0.0.0-20180724155351-3d292e4d0cdc/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+google.golang.org/api v0.0.0-20180802201733-6c5c3d4ff961 h1:4UCinJPIvteXVkjbqVHRlW5pFIbzq7t5XAw/5x79zYI=
+google.golang.org/api v0.0.0-20180802201733-6c5c3d4ff961/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
+google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
+google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/internal/contributebot/main.tf
+++ b/internal/contributebot/main.tf
@@ -1,0 +1,53 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+provider "google" {
+  version = "~> 1.15"
+  project = "${var.project}"
+}
+
+locals {
+  appengine_service_account = "${var.project}@appspot.gserviceaccount.com"
+}
+
+# Stackdriver Tracing
+
+resource "google_project_service" "trace" {
+  service            = "cloudtrace.googleapis.com"
+  project            = "${var.project}"
+  disable_on_destroy = false
+}
+
+# Pub/Sub
+
+resource "google_pubsub_topic" "github_events" {
+  name    = "contributebot-github-events"
+  project = "${var.project}"
+}
+
+data "google_iam_policy" "github_events" {
+  binding {
+    role = "roles/pubsub.publisher"
+
+    members = [
+      "serviceAccount:${local.appengine_service_account}",
+    ]
+  }
+}
+
+resource "google_pubsub_topic_iam_policy" "github_events" {
+  topic       = "${google_pubsub_topic.github_events.name}"
+  project     = "${var.project}"
+  policy_data = "${data.google_iam_policy.github_events.policy_data}"
+}

--- a/internal/contributebot/outputs.tf
+++ b/internal/contributebot/outputs.tf
@@ -1,0 +1,23 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "project" {
+  value       = "${var.project}"
+  description = "The GCP project ID."
+}
+
+output "github_events_topic" {
+  value       = "projects/${var.project}/topics/${google_pubsub_topic.github_events.name}"
+  description = "The fully qualified name of the topic."
+}

--- a/internal/contributebot/variables.tf
+++ b/internal/contributebot/variables.tf
@@ -1,0 +1,22 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  backend "gcs" {}
+}
+
+variable "project" {
+  type        = "string"
+  description = "Project to set up."
+}

--- a/internal/contributebot/webhook/README.md
+++ b/internal/contributebot/webhook/README.md
@@ -3,8 +3,11 @@
 Contribute Bot Webhook Listener is a microservice that listens for
 [GitHub webhook][] events and publishes them to a [Cloud Pub/Sub][] topic.
 
-[GitHub webhook]: https://developer.github.com/webhooks/
+You will need the [Go App Engine SDK][] to develop this server.
+
 [Cloud Pub/Sub]: https://cloud.google.com/pubsub/docs/publisher
+[GitHub webhook]: https://developer.github.com/webhooks/
+[Go App Engine SDK]: https://cloud.google.com/appengine/docs/standard/go/download
 
 ## Running Locally
 

--- a/internal/contributebot/webhook/README.md
+++ b/internal/contributebot/webhook/README.md
@@ -1,0 +1,24 @@
+# Contribute Bot Webhook Listener
+
+Contribute Bot Webhook Listener is a microservice that listens for
+[GitHub webhook][] events and publishes them to a [Cloud Pub/Sub][] topic.
+
+[GitHub webhook]: https://developer.github.com/webhooks/
+[Cloud Pub/Sub]: https://cloud.google.com/pubsub/docs/publisher
+
+## Running Locally
+
+```shell
+cp app.yaml.in app.yaml
+# Edit app.yaml to fill in configuration.
+dev_appserver.py .
+```
+
+
+## Deploying
+
+```shell
+cp app.yaml.in app.yaml
+# Edit app.yaml to fill in configuration.
+gcloud app deploy .
+```

--- a/internal/contributebot/webhook/app.yaml.in
+++ b/internal/contributebot/webhook/app.yaml.in
@@ -1,0 +1,15 @@
+runtime: go
+api_version: go1
+
+env_variables:
+  # Uncomment this line and replace with the actual webhook secret.
+  # CONTRIBUTEBOT_WEBHOOK_SECRET: xyzzy
+
+handlers:
+- url: /.*
+  script: _go_app
+  secure: always
+
+skip_files:
+- \.md$
+- \.yaml\.in$

--- a/internal/contributebot/webhook/main.go
+++ b/internal/contributebot/webhook/main.go
@@ -1,0 +1,119 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/pubsub/v1"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/log"
+	"google.golang.org/appengine/urlfetch"
+)
+
+func main() {
+	http.HandleFunc("/", handleDefault)
+	http.HandleFunc("/webhook", handleWebhook)
+	appengine.Main()
+}
+
+func handleDefault(w http.ResponseWriter, r *http.Request) {
+	const responseData = `<!DOCTYPE html>
+<title>Go Cloud Contribute Bot</title>
+<h1>Go Cloud Contribute Bot</h1>
+<p>Hello, you've reached <a href="https://github.com/google/go-cloud">Go Cloud</a>'s contribute bot!</p>`
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != "GET" && r.Method != "HEAD" {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "Only GET or HEAD allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Length", fmt.Sprint(len(responseData)))
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if r.Method == "GET" {
+		io.WriteString(w, responseData)
+	}
+}
+
+func handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "Only POST allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	ctx := appengine.NewContext(r)
+	payload, err := github.ValidatePayload(r, []byte(os.Getenv("CONTRIBUTEBOT_WEBHOOK_SECRET")))
+	if err != nil {
+		log.Errorf(ctx, "%v", err)
+		http.Error(w, "Could not connect to PubSub", http.StatusInternalServerError)
+		return
+	}
+	client, err := newPubSubClient(ctx)
+	if err != nil {
+		log.Errorf(ctx, "%v", err)
+		http.Error(w, "Could not connect to PubSub", http.StatusInternalServerError)
+		return
+	}
+	projectID := appengine.AppID(ctx)
+	topic := "projects/" + projectID + "/topics/contributebot-github-events"
+	call := client.Projects.Topics.Publish(topic, &pubsub.PublishRequest{
+		Messages: []*pubsub.PubsubMessage{
+			{
+				Data: base64.URLEncoding.EncodeToString(payload),
+				Attributes: map[string]string{
+					"X-GitHub-Event":    r.Header.Get("X-GitHub-Event"),
+					"X-GitHub-Delivery": r.Header.Get("X-GitHub-Delivery"),
+				},
+			},
+		},
+	})
+	if _, err := call.Context(ctx).Do(); err != nil {
+		log.Errorf(ctx, "PubSub publish: %v", err)
+		http.Error(w, "PubSub publish failed", http.StatusInternalServerError)
+		return
+	}
+}
+
+func newPubSubClient(ctx context.Context) (*pubsub.Service, error) {
+	tok, expiry, err := appengine.AccessToken(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, fmt.Errorf("create pubsub client: %v")
+	}
+	hc := &http.Client{
+		Transport: &oauth2.Transport{
+			Source: oauth2.StaticTokenSource(&oauth2.Token{
+				AccessToken: tok,
+				TokenType:   "Bearer",
+				Expiry:      expiry,
+			}),
+			Base: &urlfetch.Transport{Context: ctx},
+		},
+	}
+	srv, err := pubsub.New(hc)
+	if err != nil {
+		return nil, fmt.Errorf("create pubsub client: %v")
+	}
+	return srv, nil
+}


### PR DESCRIPTION
Includes Terraform configuration for adding the Pub/Sub topic.

Updates #216