### PR TITLE
internal: re-order go.sum file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,8 +50,8 @@ require (
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/jtolds/gls v0.0.0-20170503224851-77f18212c9c7 // indirect
-	github.com/opencensus-integrations/ocsql v0.0.0-20180908125828-63b3e35325e2
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/opencensus-integrations/ocsql v0.0.0-20180908125828-63b3e35325e2
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v0.8.0 // indirect
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,10 +70,10 @@ github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jtolds/gls v0.0.0-20170503224851-77f18212c9c7 h1:EkBV8n/hyCf3FCSmYY5aqZxIXI4VPRMOVH+YVgMJla4=
 github.com/jtolds/gls v0.0.0-20170503224851-77f18212c9c7/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/opencensus-integrations/ocsql v0.0.0-20180908125828-63b3e35325e2 h1:ILy0L+3klsiYa4R7K7VnQxBsjWGPEio7JD4sLN/DgjU=
-github.com/opencensus-integrations/ocsql v0.0.0-20180908125828-63b3e35325e2/go.mod h1:ozPYpNVBHZsX33jfoQPO5TlI5lqh0/3R36kirEqJKAM=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/opencensus-integrations/ocsql v0.0.0-20180908125828-63b3e35325e2 h1:ILy0L+3klsiYa4R7K7VnQxBsjWGPEio7JD4sLN/DgjU=
+github.com/opencensus-integrations/ocsql v0.0.0-20180908125828-63b3e35325e2/go.mod h1:ozPYpNVBHZsX33jfoQPO5TlI5lqh0/3R36kirEqJKAM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.8.0 h1:1921Yw9Gc3iSc4VQh3PIoOqgPCZS7G/4xQNVUp8Mda8=


### PR DESCRIPTION
Every time I run "go" anything this diff shows up, not sure why they are out of order.