### PR TITLE
blob: Add support for key/value Metadata

### DIFF
--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -58,6 +58,8 @@ type WriterOptions struct {
 	// write in a single request, if supported. Larger objects will be split into
 	// multiple requests.
 	BufferSize int
+	// Metadata holds key/value strings to be associated with the blob.
+	Metadata map[string]string
 }
 
 // ReaderAttributes contains a subset of attributes about a blob that are
@@ -76,6 +78,9 @@ type ReaderAttributes struct {
 type Attributes struct {
 	// ContentType is the MIME type of the blob object. It must not be empty.
 	ContentType string
+	// Metadata holds key/value pairs associated with the blob.
+	// Keys are case-insensitive and will always be returned in lowercase.
+	Metadata map[string]string
 	// ModTime is the time the blob object was last modified.
 	ModTime time.Time
 	// Size is the size of the object in bytes.

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -59,6 +59,7 @@ type WriterOptions struct {
 	// multiple requests.
 	BufferSize int
 	// Metadata holds key/value strings to be associated with the blob.
+	// Keys are guaranteed to be non-empty and lowercased.
 	Metadata map[string]string
 }
 
@@ -79,7 +80,10 @@ type Attributes struct {
 	// ContentType is the MIME type of the blob object. It must not be empty.
 	ContentType string
 	// Metadata holds key/value pairs associated with the blob.
-	// Keys are case-insensitive and will always be returned in lowercase.
+	// Keys will be lowercased by the concrete type before being returned
+	// to the user. If there are duplicate case-insensitive keys (e.g.,
+	// "foo" and "FOO"), only one value will be kept, and it is undefined
+	// which one.
 	Metadata map[string]string
 	// ModTime is the time the blob object was last modified.
 	ModTime time.Time

--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -493,6 +493,12 @@ func testMetadata(t *testing.T, newHarness HarnessMaker) {
 			wantErr:  true,
 		},
 		{
+			name:     "duplicate case-insensitive key fails",
+			content:  hello,
+			metadata: map[string]string{"abc": "foo", "aBc": "bar"},
+			wantErr:  true,
+		},
+		{
 			name:    "valid metadata",
 			content: hello,
 			metadata: map[string]string{

--- a/blob/fileblob/attrs.go
+++ b/blob/fileblob/attrs.go
@@ -25,7 +25,8 @@ const attrsExt = ".attrs"
 // filesystem extended attributes, see
 // https://www.freedesktop.org/wiki/CommonExtendedAttributes.
 type xattrs struct {
-	ContentType string `json:"user.content_type"`
+	ContentType string            `json:"user.content_type"`
+	Metadata    map[string]string `json:"user.metadata"`
 }
 
 // setAttrs creates a "path.attrs" file along with blob to store the attributes,
@@ -49,7 +50,7 @@ func getAttrs(path string) (xattrs, error) {
 	f, err := os.Open(path + attrsExt)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// Handle gracefully for non-existing .attr files.
+			// Handle gracefully for non-existent .attr files.
 			return xattrs{
 				ContentType: "application/octet-stream",
 			}, nil

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -107,6 +107,7 @@ func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes,
 	}
 	return driver.Attributes{
 		ContentType: xa.ContentType,
+		Metadata:    xa.Metadata,
 		ModTime:     info.ModTime(),
 		Size:        info.Size(),
 	}, nil
@@ -183,8 +184,13 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType str
 	if err != nil {
 		return nil, fmt.Errorf("open file blob %s: %v", key, err)
 	}
+	var metadata map[string]string
+	if opt != nil && len(opt.Metadata) > 0 {
+		metadata = opt.Metadata
+	}
 	attrs := xattrs{
 		ContentType: contentType,
+		Metadata:    metadata,
 	}
 	return &writer{
 		ctx:   ctx,

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -85,6 +85,7 @@ func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes,
 	}
 	return driver.Attributes{
 		ContentType: attrs.ContentType,
+		Metadata:    attrs.Metadata,
 		ModTime:     attrs.Updated,
 		Size:        attrs.Size,
 	}, nil
@@ -120,6 +121,7 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType str
 	w.ContentType = contentType
 	if opts != nil {
 		w.ChunkSize = bufferSize(opts.BufferSize)
+		w.Metadata = opts.Metadata
 	}
 	return w, nil
 }

--- a/blob/gcsblob/testdata/TestConformance/TestMetadata/empty.yaml
+++ b/blob/gcsblob/testdata/TestConformance/TestMetadata/empty.yaml
@@ -1,0 +1,387 @@
+---
+version: 1
+interactions:
+- request:
+    body: "--1bcd10627a48468974fc3c7d3084255a91b126fa67213784866e6baf5ade\r\nContent-Type:
+      application/json\r\n\r\n{\"bucket\":\"go-cloud-blob-test-bucket\",\"contentType\":\"text/plain;
+      charset=utf-8\",\"name\":\"blob-for-metadata\"}\n\r\n--1bcd10627a48468974fc3c7d3084255a91b126fa67213784866e6baf5ade\r\nContent-Type:
+      text/plain; charset=utf-8\r\n\r\nhello\r\n--1bcd10627a48468974fc3c7d3084255a91b126fa67213784866e6baf5ade--\r\n"
+    form: {}
+    headers:
+      Content-Type:
+      - multipart/related; boundary=1bcd10627a48468974fc3c7d3084255a91b126fa67213784866e6baf5ade
+      User-Agent:
+      - google-api-go-client/0.5
+      X-Goog-Api-Client:
+      - gl-go/1.11.0-rc2 gccl/20180226
+    url: https://www.googleapis.com/upload/storage/v1/b/go-cloud-blob-test-bucket/o?alt=json&projection=full&uploadType=multipart
+    method: POST
+  response:
+    body: |
+      {
+       "kind": "storage#object",
+       "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615048680",
+       "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata",
+       "name": "blob-for-metadata",
+       "bucket": "go-cloud-blob-test-bucket",
+       "generation": "1538176615048680",
+       "metageneration": "1",
+       "contentType": "text/plain; charset=utf-8",
+       "timeCreated": "2018-09-28T23:16:55.048Z",
+       "updated": "2018-09-28T23:16:55.048Z",
+       "storageClass": "REGIONAL",
+       "timeStorageClassUpdated": "2018-09-28T23:16:55.048Z",
+       "size": "5",
+       "md5Hash": "XUFAKrxLKna5cZ2REBfFkg==",
+       "mediaLink": "https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?generation=1538176615048680&alt=media",
+       "acl": [
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615048680/project-owners-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-owners-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615048680",
+         "entity": "project-owners-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "owners"
+         },
+         "etag": "COjL97Xq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615048680/project-editors-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-editors-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615048680",
+         "entity": "project-editors-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "editors"
+         },
+         "etag": "COjL97Xq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615048680/project-viewers-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-viewers-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615048680",
+         "entity": "project-viewers-892942638129",
+         "role": "READER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "viewers"
+         },
+         "etag": "COjL97Xq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615048680/user-rvangent@google.com",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/user-rvangent@google.com",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615048680",
+         "entity": "user-rvangent@google.com",
+         "role": "OWNER",
+         "email": "rvangent@google.com",
+         "etag": "COjL97Xq3t0CEAE="
+        }
+       ],
+       "owner": {
+        "entity": "user-rvangent@google.com"
+       },
+       "crc32c": "mnG7TA==",
+       "etag": "COjL97Xq3t0CEAE="
+      }
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "3137"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 28 Sep 2018 23:16:55 GMT
+      Etag:
+      - COjL97Xq3t0CEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Google-Apiary-Auth-Expires:
+      - "1538176914000"
+      X-Google-Apiary-Auth-Scopes:
+      - https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/devstorage.read_write https://www.googleapis.com/auth/devstorage.write_only
+      X-Google-Apiary-Auth-User:
+      - "61688748495"
+      X-Google-Backends:
+      - hilaxcbe8:4497,/bns/hi/borg/hi/bns/blobstore2/bitpusher/19.scotty,acsfoc2:443
+      X-Google-Dos-Service-Trace:
+      - main:apps-upload-cloud-storage-unified
+      X-Google-Gfe-Backend-Request-Info:
+      - eid=ZrauW4yMM-GgxgPb-4TIBg
+      X-Google-Gfe-Cloud-Project-Number:
+      - "892942638129"
+      X-Google-Gfe-Request-Trace:
+      - acsfoc2:443,/bns/hi/borg/hi/bns/blobstore2/bitpusher/19.scotty,acsfoc2:443
+      X-Google-Gfe-Response-Code-Details-Trace:
+      - response_code_set_by_backend
+      X-Google-Gfe-Service-Trace:
+      - bitpusher-gcs-apiary
+      X-Google-Netmon-Label:
+      - /bns/hi/borg/hi/bns/blobstore2/bitpusher/19:caf3
+      X-Google-Service:
+      - bitpusher-gcs-apiary
+      X-Google-Session-Info:
+      - CM-zvuflARoCGAY6fAoSY2xvdWQtc3RvcmFnZS1yb3N5EghiaWdzdG9yZRiKyM-4nhYiSDc2NDA4NjA1MTg1MC02cXI0cDZncGk2aG41MDZwdDhlanVxODNkaTM0MWh1ci5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTCQlgIw4Csw4Ssw4ytKDzoNMS9SMmJWQ0ZqRzVIfg
+      X-Google-Shellfish-Status:
+      - CA0gBEBG
+      X-Guploader-Customer:
+      - apiary_cloudstorage_single_post_uploads
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2UrIUwAhyqcu_X8015_JhmpPlxcV-E84IE0Q6BJsX4hmhLlXj4AiLhMLV0gvJ8zc0XmGIt2xmiejt65LZL8Tawer5GnHUQ
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - google-api-go-client/0.5
+      X-Goog-Api-Client:
+      - gl-go/1.11.0-rc2 gccl/20180226
+    url: https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?alt=json&projection=full
+    method: GET
+  response:
+    body: |
+      {
+       "kind": "storage#object",
+       "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615048680",
+       "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata",
+       "name": "blob-for-metadata",
+       "bucket": "go-cloud-blob-test-bucket",
+       "generation": "1538176615048680",
+       "metageneration": "1",
+       "contentType": "text/plain; charset=utf-8",
+       "timeCreated": "2018-09-28T23:16:55.048Z",
+       "updated": "2018-09-28T23:16:55.048Z",
+       "storageClass": "REGIONAL",
+       "timeStorageClassUpdated": "2018-09-28T23:16:55.048Z",
+       "size": "5",
+       "md5Hash": "XUFAKrxLKna5cZ2REBfFkg==",
+       "mediaLink": "https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?generation=1538176615048680&alt=media",
+       "acl": [
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615048680/project-owners-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-owners-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615048680",
+         "entity": "project-owners-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "owners"
+         },
+         "etag": "COjL97Xq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615048680/project-editors-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-editors-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615048680",
+         "entity": "project-editors-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "editors"
+         },
+         "etag": "COjL97Xq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615048680/project-viewers-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-viewers-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615048680",
+         "entity": "project-viewers-892942638129",
+         "role": "READER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "viewers"
+         },
+         "etag": "COjL97Xq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615048680/user-rvangent@google.com",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/user-rvangent@google.com",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615048680",
+         "entity": "user-rvangent@google.com",
+         "role": "OWNER",
+         "email": "rvangent@google.com",
+         "etag": "COjL97Xq3t0CEAE="
+        }
+       ],
+       "owner": {
+        "entity": "user-rvangent@google.com"
+       },
+       "crc32c": "mnG7TA==",
+       "etag": "COjL97Xq3t0CEAE="
+      }
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "3137"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 28 Sep 2018 23:16:55 GMT
+      Etag:
+      - COjL97Xq3t0CEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Google-Apiary-Auth-Expires:
+      - "1538176914000"
+      X-Google-Apiary-Auth-Scopes:
+      - https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/cloud-platform.read-only https://www.googleapis.com/auth/devstorage.read_write
+        https://www.googleapis.com/auth/devstorage.read_only
+      X-Google-Apiary-Auth-User:
+      - "61688748495"
+      X-Google-Backends:
+      - hhlaxbbb12:4121,/bns/hi/borg/hi/bns/blobstore2/bitpusher/16.scotty,acsfoc2:443
+      X-Google-Dos-Service-Trace:
+      - main:apps-upload-cloud-storage-unified
+      X-Google-Gfe-Backend-Request-Info:
+      - eid=Z7auW4WSBIqnxgON54vIDw
+      X-Google-Gfe-Request-Trace:
+      - acsfoc2:443,/bns/hi/borg/hi/bns/blobstore2/bitpusher/16.scotty,acsfoc2:443
+      X-Google-Gfe-Response-Code-Details-Trace:
+      - response_code_set_by_backend
+      X-Google-Gfe-Service-Trace:
+      - bitpusher-gcs-apiary
+      X-Google-Netmon-Label:
+      - /bns/hi/borg/hi/bns/blobstore2/bitpusher/16:caf3
+      X-Google-Service:
+      - bitpusher-gcs-apiary
+      X-Google-Session-Info:
+      - CM-zvuflARoCGAY6gAEKEmNsb3VkLXN0b3JhZ2Utcm9zeRIIYmlnc3RvcmUYisjPuJ4WIkg3NjQwODYwNTE4NTAtNnFyNHA2Z3BpNmhuNTA2cHQ4ZWp1cTgzZGkzNDFodXIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20wkJYCMOArMJGWAjDhKzDiK0oPOg0xL1IyYlZDRmpHNUh-
+      X-Google-Shellfish-Status:
+      - CA0gBEBG
+      X-Guploader-Customer:
+      - apiary_cloudstorage_metadata
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2UoYbDJRZYgAPkT3lpX0pI5_jjmR7idp7AZdHnHxL4_ePog6EuuEzjGYQO29Kyz2Xf91gBN1-BTdlAB6f_Rh0ehUTYmEEw
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - google-api-go-client/0.5
+      X-Goog-Api-Client:
+      - gl-go/1.11.0-rc2 gccl/20180226
+    url: https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?alt=json
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "0"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 28 Sep 2018 23:16:55 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Google-Apiary-Auth-Expires:
+      - "1538176914000"
+      X-Google-Apiary-Auth-Scopes:
+      - https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/devstorage.read_write https://www.googleapis.com/auth/devstorage.write_only
+      X-Google-Apiary-Auth-User:
+      - "61688748495"
+      X-Google-Backends:
+      - hilaxcae2:4090,/bns/hi/borg/hi/bns/blobstore2/bitpusher/22.scotty,acsfoc2:443
+      X-Google-Dos-Service-Trace:
+      - main:apps-upload-cloud-storage-unified
+      X-Google-Gfe-Backend-Request-Info:
+      - eid=Z7auW6v8C-mmxgPS3IOoAQ
+      X-Google-Gfe-Request-Trace:
+      - acsfoc2:443,/bns/hi/borg/hi/bns/blobstore2/bitpusher/22.scotty,acsfoc2:443
+      X-Google-Gfe-Response-Code-Details-Trace:
+      - response_code_set_by_backend
+      X-Google-Gfe-Service-Trace:
+      - bitpusher-gcs-apiary
+      X-Google-Netmon-Label:
+      - /bns/hi/borg/hi/bns/blobstore2/bitpusher/22:caf3
+      X-Google-Service:
+      - bitpusher-gcs-apiary
+      X-Google-Session-Info:
+      - CM-zvuflARoCGAY6fAoSY2xvdWQtc3RvcmFnZS1yb3N5EghiaWdzdG9yZRiKyM-4nhYiSDc2NDA4NjA1MTg1MC02cXI0cDZncGk2aG41MDZwdDhlanVxODNkaTM0MWh1ci5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTCQlgIw4Csw4Ssw4ytKDzoNMS9SMmJWQ0ZqRzVIfg
+      X-Google-Shellfish-Status:
+      - CA0gBEBG
+      X-Guploader-Customer:
+      - apiary_cloudstorage_metadata
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2UoXAfeIUmmHGGS6R5FoqUrrqSFwc_l3QCISS2W-uVX-nPzBseZGQU6Mfuk794DpRQnm0bcAwbt0LV2ungy0xuqvKuoKcA
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/blob/gcsblob/testdata/TestConformance/TestMetadata/valid_metadata.yaml
+++ b/blob/gcsblob/testdata/TestConformance/TestMetadata/valid_metadata.yaml
@@ -1,0 +1,397 @@
+---
+version: 1
+interactions:
+- request:
+    body: "--f1c526ca95d31fb2d67a267aa26fa42b0c67e669f239c27e2ee1ff1d2595\r\nContent-Type:
+      application/json\r\n\r\n{\"bucket\":\"go-cloud-blob-test-bucket\",\"contentType\":\"text/plain;
+      charset=utf-8\",\"metadata\":{\"key-a\":\"value-a\",\"key-b\":\"value-b\",\"key-c\":\"vAlUe-c\"},\"name\":\"blob-for-metadata\"}\n\r\n--f1c526ca95d31fb2d67a267aa26fa42b0c67e669f239c27e2ee1ff1d2595\r\nContent-Type:
+      text/plain; charset=utf-8\r\n\r\nhello\r\n--f1c526ca95d31fb2d67a267aa26fa42b0c67e669f239c27e2ee1ff1d2595--\r\n"
+    form: {}
+    headers:
+      Content-Type:
+      - multipart/related; boundary=f1c526ca95d31fb2d67a267aa26fa42b0c67e669f239c27e2ee1ff1d2595
+      User-Agent:
+      - google-api-go-client/0.5
+      X-Goog-Api-Client:
+      - gl-go/1.11.0-rc2 gccl/20180226
+    url: https://www.googleapis.com/upload/storage/v1/b/go-cloud-blob-test-bucket/o?alt=json&projection=full&uploadType=multipart
+    method: POST
+  response:
+    body: |
+      {
+       "kind": "storage#object",
+       "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615707405",
+       "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata",
+       "name": "blob-for-metadata",
+       "bucket": "go-cloud-blob-test-bucket",
+       "generation": "1538176615707405",
+       "metageneration": "1",
+       "contentType": "text/plain; charset=utf-8",
+       "timeCreated": "2018-09-28T23:16:55.707Z",
+       "updated": "2018-09-28T23:16:55.707Z",
+       "storageClass": "REGIONAL",
+       "timeStorageClassUpdated": "2018-09-28T23:16:55.707Z",
+       "size": "5",
+       "md5Hash": "XUFAKrxLKna5cZ2REBfFkg==",
+       "mediaLink": "https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?generation=1538176615707405&alt=media",
+       "metadata": {
+        "key-a": "value-a",
+        "key-b": "value-b",
+        "key-c": "vAlUe-c"
+       },
+       "acl": [
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615707405/project-owners-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-owners-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615707405",
+         "entity": "project-owners-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "owners"
+         },
+         "etag": "CI3mn7bq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615707405/project-editors-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-editors-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615707405",
+         "entity": "project-editors-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "editors"
+         },
+         "etag": "CI3mn7bq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615707405/project-viewers-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-viewers-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615707405",
+         "entity": "project-viewers-892942638129",
+         "role": "READER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "viewers"
+         },
+         "etag": "CI3mn7bq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615707405/user-rvangent@google.com",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/user-rvangent@google.com",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615707405",
+         "entity": "user-rvangent@google.com",
+         "role": "OWNER",
+         "email": "rvangent@google.com",
+         "etag": "CI3mn7bq3t0CEAE="
+        }
+       ],
+       "owner": {
+        "entity": "user-rvangent@google.com"
+       },
+       "crc32c": "mnG7TA==",
+       "etag": "CI3mn7bq3t0CEAE="
+      }
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "3221"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 28 Sep 2018 23:16:55 GMT
+      Etag:
+      - CI3mn7bq3t0CEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Google-Apiary-Auth-Expires:
+      - "1538176915000"
+      X-Google-Apiary-Auth-Scopes:
+      - https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/devstorage.read_write https://www.googleapis.com/auth/devstorage.write_only
+      X-Google-Apiary-Auth-User:
+      - "61688748495"
+      X-Google-Backends:
+      - hhlaxban11:4088,/bns/hi/borg/hi/bns/blobstore2/bitpusher/3.scotty,acsfoc2:443
+      X-Google-Dos-Service-Trace:
+      - main:apps-upload-cloud-storage-unified
+      X-Google-Gfe-Backend-Request-Info:
+      - eid=Z7auW66HH6KgxgO2hZXgCQ
+      X-Google-Gfe-Cloud-Project-Number:
+      - "892942638129"
+      X-Google-Gfe-Request-Trace:
+      - acsfoc2:443,/bns/hi/borg/hi/bns/blobstore2/bitpusher/3.scotty,acsfoc2:443
+      X-Google-Gfe-Response-Code-Details-Trace:
+      - response_code_set_by_backend
+      X-Google-Gfe-Service-Trace:
+      - bitpusher-gcs-apiary
+      X-Google-Netmon-Label:
+      - /bns/hi/borg/hi/bns/blobstore2/bitpusher/3:caf3
+      X-Google-Service:
+      - bitpusher-gcs-apiary
+      X-Google-Session-Info:
+      - CM-zvuflARoCGAY6fAoSY2xvdWQtc3RvcmFnZS1yb3N5EghiaWdzdG9yZRiKyM-4nhYiSDc2NDA4NjA1MTg1MC02cXI0cDZncGk2aG41MDZwdDhlanVxODNkaTM0MWh1ci5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTCQlgIw4Csw4Ssw4ytKDzoNMS9SMmJWQ0ZqRzVIfg
+      X-Google-Shellfish-Status:
+      - CA0gBEBG
+      X-Guploader-Customer:
+      - apiary_cloudstorage_single_post_uploads
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2Uo9w9qEC4Nz7vfzdt4irAwk9hmM45cb4HXfSEWLZ0kJ-9DrI8PC36fMVXbX_7SyVaWoVfmMr1nVojsjSKZAIk5-Twjsow
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - google-api-go-client/0.5
+      X-Goog-Api-Client:
+      - gl-go/1.11.0-rc2 gccl/20180226
+    url: https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?alt=json&projection=full
+    method: GET
+  response:
+    body: |
+      {
+       "kind": "storage#object",
+       "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615707405",
+       "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata",
+       "name": "blob-for-metadata",
+       "bucket": "go-cloud-blob-test-bucket",
+       "generation": "1538176615707405",
+       "metageneration": "1",
+       "contentType": "text/plain; charset=utf-8",
+       "timeCreated": "2018-09-28T23:16:55.707Z",
+       "updated": "2018-09-28T23:16:55.707Z",
+       "storageClass": "REGIONAL",
+       "timeStorageClassUpdated": "2018-09-28T23:16:55.707Z",
+       "size": "5",
+       "md5Hash": "XUFAKrxLKna5cZ2REBfFkg==",
+       "mediaLink": "https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?generation=1538176615707405&alt=media",
+       "metadata": {
+        "key-a": "value-a",
+        "key-b": "value-b",
+        "key-c": "vAlUe-c"
+       },
+       "acl": [
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615707405/project-owners-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-owners-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615707405",
+         "entity": "project-owners-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "owners"
+         },
+         "etag": "CI3mn7bq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615707405/project-editors-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-editors-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615707405",
+         "entity": "project-editors-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "editors"
+         },
+         "etag": "CI3mn7bq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615707405/project-viewers-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-viewers-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615707405",
+         "entity": "project-viewers-892942638129",
+         "role": "READER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "viewers"
+         },
+         "etag": "CI3mn7bq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176615707405/user-rvangent@google.com",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/user-rvangent@google.com",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176615707405",
+         "entity": "user-rvangent@google.com",
+         "role": "OWNER",
+         "email": "rvangent@google.com",
+         "etag": "CI3mn7bq3t0CEAE="
+        }
+       ],
+       "owner": {
+        "entity": "user-rvangent@google.com"
+       },
+       "crc32c": "mnG7TA==",
+       "etag": "CI3mn7bq3t0CEAE="
+      }
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "3221"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 28 Sep 2018 23:16:55 GMT
+      Etag:
+      - CI3mn7bq3t0CEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Google-Apiary-Auth-Expires:
+      - "1538176915000"
+      X-Google-Apiary-Auth-Scopes:
+      - https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/cloud-platform.read-only https://www.googleapis.com/auth/devstorage.read_write
+        https://www.googleapis.com/auth/devstorage.read_only
+      X-Google-Apiary-Auth-User:
+      - "61688748495"
+      X-Google-Backends:
+      - hhlaxbbd2:4277,/bns/hi/borg/hi/bns/blobstore2/bitpusher/21.scotty,acsfoc2:443
+      X-Google-Dos-Service-Trace:
+      - main:apps-upload-cloud-storage-unified
+      X-Google-Gfe-Backend-Request-Info:
+      - eid=Z7auW7KlLMynxgPx2J7gBQ
+      X-Google-Gfe-Request-Trace:
+      - acsfoc2:443,/bns/hi/borg/hi/bns/blobstore2/bitpusher/21.scotty,acsfoc2:443
+      X-Google-Gfe-Response-Code-Details-Trace:
+      - response_code_set_by_backend
+      X-Google-Gfe-Service-Trace:
+      - bitpusher-gcs-apiary
+      X-Google-Netmon-Label:
+      - /bns/hi/borg/hi/bns/blobstore2/bitpusher/21:caf3
+      X-Google-Service:
+      - bitpusher-gcs-apiary
+      X-Google-Session-Info:
+      - CM-zvuflARoCGAY6gAEKEmNsb3VkLXN0b3JhZ2Utcm9zeRIIYmlnc3RvcmUYisjPuJ4WIkg3NjQwODYwNTE4NTAtNnFyNHA2Z3BpNmhuNTA2cHQ4ZWp1cTgzZGkzNDFodXIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20wkJYCMOArMJGWAjDhKzDiK0oPOg0xL1IyYlZDRmpHNUh-
+      X-Google-Shellfish-Status:
+      - CA0gBEBG
+      X-Guploader-Customer:
+      - apiary_cloudstorage_metadata
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2UpxcWj59Y2yoAjJznk7X8Q-p2_6x8rbkIKWtFdniLnktozuJ_Q3v0fx5NRz8mI3cF3aOsfAme8R9LuKsDYnE2bSI-WC4Q
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - google-api-go-client/0.5
+      X-Goog-Api-Client:
+      - gl-go/1.11.0-rc2 gccl/20180226
+    url: https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?alt=json
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "0"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 28 Sep 2018 23:16:55 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Google-Apiary-Auth-Expires:
+      - "1538176915000"
+      X-Google-Apiary-Auth-Scopes:
+      - https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/devstorage.read_write https://www.googleapis.com/auth/devstorage.write_only
+      X-Google-Apiary-Auth-User:
+      - "61688748495"
+      X-Google-Backends:
+      - hhlaxbbb12:4121,/bns/hi/borg/hi/bns/blobstore2/bitpusher/1.scotty,acsfoc2:443
+      X-Google-Dos-Service-Trace:
+      - main:apps-upload-cloud-storage-unified
+      X-Google-Gfe-Backend-Request-Info:
+      - eid=Z7auW62JMMyoxgOFr6yYAw
+      X-Google-Gfe-Request-Trace:
+      - acsfoc2:443,/bns/hi/borg/hi/bns/blobstore2/bitpusher/1.scotty,acsfoc2:443
+      X-Google-Gfe-Response-Code-Details-Trace:
+      - response_code_set_by_backend
+      X-Google-Gfe-Service-Trace:
+      - bitpusher-gcs-apiary
+      X-Google-Netmon-Label:
+      - /bns/hi/borg/hi/bns/blobstore2/bitpusher/1:caf3
+      X-Google-Service:
+      - bitpusher-gcs-apiary
+      X-Google-Session-Info:
+      - CM-zvuflARoCGAY6fAoSY2xvdWQtc3RvcmFnZS1yb3N5EghiaWdzdG9yZRiKyM-4nhYiSDc2NDA4NjA1MTg1MC02cXI0cDZncGk2aG41MDZwdDhlanVxODNkaTM0MWh1ci5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTCQlgIw4Csw4Ssw4ytKDzoNMS9SMmJWQ0ZqRzVIfg
+      X-Google-Shellfish-Status:
+      - CA0gBEBG
+      X-Guploader-Customer:
+      - apiary_cloudstorage_metadata
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2UrZh27jIrER0Vr1zyDVCaLSiEUjRDwXIL2RAANQEDjZRLdTFjM7_vyCQ9cLlrKNIrQvcuUQKGqC2RzUAbWK-hDC0dT6jA
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/blob/gcsblob/testdata/TestConformance/TestMetadata/valid_metadata_with_empty_body.yaml
+++ b/blob/gcsblob/testdata/TestConformance/TestMetadata/valid_metadata_with_empty_body.yaml
@@ -1,0 +1,393 @@
+---
+version: 1
+interactions:
+- request:
+    body: "--739445337b74bb79acd1fa81ed53fbd9a3709338c54d6ca5f3afe3d79f4d\r\nContent-Type:
+      application/json\r\n\r\n{\"bucket\":\"go-cloud-blob-test-bucket\",\"contentType\":\"text/plain;
+      charset=utf-8\",\"metadata\":{\"foo\":\"bar\"},\"name\":\"blob-for-metadata\"}\n\r\n--739445337b74bb79acd1fa81ed53fbd9a3709338c54d6ca5f3afe3d79f4d\r\nContent-Type:
+      text/plain; charset=utf-8\r\n\r\nhello\r\n--739445337b74bb79acd1fa81ed53fbd9a3709338c54d6ca5f3afe3d79f4d--\r\n"
+    form: {}
+    headers:
+      Content-Type:
+      - multipart/related; boundary=739445337b74bb79acd1fa81ed53fbd9a3709338c54d6ca5f3afe3d79f4d
+      User-Agent:
+      - google-api-go-client/0.5
+      X-Goog-Api-Client:
+      - gl-go/1.11.0-rc2 gccl/20180226
+    url: https://www.googleapis.com/upload/storage/v1/b/go-cloud-blob-test-bucket/o?alt=json&projection=full&uploadType=multipart
+    method: POST
+  response:
+    body: |
+      {
+       "kind": "storage#object",
+       "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176616313050",
+       "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata",
+       "name": "blob-for-metadata",
+       "bucket": "go-cloud-blob-test-bucket",
+       "generation": "1538176616313050",
+       "metageneration": "1",
+       "contentType": "text/plain; charset=utf-8",
+       "timeCreated": "2018-09-28T23:16:56.312Z",
+       "updated": "2018-09-28T23:16:56.312Z",
+       "storageClass": "REGIONAL",
+       "timeStorageClassUpdated": "2018-09-28T23:16:56.312Z",
+       "size": "5",
+       "md5Hash": "XUFAKrxLKna5cZ2REBfFkg==",
+       "mediaLink": "https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?generation=1538176616313050&alt=media",
+       "metadata": {
+        "foo": "bar"
+       },
+       "acl": [
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176616313050/project-owners-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-owners-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176616313050",
+         "entity": "project-owners-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "owners"
+         },
+         "etag": "CNrhxLbq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176616313050/project-editors-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-editors-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176616313050",
+         "entity": "project-editors-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "editors"
+         },
+         "etag": "CNrhxLbq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176616313050/project-viewers-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-viewers-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176616313050",
+         "entity": "project-viewers-892942638129",
+         "role": "READER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "viewers"
+         },
+         "etag": "CNrhxLbq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176616313050/user-rvangent@google.com",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/user-rvangent@google.com",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176616313050",
+         "entity": "user-rvangent@google.com",
+         "role": "OWNER",
+         "email": "rvangent@google.com",
+         "etag": "CNrhxLbq3t0CEAE="
+        }
+       ],
+       "owner": {
+        "entity": "user-rvangent@google.com"
+       },
+       "crc32c": "mnG7TA==",
+       "etag": "CNrhxLbq3t0CEAE="
+      }
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "3171"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 28 Sep 2018 23:16:56 GMT
+      Etag:
+      - CNrhxLbq3t0CEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Google-Apiary-Auth-Expires:
+      - "1538176915000"
+      X-Google-Apiary-Auth-Scopes:
+      - https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/devstorage.read_write https://www.googleapis.com/auth/devstorage.write_only
+      X-Google-Apiary-Auth-User:
+      - "61688748495"
+      X-Google-Backends:
+      - hilaxcaz11:4473,/bns/hi/borg/hi/bns/blobstore2/bitpusher/5.scotty,acsfoc2:443
+      X-Google-Dos-Service-Trace:
+      - main:apps-upload-cloud-storage-unified
+      X-Google-Gfe-Backend-Request-Info:
+      - eid=aLauW5GqB6eoxgO7sJLwAQ
+      X-Google-Gfe-Cloud-Project-Number:
+      - "892942638129"
+      X-Google-Gfe-Request-Trace:
+      - acsfoc2:443,/bns/hi/borg/hi/bns/blobstore2/bitpusher/5.scotty,acsfoc2:443
+      X-Google-Gfe-Response-Code-Details-Trace:
+      - response_code_set_by_backend
+      X-Google-Gfe-Service-Trace:
+      - bitpusher-gcs-apiary
+      X-Google-Netmon-Label:
+      - /bns/hi/borg/hi/bns/blobstore2/bitpusher/5:caf3
+      X-Google-Service:
+      - bitpusher-gcs-apiary
+      X-Google-Session-Info:
+      - CM-zvuflARoCGAY6fAoSY2xvdWQtc3RvcmFnZS1yb3N5EghiaWdzdG9yZRiKyM-4nhYiSDc2NDA4NjA1MTg1MC02cXI0cDZncGk2aG41MDZwdDhlanVxODNkaTM0MWh1ci5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTCQlgIw4Csw4Ssw4ytKDzoNMS9SMmJWQ0ZqRzVIfg
+      X-Google-Shellfish-Status:
+      - CA0gBEBG
+      X-Guploader-Customer:
+      - apiary_cloudstorage_single_post_uploads
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2Uog_DSiOx_LIYsMioI9s_yGItJjXZBWV-ExzXkaidOkbAIgx3q8zAPoE5SULEzknCWtKEQF_SvXFDft7V78aoEaofGmEw
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - google-api-go-client/0.5
+      X-Goog-Api-Client:
+      - gl-go/1.11.0-rc2 gccl/20180226
+    url: https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?alt=json&projection=full
+    method: GET
+  response:
+    body: |
+      {
+       "kind": "storage#object",
+       "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176616313050",
+       "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata",
+       "name": "blob-for-metadata",
+       "bucket": "go-cloud-blob-test-bucket",
+       "generation": "1538176616313050",
+       "metageneration": "1",
+       "contentType": "text/plain; charset=utf-8",
+       "timeCreated": "2018-09-28T23:16:56.312Z",
+       "updated": "2018-09-28T23:16:56.312Z",
+       "storageClass": "REGIONAL",
+       "timeStorageClassUpdated": "2018-09-28T23:16:56.312Z",
+       "size": "5",
+       "md5Hash": "XUFAKrxLKna5cZ2REBfFkg==",
+       "mediaLink": "https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?generation=1538176616313050&alt=media",
+       "metadata": {
+        "foo": "bar"
+       },
+       "acl": [
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176616313050/project-owners-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-owners-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176616313050",
+         "entity": "project-owners-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "owners"
+         },
+         "etag": "CNrhxLbq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176616313050/project-editors-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-editors-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176616313050",
+         "entity": "project-editors-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "editors"
+         },
+         "etag": "CNrhxLbq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176616313050/project-viewers-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-viewers-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176616313050",
+         "entity": "project-viewers-892942638129",
+         "role": "READER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "viewers"
+         },
+         "etag": "CNrhxLbq3t0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538176616313050/user-rvangent@google.com",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/user-rvangent@google.com",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538176616313050",
+         "entity": "user-rvangent@google.com",
+         "role": "OWNER",
+         "email": "rvangent@google.com",
+         "etag": "CNrhxLbq3t0CEAE="
+        }
+       ],
+       "owner": {
+        "entity": "user-rvangent@google.com"
+       },
+       "crc32c": "mnG7TA==",
+       "etag": "CNrhxLbq3t0CEAE="
+      }
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "3171"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 28 Sep 2018 23:16:56 GMT
+      Etag:
+      - CNrhxLbq3t0CEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Google-Apiary-Auth-Expires:
+      - "1538176915000"
+      X-Google-Apiary-Auth-Scopes:
+      - https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/cloud-platform.read-only https://www.googleapis.com/auth/devstorage.read_write
+        https://www.googleapis.com/auth/devstorage.read_only
+      X-Google-Apiary-Auth-User:
+      - "61688748495"
+      X-Google-Backends:
+      - hilaxcai3:4110,/bns/hi/borg/hi/bns/blobstore2/bitpusher/7.scotty,acsfoc2:443
+      X-Google-Dos-Service-Trace:
+      - main:apps-upload-cloud-storage-unified
+      X-Google-Gfe-Backend-Request-Info:
+      - eid=aLauW_2XFKSjxgO7kKewCA
+      X-Google-Gfe-Request-Trace:
+      - acsfoc2:443,/bns/hi/borg/hi/bns/blobstore2/bitpusher/7.scotty,acsfoc2:443
+      X-Google-Gfe-Response-Code-Details-Trace:
+      - response_code_set_by_backend
+      X-Google-Gfe-Service-Trace:
+      - bitpusher-gcs-apiary
+      X-Google-Netmon-Label:
+      - /bns/hi/borg/hi/bns/blobstore2/bitpusher/7:caf3
+      X-Google-Service:
+      - bitpusher-gcs-apiary
+      X-Google-Session-Info:
+      - CM-zvuflARoCGAY6gAEKEmNsb3VkLXN0b3JhZ2Utcm9zeRIIYmlnc3RvcmUYisjPuJ4WIkg3NjQwODYwNTE4NTAtNnFyNHA2Z3BpNmhuNTA2cHQ4ZWp1cTgzZGkzNDFodXIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20wkJYCMOArMJGWAjDhKzDiK0oPOg0xL1IyYlZDRmpHNUh-
+      X-Google-Shellfish-Status:
+      - CA0gBEBG
+      X-Guploader-Customer:
+      - apiary_cloudstorage_metadata
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2Uq8oWgoLYhlrEa8DUKbUjOkQWPsP7r7FDHojMwRMKuumZ9ks7aTUWCnwe42r-7pHhXKbSqYgFfsKR-SfUuyyiuaSoTh4Q
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - google-api-go-client/0.5
+      X-Goog-Api-Client:
+      - gl-go/1.11.0-rc2 gccl/20180226
+    url: https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?alt=json
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "0"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 28 Sep 2018 23:16:56 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Google-Apiary-Auth-Expires:
+      - "1538176915000"
+      X-Google-Apiary-Auth-Scopes:
+      - https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/devstorage.read_write https://www.googleapis.com/auth/devstorage.write_only
+      X-Google-Apiary-Auth-User:
+      - "61688748495"
+      X-Google-Backends:
+      - hhlaxbai4:4499,/bns/hi/borg/hi/bns/blobstore2/bitpusher/24.scotty,acsfoc2:443
+      X-Google-Dos-Service-Trace:
+      - main:apps-upload-cloud-storage-unified
+      X-Google-Gfe-Backend-Request-Info:
+      - eid=aLauW5CCGOSoxgOJjYagBw
+      X-Google-Gfe-Request-Trace:
+      - acsfoc2:443,/bns/hi/borg/hi/bns/blobstore2/bitpusher/24.scotty,acsfoc2:443
+      X-Google-Gfe-Response-Code-Details-Trace:
+      - response_code_set_by_backend
+      X-Google-Gfe-Service-Trace:
+      - bitpusher-gcs-apiary
+      X-Google-Netmon-Label:
+      - /bns/hi/borg/hi/bns/blobstore2/bitpusher/24:caf3
+      X-Google-Service:
+      - bitpusher-gcs-apiary
+      X-Google-Session-Info:
+      - CM-zvuflARoCGAY6fAoSY2xvdWQtc3RvcmFnZS1yb3N5EghiaWdzdG9yZRiKyM-4nhYiSDc2NDA4NjA1MTg1MC02cXI0cDZncGk2aG41MDZwdDhlanVxODNkaTM0MWh1ci5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTCQlgIw4Csw4Ssw4ytKDzoNMS9SMmJWQ0ZqRzVIfg
+      X-Google-Shellfish-Status:
+      - CA0gBEBG
+      X-Guploader-Customer:
+      - apiary_cloudstorage_metadata
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2UqIGeAieFLNYXp6rkCtx7xzEP1ud-8K-OCCUNW-fSFxnHT3j9QfggeNePP-dAkAQHdEFmFg10k8lfxJCTbr2irT0Csn_A
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/blob/s3blob/testdata/TestConformance/TestMetadata/empty.yaml
+++ b/blob/s3blob/testdata/TestConformance/TestMetadata/empty.yaml
@@ -1,0 +1,137 @@
+---
+version: 1
+interactions:
+- request:
+    body: hello
+    form: {}
+    headers:
+      Content-Length:
+      - "5"
+      Content-Md5:
+      - XUFAKrxLKna5cZ2REBfFkg==
+      Content-Type:
+      - text/plain; charset=utf-8
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64) S3Manager
+      X-Amz-Content-Sha256:
+      - 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+      X-Amz-Date:
+      - 20180928T231728Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: PUT
+  response:
+    body: ""
+    headers:
+      Content-Length:
+      - "0"
+      Date:
+      - Fri, 28 Sep 2018 23:17:30 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - vmcmHcONdjml+mrV43Au4hu2vEBbRT3e1hb0ej+FJ5MxTwuV3ItopmF16xs/QSbZ1aYJXlsSOZo=
+      X-Amz-Request-Id:
+      - 15907D549C26B541
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20180928T231729Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: HEAD
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - "5"
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 28 Sep 2018 23:17:30 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Last-Modified:
+      - Fri, 28 Sep 2018 23:17:30 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - 1uWTj5SB3EgAZJ9kDRdS+sAGhULiJfQoHA4c4/kmfyIrKqE02gzSxoedQYmSFXcLg4X/UyCNDnc=
+      X-Amz-Request-Id:
+      - CD9456B7B2AB7307
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20180928T231729Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: HEAD
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - "5"
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 28 Sep 2018 23:17:30 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Last-Modified:
+      - Fri, 28 Sep 2018 23:17:30 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - kdY+PFY1c2HwsT+07/gZj3mGM0Lxu29T39EIuJZ6ph9ZFj21hKmsqIEy1zqpM5GwdTRdTGBMOI4=
+      X-Amz-Request-Id:
+      - A6A655959CE6E367
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20180928T231729Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Fri, 28 Sep 2018 23:17:30 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - v9nl5el64Yh7raR0Gd+xL6qmdoQR+yfccIR/Kk/fXoNjVC2pqjyUTbng20zqnZOFo2dfDv+bs2w=
+      X-Amz-Request-Id:
+      - A366D0F98E6FA8E8
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/blob/s3blob/testdata/TestConformance/TestMetadata/valid_metadata.yaml
+++ b/blob/s3blob/testdata/TestConformance/TestMetadata/valid_metadata.yaml
@@ -1,0 +1,155 @@
+---
+version: 1
+interactions:
+- request:
+    body: hello
+    form: {}
+    headers:
+      Content-Length:
+      - "5"
+      Content-Md5:
+      - XUFAKrxLKna5cZ2REBfFkg==
+      Content-Type:
+      - text/plain; charset=utf-8
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64) S3Manager
+      X-Amz-Content-Sha256:
+      - 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+      X-Amz-Date:
+      - 20180928T231729Z
+      X-Amz-Meta-Key-A:
+      - value-a
+      X-Amz-Meta-Key-B:
+      - value-b
+      X-Amz-Meta-Key-C:
+      - vAlUe-c
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: PUT
+  response:
+    body: ""
+    headers:
+      Content-Length:
+      - "0"
+      Date:
+      - Fri, 28 Sep 2018 23:17:30 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - 0QtWxECCgSiLqqc9Lw4gxJAM4onU/47MKhJTCZRRufpnW8qVM9OKO7vWkcMnW4ZXWNaPtxon/gM=
+      X-Amz-Request-Id:
+      - 48CCA939C67B455B
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20180928T231729Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: HEAD
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - "5"
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 28 Sep 2018 23:17:30 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Last-Modified:
+      - Fri, 28 Sep 2018 23:17:30 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - QNWHz02mEbmx35txm91+SRi2n5IB+8FIRA1eVrCd80RQcYOJJl0vocaFCwLWg8v++1FqYb3geng=
+      X-Amz-Meta-Key-A:
+      - value-a
+      X-Amz-Meta-Key-B:
+      - value-b
+      X-Amz-Meta-Key-C:
+      - vAlUe-c
+      X-Amz-Request-Id:
+      - 9F30A1833AA7A01B
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20180928T231729Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: HEAD
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - "5"
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 28 Sep 2018 23:17:31 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Last-Modified:
+      - Fri, 28 Sep 2018 23:17:30 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - txV5jWSG/urYN2e4tnhopudnaPlVTNOHTskYhd0+ntqwwDGzPmf2yWNkTxJzsUxpJKXHItsf2Ik=
+      X-Amz-Meta-Key-A:
+      - value-a
+      X-Amz-Meta-Key-B:
+      - value-b
+      X-Amz-Meta-Key-C:
+      - vAlUe-c
+      X-Amz-Request-Id:
+      - 3B408F410ED17758
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20180928T231730Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Fri, 28 Sep 2018 23:17:31 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - Oow/yNiSOn49ZjTstp40zLsX/YHpQPzu9odpI1jg7bm3du0jCjr1DfmKz5+lLbTitb6al/yjbZQ=
+      X-Amz-Request-Id:
+      - C0686F7D17A009A3
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/blob/s3blob/testdata/TestConformance/TestMetadata/valid_metadata_with_empty_body.yaml
+++ b/blob/s3blob/testdata/TestConformance/TestMetadata/valid_metadata_with_empty_body.yaml
@@ -1,0 +1,143 @@
+---
+version: 1
+interactions:
+- request:
+    body: hello
+    form: {}
+    headers:
+      Content-Length:
+      - "5"
+      Content-Md5:
+      - XUFAKrxLKna5cZ2REBfFkg==
+      Content-Type:
+      - text/plain; charset=utf-8
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64) S3Manager
+      X-Amz-Content-Sha256:
+      - 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+      X-Amz-Date:
+      - 20180928T231730Z
+      X-Amz-Meta-Foo:
+      - bar
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: PUT
+  response:
+    body: ""
+    headers:
+      Content-Length:
+      - "0"
+      Date:
+      - Fri, 28 Sep 2018 23:17:31 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - guUo/Z3YhgZOsiFpaKgjJMbAVcaNTKWJpVDYp+fKAuJ1rdGq/5l/6hfXU4KQKomrGWiEvuDfAlU=
+      X-Amz-Request-Id:
+      - 327F8E9BB8C970D6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20180928T231730Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: HEAD
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - "5"
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 28 Sep 2018 23:17:31 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Last-Modified:
+      - Fri, 28 Sep 2018 23:17:31 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - iadXHeMUcT/q2xOpzwDaMVlxfCVm/UMbTQ1v4cT7c/BpI0r11AIKxLlm8J1TX2FayXYSwfhy48s=
+      X-Amz-Meta-Foo:
+      - bar
+      X-Amz-Request-Id:
+      - 54F793955DC4DD9D
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20180928T231730Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: HEAD
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - "5"
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 28 Sep 2018 23:17:31 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Last-Modified:
+      - Fri, 28 Sep 2018 23:17:31 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - CoBaidTqfVYviuiElbr92WU/m1RK6HWpUyhX98y/Nmm3Pe2S6o6hUwqI8HBerv8td9xB+ynVH9U=
+      X-Amz-Meta-Foo:
+      - bar
+      X-Amz-Request-Id:
+      - 5BC5D80D8D781C13
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20180928T231730Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Fri, 28 Sep 2018 23:17:31 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - vHuaRbGOiDASy8b2DX3cCSk2bVq/SsovZactbo/jBxSrbNlWIt7YqGtG19vPvvLXc3+5sEaeNBo=
+      X-Amz-Request-Id:
+      - F4EA24217B0F0CBB
+    status: 204 No Content
+    code: 204
+    duration: ""


