### PR TITLE
blob: fix setting of metadata when ContentType is specified

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -260,15 +260,6 @@ func (b *Bucket) NewWriter(ctx context.Context, key string, opt *WriterOptions) 
 		dopt = &driver.WriterOptions{
 			BufferSize: opt.BufferSize,
 		}
-		if opt.ContentType != "" {
-			t, p, err := mime.ParseMediaType(opt.ContentType)
-			if err != nil {
-				return nil, err
-			}
-			ct := mime.FormatMediaType(t, p)
-			w, err = b.b.NewTypedWriter(ctx, key, ct, dopt)
-			return &Writer{w: w}, err
-		}
 		if len(opt.Metadata) > 0 {
 			// Providers are inconsistent, but at least some treat keys
 			// as case-insensitive. To make the behavior consistent, we
@@ -285,6 +276,15 @@ func (b *Bucket) NewWriter(ctx context.Context, key string, opt *WriterOptions) 
 				md[lowerK] = v
 			}
 			dopt.Metadata = md
+		}
+		if opt.ContentType != "" {
+			t, p, err := mime.ParseMediaType(opt.ContentType)
+			if err != nil {
+				return nil, err
+			}
+			ct := mime.FormatMediaType(t, p)
+			w, err = b.b.NewTypedWriter(ctx, key, ct, dopt)
+			return &Writer{w: w}, err
 		}
 	}
 	return &Writer{

--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -474,11 +474,12 @@ func testMetadata(t *testing.T, newHarness HarnessMaker) {
 	hello := []byte("hello")
 
 	tests := []struct {
-		name     string
-		metadata map[string]string
-		content  []byte
-		want     map[string]string
-		wantErr  bool
+		name        string
+		metadata    map[string]string
+		content     []byte
+		contentType string
+		want        map[string]string
+		wantErr     bool
 	}{
 		{
 			name:     "empty",
@@ -518,6 +519,13 @@ func testMetadata(t *testing.T, newHarness HarnessMaker) {
 			metadata: map[string]string{"foo": "bar"},
 			want:     map[string]string{"foo": "bar"},
 		},
+		{
+			name:        "valid metadata with content type",
+			content:     hello,
+			contentType: "text/plain",
+			metadata:    map[string]string{"foo": "bar"},
+			want:        map[string]string{"foo": "bar"},
+		},
 	}
 
 	ctx := context.Background()
@@ -534,7 +542,8 @@ func testMetadata(t *testing.T, newHarness HarnessMaker) {
 				t.Fatal(err)
 			}
 			opts := &blob.WriterOptions{
-				Metadata: tc.metadata,
+				Metadata:    tc.metadata,
+				ContentType: tc.contentType,
 			}
 			err = b.WriteAll(ctx, key, hello, opts)
 			if (err != nil) != tc.wantErr {

--- a/blob/gcsblob/testdata/TestConformance/TestMetadata/valid_metadata_with_content_type.yaml
+++ b/blob/gcsblob/testdata/TestConformance/TestMetadata/valid_metadata_with_content_type.yaml
@@ -1,0 +1,392 @@
+---
+version: 1
+interactions:
+- request:
+    body: "--b1d6887a62ba5f0981de27e7d4fdcea9a363dd626e2e6bedf669cea29c37\r\nContent-Type:
+      application/json\r\n\r\n{\"bucket\":\"go-cloud-blob-test-bucket\",\"contentType\":\"text/plain\",\"metadata\":{\"foo\":\"bar\"},\"name\":\"blob-for-metadata\"}\n\r\n--b1d6887a62ba5f0981de27e7d4fdcea9a363dd626e2e6bedf669cea29c37\r\nContent-Type:
+      text/plain\r\n\r\nhello\r\n--b1d6887a62ba5f0981de27e7d4fdcea9a363dd626e2e6bedf669cea29c37--\r\n"
+    form: {}
+    headers:
+      Content-Type:
+      - multipart/related; boundary=b1d6887a62ba5f0981de27e7d4fdcea9a363dd626e2e6bedf669cea29c37
+      User-Agent:
+      - google-api-go-client/0.5
+      X-Goog-Api-Client:
+      - gl-go/1.11.0-rc2 gccl/20180226
+    url: https://www.googleapis.com/upload/storage/v1/b/go-cloud-blob-test-bucket/o?alt=json&projection=full&uploadType=multipart
+    method: POST
+  response:
+    body: |
+      {
+       "kind": "storage#object",
+       "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538695874046526",
+       "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata",
+       "name": "blob-for-metadata",
+       "bucket": "go-cloud-blob-test-bucket",
+       "generation": "1538695874046526",
+       "metageneration": "1",
+       "contentType": "text/plain",
+       "timeCreated": "2018-10-04T23:31:14.046Z",
+       "updated": "2018-10-04T23:31:14.046Z",
+       "storageClass": "REGIONAL",
+       "timeStorageClassUpdated": "2018-10-04T23:31:14.046Z",
+       "size": "5",
+       "md5Hash": "XUFAKrxLKna5cZ2REBfFkg==",
+       "mediaLink": "https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?generation=1538695874046526&alt=media",
+       "metadata": {
+        "foo": "bar"
+       },
+       "acl": [
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538695874046526/project-owners-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-owners-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538695874046526",
+         "entity": "project-owners-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "owners"
+         },
+         "etag": "CL7U9ef47d0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538695874046526/project-editors-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-editors-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538695874046526",
+         "entity": "project-editors-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "editors"
+         },
+         "etag": "CL7U9ef47d0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538695874046526/project-viewers-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-viewers-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538695874046526",
+         "entity": "project-viewers-892942638129",
+         "role": "READER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "viewers"
+         },
+         "etag": "CL7U9ef47d0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538695874046526/user-rvangent@google.com",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/user-rvangent@google.com",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538695874046526",
+         "entity": "user-rvangent@google.com",
+         "role": "OWNER",
+         "email": "rvangent@google.com",
+         "etag": "CL7U9ef47d0CEAE="
+        }
+       ],
+       "owner": {
+        "entity": "user-rvangent@google.com"
+       },
+       "crc32c": "mnG7TA==",
+       "etag": "CL7U9ef47d0CEAE="
+      }
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "3156"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 04 Oct 2018 23:31:14 GMT
+      Etag:
+      - CL7U9ef47d0CEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Google-Apiary-Auth-Expires:
+      - "1538696173000"
+      X-Google-Apiary-Auth-Scopes:
+      - https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/devstorage.read_write https://www.googleapis.com/auth/devstorage.write_only
+      X-Google-Apiary-Auth-User:
+      - "61688748495"
+      X-Google-Backends:
+      - lmbg26:4055,/bns/lu/borg/lu/bns/blobstore2/bitpusher/9.scotty,lubdo2:443
+      X-Google-Dos-Service-Trace:
+      - main:apps-upload-cloud-storage-unified
+      X-Google-Gfe-Backend-Request-Info:
+      - eid=waK2W8CyLMyEqwGUuq2oCw
+      X-Google-Gfe-Cloud-Project-Number:
+      - "892942638129"
+      X-Google-Gfe-Request-Trace:
+      - lubdo2:443,/bns/lu/borg/lu/bns/blobstore2/bitpusher/9.scotty,lubdo2:443
+      X-Google-Gfe-Response-Code-Details-Trace:
+      - response_code_set_by_backend
+      X-Google-Gfe-Service-Trace:
+      - bitpusher-gcs-apiary
+      X-Google-Netmon-Label:
+      - /bns/lu/borg/lu/bns/blobstore2/bitpusher/9:caf3
+      X-Google-Service:
+      - bitpusher-gcs-apiary
+      X-Google-Session-Info:
+      - CM-zvuflARoCGAY6fAoSY2xvdWQtc3RvcmFnZS1yb3N5EghiaWdzdG9yZRiKyM-4nhYiSDc2NDA4NjA1MTg1MC02cXI0cDZncGk2aG41MDZwdDhlanVxODNkaTM0MWh1ci5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTCQlgIw4Csw4Ssw4ytKDzoNMS9SMmJWQ0ZqRzVIfg
+      X-Google-Shellfish-Status:
+      - CA0gBEBG
+      X-Guploader-Customer:
+      - apiary_cloudstorage_single_post_uploads
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2UoTNJh8c7kioxO-NmUSL0k9mjp8h1-8GL-y84AQhqNWQxXJwXNLjxee6hDcY3sp1QaC5eMHlPnyltqmzmTld5c7M-mTYQ
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - google-api-go-client/0.5
+      X-Goog-Api-Client:
+      - gl-go/1.11.0-rc2 gccl/20180226
+    url: https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?alt=json&projection=full
+    method: GET
+  response:
+    body: |
+      {
+       "kind": "storage#object",
+       "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538695874046526",
+       "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata",
+       "name": "blob-for-metadata",
+       "bucket": "go-cloud-blob-test-bucket",
+       "generation": "1538695874046526",
+       "metageneration": "1",
+       "contentType": "text/plain",
+       "timeCreated": "2018-10-04T23:31:14.046Z",
+       "updated": "2018-10-04T23:31:14.046Z",
+       "storageClass": "REGIONAL",
+       "timeStorageClassUpdated": "2018-10-04T23:31:14.046Z",
+       "size": "5",
+       "md5Hash": "XUFAKrxLKna5cZ2REBfFkg==",
+       "mediaLink": "https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?generation=1538695874046526&alt=media",
+       "metadata": {
+        "foo": "bar"
+       },
+       "acl": [
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538695874046526/project-owners-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-owners-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538695874046526",
+         "entity": "project-owners-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "owners"
+         },
+         "etag": "CL7U9ef47d0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538695874046526/project-editors-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-editors-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538695874046526",
+         "entity": "project-editors-892942638129",
+         "role": "OWNER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "editors"
+         },
+         "etag": "CL7U9ef47d0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538695874046526/project-viewers-892942638129",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/project-viewers-892942638129",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538695874046526",
+         "entity": "project-viewers-892942638129",
+         "role": "READER",
+         "projectTeam": {
+          "projectNumber": "892942638129",
+          "team": "viewers"
+         },
+         "etag": "CL7U9ef47d0CEAE="
+        },
+        {
+         "kind": "storage#objectAccessControl",
+         "id": "go-cloud-blob-test-bucket/blob-for-metadata/1538695874046526/user-rvangent@google.com",
+         "selfLink": "https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata/acl/user-rvangent@google.com",
+         "bucket": "go-cloud-blob-test-bucket",
+         "object": "blob-for-metadata",
+         "generation": "1538695874046526",
+         "entity": "user-rvangent@google.com",
+         "role": "OWNER",
+         "email": "rvangent@google.com",
+         "etag": "CL7U9ef47d0CEAE="
+        }
+       ],
+       "owner": {
+        "entity": "user-rvangent@google.com"
+       },
+       "crc32c": "mnG7TA==",
+       "etag": "CL7U9ef47d0CEAE="
+      }
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "3156"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 04 Oct 2018 23:31:14 GMT
+      Etag:
+      - CL7U9ef47d0CEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Google-Apiary-Auth-Expires:
+      - "1538696173000"
+      X-Google-Apiary-Auth-Scopes:
+      - https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/cloud-platform.read-only https://www.googleapis.com/auth/devstorage.read_write
+        https://www.googleapis.com/auth/devstorage.read_only
+      X-Google-Apiary-Auth-User:
+      - "61688748495"
+      X-Google-Backends:
+      - lgq188:4117,/bns/lu/borg/lu/bns/blobstore2/bitpusher/12.scotty,lubdo2:443
+      X-Google-Dos-Service-Trace:
+      - main:apps-upload-cloud-storage-unified
+      X-Google-Gfe-Backend-Request-Info:
+      - eid=wqK2W9_vFMuYqwGYuo3gBg
+      X-Google-Gfe-Request-Trace:
+      - lubdo2:443,/bns/lu/borg/lu/bns/blobstore2/bitpusher/12.scotty,lubdo2:443
+      X-Google-Gfe-Response-Code-Details-Trace:
+      - response_code_set_by_backend
+      X-Google-Gfe-Service-Trace:
+      - bitpusher-gcs-apiary
+      X-Google-Netmon-Label:
+      - /bns/lu/borg/lu/bns/blobstore2/bitpusher/12:caf3
+      X-Google-Service:
+      - bitpusher-gcs-apiary
+      X-Google-Session-Info:
+      - CM-zvuflARoCGAY6gAEKEmNsb3VkLXN0b3JhZ2Utcm9zeRIIYmlnc3RvcmUYisjPuJ4WIkg3NjQwODYwNTE4NTAtNnFyNHA2Z3BpNmhuNTA2cHQ4ZWp1cTgzZGkzNDFodXIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20wkJYCMOArMJGWAjDhKzDiK0oPOg0xL1IyYlZDRmpHNUh-
+      X-Google-Shellfish-Status:
+      - CA0gBEBG
+      X-Guploader-Customer:
+      - apiary_cloudstorage_metadata
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2UrguqUkb18JDGHd7K06605xvxZ8qXQmlCUCNyacL9PVqzNov-702J_952sMwiHd71hnL2C1445vV1LfIHneip0Ih86-nw
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - google-api-go-client/0.5
+      X-Goog-Api-Client:
+      - gl-go/1.11.0-rc2 gccl/20180226
+    url: https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-metadata?alt=json
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "0"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Oct 2018 23:31:15 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Google-Apiary-Auth-Expires:
+      - "1538696173000"
+      X-Google-Apiary-Auth-Scopes:
+      - https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/devstorage.read_write https://www.googleapis.com/auth/devstorage.write_only
+      X-Google-Apiary-Auth-User:
+      - "61688748495"
+      X-Google-Backends:
+      - lmnf1:4052,/bns/lu/borg/lu/bns/blobstore2/bitpusher/13.scotty,lubdo2:443
+      X-Google-Dos-Service-Trace:
+      - main:apps-upload-cloud-storage-unified
+      X-Google-Gfe-Backend-Request-Info:
+      - eid=wqK2W8inNNCbqwHR9oioAw
+      X-Google-Gfe-Request-Trace:
+      - lubdo2:443,/bns/lu/borg/lu/bns/blobstore2/bitpusher/13.scotty,lubdo2:443
+      X-Google-Gfe-Response-Code-Details-Trace:
+      - response_code_set_by_backend
+      X-Google-Gfe-Service-Trace:
+      - bitpusher-gcs-apiary
+      X-Google-Netmon-Label:
+      - /bns/lu/borg/lu/bns/blobstore2/bitpusher/13:caf3
+      X-Google-Service:
+      - bitpusher-gcs-apiary
+      X-Google-Session-Info:
+      - CM-zvuflARoCGAY6fAoSY2xvdWQtc3RvcmFnZS1yb3N5EghiaWdzdG9yZRiKyM-4nhYiSDc2NDA4NjA1MTg1MC02cXI0cDZncGk2aG41MDZwdDhlanVxODNkaTM0MWh1ci5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTCQlgIw4Csw4Ssw4ytKDzoNMS9SMmJWQ0ZqRzVIfg
+      X-Google-Shellfish-Status:
+      - CA0gBEBG
+      X-Guploader-Customer:
+      - apiary_cloudstorage_metadata
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2UpLbiEBCPXHfaMYelHhOOX8fgeWg91tYsEavUX_UX6p9wq07FBv2DYPuMfVPHB-FeANO_iM0QxU76Pf2IQ09nRRyku5SQ
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/blob/s3blob/testdata/TestConformance/TestMetadata/valid_metadata_with_content_type.yaml
+++ b/blob/s3blob/testdata/TestConformance/TestMetadata/valid_metadata_with_content_type.yaml
@@ -1,0 +1,143 @@
+---
+version: 1
+interactions:
+- request:
+    body: hello
+    form: {}
+    headers:
+      Content-Length:
+      - "5"
+      Content-Md5:
+      - XUFAKrxLKna5cZ2REBfFkg==
+      Content-Type:
+      - text/plain
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64) S3Manager
+      X-Amz-Content-Sha256:
+      - 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+      X-Amz-Date:
+      - 20181004T233105Z
+      X-Amz-Meta-Foo:
+      - bar
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: PUT
+  response:
+    body: ""
+    headers:
+      Content-Length:
+      - "0"
+      Date:
+      - Thu, 04 Oct 2018 23:31:07 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - KrUA9EOkrcQgt6+NOujw71wpKioTNMPh58TygrTD/iFUX6+CJ3HjN5myafuNLzZimHjWjIYtYOY=
+      X-Amz-Request-Id:
+      - 8AC0C237E0DFE41D
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20181004T233106Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: HEAD
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - "5"
+      Content-Type:
+      - text/plain
+      Date:
+      - Thu, 04 Oct 2018 23:31:07 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Last-Modified:
+      - Thu, 04 Oct 2018 23:31:07 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - sNVgG09y2jiUpfMAw3xgL6lGJgj9/v2VYQCUQ0YpyxqIn7jd+71S5C/aJGj9dETKZPS4/O/K+Bc=
+      X-Amz-Meta-Foo:
+      - bar
+      X-Amz-Request-Id:
+      - CB42B521EF2FE35B
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20181004T233106Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: HEAD
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - "5"
+      Content-Type:
+      - text/plain
+      Date:
+      - Thu, 04 Oct 2018 23:31:07 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Last-Modified:
+      - Thu, 04 Oct 2018 23:31:07 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - Fa/zUK442YujYTMq1Wdo0ZDwsxmhwlBA5fWFuJudPYCG3STVY6rYjJDKP2JrRtRvbz1iJREGy4s=
+      X-Amz-Meta-Foo:
+      - bar
+      X-Amz-Request-Id:
+      - 10690B9DBC8E3013
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.13.20 (go1.11rc2; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20181004T233106Z
+    url: https://go-cloud-bucket.s3.us-east-2.amazonaws.com/blob-for-metadata
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 23:31:07 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - 9opPyxK0bVCtVzLb8MovnfHSNvVww39cV2OKLGv10MhAhcrUltgRFk9hJ1G5gWTokc2X+Uxw26c=
+      X-Amz-Request-Id:
+      - 1C21D2AB6DC39468
+    status: 204 No Content
+    code: 204
+    duration: ""


### PR DESCRIPTION
I missed that if ContentType is specified, `blob.NewWriter` was returning early; the code to set the metadata field in `driver.WriterOptions` was after the early return, so it wasn't be set correctly. This just moves the metadata code block earlier, and adds a testcase. The testcase failed before the fix.