### PR TITLE
wire: check that wire.Value values are from package scope

### DIFF
--- a/wire/internal/wire/testdata/ValueFromFunctionScope/foo/foo.go
+++ b/wire/internal/wire/testdata/ValueFromFunctionScope/foo/foo.go
@@ -1,0 +1,37 @@
+// Copyright 2018 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+)
+
+type foo struct {
+	V int
+}
+
+type bar struct {
+	V int
+}
+
+func newBar(v int) *bar {
+	return &bar{V: v}
+}
+
+func main() {
+	f := &foo{V: 42}
+	b := injectBar(f)
+	fmt.Printf("%d\n", b.V)
+}

--- a/wire/internal/wire/testdata/ValueFromFunctionScope/foo/wire.go
+++ b/wire/internal/wire/testdata/ValueFromFunctionScope/foo/wire.go
@@ -1,0 +1,29 @@
+// Copyright 2018 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build wireinject
+
+package main
+
+import (
+	"github.com/google/go-cloud/wire"
+)
+
+func injectBar(f *foo) *bar {
+	wire.Build(
+		newBar,
+		wire.Value(f.V), // fails because f.V is not from package scope
+	)
+	return nil
+}

--- a/wire/internal/wire/testdata/ValueFromFunctionScope/pkg
+++ b/wire/internal/wire/testdata/ValueFromFunctionScope/pkg
@@ -1,0 +1,1 @@
+example.com/foo

--- a/wire/internal/wire/testdata/ValueFromFunctionScope/want/wire_errs.txt
+++ b/wire/internal/wire/testdata/ValueFromFunctionScope/want/wire_errs.txt
@@ -1,0 +1,1 @@
+inject injectBar: value int can't be used: f is not declared in package scope

--- a/wire/internal/wire/wire.go
+++ b/wire/internal/wire/wire.go
@@ -765,9 +765,15 @@ func accessibleFrom(info *types.Info, node ast.Node, wantPkg string) error {
 			// Local package names are fine, since we can just reimport them.
 			return true
 		}
-		if pkg := obj.Pkg(); pkg != nil && !ast.IsExported(ident.Name) && pkg.Path() != wantPkg {
-			unexportError = fmt.Errorf("uses unexported identifier %s", obj.Name())
-			return false
+		if pkg := obj.Pkg(); pkg != nil {
+			if !ast.IsExported(ident.Name) && pkg.Path() != wantPkg {
+				unexportError = fmt.Errorf("uses unexported identifier %s", obj.Name())
+				return false
+			}
+			if obj.Parent() != pkg.Scope() {
+				unexportError = fmt.Errorf("%s is not declared in package scope", obj.Name())
+				return false
+			}
 		}
 		return true
 	})


### PR DESCRIPTION
Fixes #378 