### PR TITLE
internal/testing: use `vgo mod vendor`

### DIFF
--- a/internal/testing/checkpr.sh
+++ b/internal/testing/checkpr.sh
@@ -53,7 +53,7 @@ if has_files '^wire/'; then
 fi
 
 # Run linter and Wire checks.
-vgo mod -vendor || exit 1
+vgo mod vendor || exit 1
 mapfile -t lintdirs < <( find . -type d \
   ! -path "./.git*" \
   ! -path "./tests*" \

--- a/internal/testing/wirecheck.sh
+++ b/internal/testing/wirecheck.sh
@@ -26,6 +26,6 @@ if [[ $# -gt 0 ]]; then
 fi
 
 module="github.com/google/go-cloud"
-vgo mod -vendor || exit 1
+vgo mod vendor || exit 1
 mapfile -t all_pkgs < <( vgo list "$module/..." ) || exit 1
 wire check "${all_pkgs[@]}" || exit 1


### PR DESCRIPTION
The latest sync of vgo from upstream brought in https://golang.org/cl/126655, which changed the syntax of the `go mod` operations.

Fixes #294