### PR TITLE
runtimevar/filevar: return ctx.Err() instead of nil error when ctx is Done

### DIFF
--- a/runtimevar/drivertest/drivertest.go
+++ b/runtimevar/drivertest/drivertest.go
@@ -208,7 +208,7 @@ func testString(t *testing.T, newHarness HarnessMaker) {
 		t.Errorf("got %v want error", got)
 	}
 	if tCtx.Err() == nil {
-		t.Error("want Watch to have blocked until context was Done")
+		t.Errorf("got err %v; want Watch to have blocked until context was Done", err)
 	}
 }
 

--- a/runtimevar/filevar/filevar.go
+++ b/runtimevar/filevar/filevar.go
@@ -148,7 +148,7 @@ func (w *watcher) WatchVariable(ctx context.Context, prevVersion interface{}, pr
 		for wait {
 			select {
 			case <-ctx.Done():
-				return checkSameErr(err)
+				return nil, nil, 0, ctx.Err()
 
 			case event := <-w.notifier.Events:
 				if event.Name != w.file {


### PR DESCRIPTION
I wasn't able to repro the flake, but this is definitely a bug. I also added more info on the test failure message which may prove helpful if it flakes again.