### PR TITLE
AUTHORS: fix Google LLC entry

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,8 +11,8 @@
 # Please keep the list sorted.
 
 Ben Hinchley <benjaminhinchley@gmail.com>
-The Go Cloud Authors
 Gerasimos (Makis) Maropoulos <kataras2006@hotmail.com> <omicronmakis@gmail.com>
+Google LLC
 Oleg Kovalov <iamolegkovalov@gmail.com>
 oliverpool <oliverpool@hotmail.fr>
 Sendil Kumar N <sendilkumarn@live.com> <sendil.kn@gmail.com>


### PR DESCRIPTION
"The Go Cloud Authors" are the ones specified by this list, so the existing entry was self-referencing. While the paradox might be an interesting way to keep away robot lawyers, the copyright owner for the Googlers contributions is Google LLC.