### PR TITLE
runtimevar/etcdvar: avoid double reads of variables when they change

### DIFF
--- a/runtimevar/etcdvar/etcdvar_test.go
+++ b/runtimevar/etcdvar/etcdvar_test.go
@@ -57,8 +57,8 @@ func newHarness(t *testing.T) (drivertest.Harness, error) {
 	return &harness{client: cli}, nil
 }
 
-func (h *harness) MakeVar(ctx context.Context, name string, decoder *runtimevar.Decoder, wait time.Duration) (*runtimevar.Variable, error) {
-	return New(name, h.client, decoder, &WatchOptions{WaitTime: wait})
+func (h *harness) MakeVar(ctx context.Context, name string, decoder *runtimevar.Decoder, _ time.Duration) (*runtimevar.Variable, error) {
+	return New(name, h.client, decoder)
 }
 
 func (h *harness) CreateVariable(ctx context.Context, name string, val []byte) error {


### PR DESCRIPTION
Fixes #440.

Also avoids any repeated overhead of creating the etc client.Watch.

This code overlaps somewhat with `filevar`, but it's different enough that I don't think it's a good idea to try to refactor the common bits out.