### PR TITLE
blob/s3blob: get Size from ContentRange instead of from ContentLength, if available. ContentLength for partial reads refers to the length of the content being read, not the size of the entire blob.

### DIFF
--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -182,12 +182,9 @@ func testRead(t *testing.T, makeBkt BucketMaker) {
 			if !cmp.Equal(got[:tc.wantReadSize], tc.want) {
 				t.Errorf("got %q want %q", string(got), string(tc.want))
 			}
-			// TODO(issue #305): Fails for S3.
-			/*
-				if r.Size() != contentSize {
-					t.Errorf("got size %d want %d", r.Size(), contentSize)
-				}
-			*/
+			if r.Size() != contentSize {
+				t.Errorf("got size %d want %d", r.Size(), contentSize)
+			}
 			r.Close()
 		})
 	}

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -189,6 +189,15 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 		}
 		return nil, err
 	}
+	return &reader{
+		body:        resp.Body,
+		contentType: aws.StringValue(resp.ContentType),
+		size:        getSize(resp),
+		modTime:     aws.TimeValue(resp.LastModified),
+	}, nil
+}
+
+func getSize(resp *s3.GetObjectOutput) int64 {
 	// Default size to ContentLength, but that's incorrect for partial-length reads,
 	// where ContentLength refers to the size of the returned Body, not the entire
 	// size of the blob. ContentRange has the full size.
@@ -202,12 +211,7 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 			}
 		}
 	}
-	return &reader{
-		body:        resp.Body,
-		contentType: aws.StringValue(resp.ContentType),
-		size:        size,
-		modTime:     aws.TimeValue(resp.LastModified),
-	}, nil
+	return size
 }
 
 func (b *bucket) newMetadataReader(ctx context.Context, key string) (driver.Reader, error) {

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -189,9 +189,12 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 		}
 		return nil, err
 	}
+	// Default size to ContentLength, but that's incorrect for partial-length reads,
+	// where ContentLength refers to the size of the returned Body, not the entire
+	// size of the blob. ContentRange has the full size.
 	size := aws.Int64Value(resp.ContentLength)
 	if cr := aws.StringValue(resp.ContentRange); cr != "" {
-		// Sample: bytes 10-14/27
+		// Sample: bytes 10-14/27 (where 27 is the full size).
 		parts := strings.Split(cr, "/")
 		if len(parts) == 2 {
 			if i, err := strconv.ParseInt(parts[1], 10, 64); err == nil {


### PR DESCRIPTION
Fixed #305.