### PR TITLE
tests: build GCP test app using go 1.11 instead of vgo

### DIFF
--- a/tests/gcp/app/cloudbuild.yaml
+++ b/tests/gcp/app/cloudbuild.yaml
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 steps:
-- name: '$_VGO_IMAGE_NAME'
-  args: ['build']
-  dir: 'tests/gcp/app'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', '$_IMAGE_NAME:$BUILD_ID', '.']
   dir: 'tests/gcp/app'
+
 images:
 - '$_IMAGE_NAME:$BUILD_ID'

--- a/tests/gcp/app/cloudbuild.yaml
+++ b/tests/gcp/app/cloudbuild.yaml
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 steps:
+- name: 'golang:1.11'
+  args: ['go', 'build']
+  dir: 'tests/gcp/app'
+
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', '$_IMAGE_NAME:$BUILD_ID', '.']
   dir: 'tests/gcp/app'

--- a/tests/gcp/test.sh
+++ b/tests/gcp/test.sh
@@ -47,22 +47,14 @@ cleanup2() {
 trap cleanup2 EXIT
 terraform apply -auto-approve -input=false -var project="$project_id" "$test_dir" || exit 1
 
-# Add vgo container.
-log "Building application..."
-vgo_image="gcr.io/${project_id//:/\/}/vgo"
-if ! GCLOUD container images describe --format='value(image_summary.digest)' "$vgo_image" 1>/dev/null 2>/dev/null; then
-  GCLOUD container builds submit \
-    -t "$vgo_image" \
-    "$test_dir/../../internal/vgo_docker" || exit 1
-fi
-
 # Build the app binary.
+log "Building application..."
 app_image="gcr.io/${project_id//:/\/}/gcp-test"
 build_id="$( GCLOUD container builds submit \
   --async \
   --format='value(id)' \
   --config="$test_dir/app/cloudbuild.yaml" \
-  --substitutions="_IMAGE_NAME=$app_image,_VGO_IMAGE_NAME=$vgo_image" \
+  --substitutions="_IMAGE_NAME=$app_image" \
   "$test_dir/../.." )" || exit 1
 GCLOUD container builds log --stream "$build_id" || exit 1
 


### PR DESCRIPTION
Fixes #458 