### PR TITLE
health: factor out code to write HTTP headers

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -43,16 +43,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	writeHealthy(w)
 }
 
-func writeHeaders(status string, w http.ResponseWriter) {
-	w.Header().Set("Content-Length", strconv.Itoa(len(status)))
+func writeHeaders(statusLen int, w http.ResponseWriter) {
+	w.Header().Set("Content-Length", strconv.Itoa(statusLen))
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 }
 
 func writeUnhealthy(w http.ResponseWriter) {
-	const status = "unhealthy"
+	const (
+		status    = "unhealthy"
+		statusLen = 9
+	)
 
-	writeHeaders(status, w)
+	writeHeaders(statusLen, w)
 	w.WriteHeader(http.StatusInternalServerError)
 	io.WriteString(w, status)
 }
@@ -64,9 +67,12 @@ func HandleLive(w http.ResponseWriter, _ *http.Request) {
 }
 
 func writeHealthy(w http.ResponseWriter) {
-	const status = "ok"
+	const (
+		status    = "ok"
+		statusLen = 2
+	)
 
-	writeHeaders(status, w)
+	writeHeaders(statusLen, w)
 	w.WriteHeader(http.StatusOK)
 	io.WriteString(w, status)
 }

--- a/health/health.go
+++ b/health/health.go
@@ -18,6 +18,7 @@ package health
 import (
 	"io"
 	"net/http"
+	"strconv"
 )
 
 // Handler is an HTTP handler that reports on the success of an
@@ -42,12 +43,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	writeHealthy(w)
 }
 
-func writeUnhealthy(w http.ResponseWriter) {
-	w.Header().Set("Content-Length", "9")
+func writeHeaders(status string, w http.ResponseWriter) {
+	w.Header().Set("Content-Length", strconv.Itoa(len(status)))
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
+}
+
+func writeUnhealthy(w http.ResponseWriter) {
+	const status = "unhealthy"
+
+	writeHeaders(status, w)
 	w.WriteHeader(http.StatusInternalServerError)
-	io.WriteString(w, "unhealthy")
+	io.WriteString(w, status)
 }
 
 // HandleLive is an http.HandleFunc that handles liveness checks by
@@ -57,11 +64,11 @@ func HandleLive(w http.ResponseWriter, _ *http.Request) {
 }
 
 func writeHealthy(w http.ResponseWriter) {
-	w.Header().Set("Content-Length", "2")
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
+	const status = "ok"
+
+	writeHeaders(status, w)
 	w.WriteHeader(http.StatusOK)
-	io.WriteString(w, "ok")
+	io.WriteString(w, status)
 }
 
 // Checker wraps the CheckHealth method.

--- a/health/health.go
+++ b/health/health.go
@@ -18,7 +18,6 @@ package health
 import (
 	"io"
 	"net/http"
-	"strconv"
 )
 
 // Handler is an HTTP handler that reports on the success of an
@@ -43,8 +42,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	writeHealthy(w)
 }
 
-func writeHeaders(statusLen int, w http.ResponseWriter) {
-	w.Header().Set("Content-Length", strconv.Itoa(statusLen))
+func writeHeaders(statusLen string, w http.ResponseWriter) {
+	w.Header().Set("Content-Length", statusLen)
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 }
@@ -52,7 +51,7 @@ func writeHeaders(statusLen int, w http.ResponseWriter) {
 func writeUnhealthy(w http.ResponseWriter) {
 	const (
 		status    = "unhealthy"
-		statusLen = 9
+		statusLen = "9"
 	)
 
 	writeHeaders(statusLen, w)
@@ -69,7 +68,7 @@ func HandleLive(w http.ResponseWriter, _ *http.Request) {
 func writeHealthy(w http.ResponseWriter) {
 	const (
 		status    = "ok"
-		statusLen = 2
+		statusLen = "2"
 	)
 
 	writeHeaders(statusLen, w)


### PR DESCRIPTION
This patch adds a small function to write out the HTTP headers in the health check handlers since they're more or less the same.