### PR DESCRIPTION
Fixes #324.

The most controversial thing in this PR is force-lowercasing the Metadata keys during reading and writing. Provider behavior is inconsistent on this. I think both S3 and GCS store keys case-sensitive, but GCS claims it is case-insensitive 

- GCP claims to be case-insensitive (search for "Field names are case-insensitive" [here](https://cloud.google.com/storage/docs/gsutil/addlhelp/WorkingWithObjectMetadata)). However, the backend is actually case-sensitive. The JSON and XML-based APIs handle casing, but the HTTP one does not. Further discussion [here](https://github.com/GoogleCloudPlatform/google-cloud-go/issues/1132).

- S3 claims to store them in lowercase (search for "user-defined metadata keys in lowercase" [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-metadata)). However, the HTTP API actually returns them capitalized due to Go's header canonicalization; see [this long-standing issue](https://github.com/aws/aws-sdk-go/issues/445) complaining about it. It suggests parsing the headers yourself, but the original case can't be recovered that way so I'm not sure how that helps.

So, I think the best way to make the behavior consistent across providers and simple for users is to force-lowercase the metadata keys during reading and writing. There might still be unexpected behavior if:
1. The provider stores keys case-sensitive
2. The user is writing metadata using some mechanism other than Go Cloud
In this scenario, multiple case-sensitive keys will be collapsed into a single key when reading using Go Cloud. Note that this would happen anyway for S3, at least when using the HTTP client.
