### PR TITLE
wire: Fix sample code in README of wire

### DIFF
--- a/wire/README.md
+++ b/wire/README.md
@@ -339,7 +339,7 @@ For interface values, use `InterfaceValue`:
 ```go
 func injectReader() io.Reader {
     wire.Build(wire.InterfaceValue(new(io.Reader), os.Stdin))
-    return Foo{}
+    return nil
 }
 ```
 


### PR DESCRIPTION
I read README to study wire command. and I had a feeling of strangeness in this sample.
`injectReader` returns `io.Reader`,  and `wire.Build` argument indicates `io.Reader`. Therefore, I think return value does not need `Foo{}`. 
```go
func injectReader() io.Reader {
    wire.Build(wire.InterfaceValue(new(io.Reader), os.Stdin))
    return Foo{}
}
```

I would appreciate it if you could check this PR.