### PR TITLE
blob/tests: don't fail test if Reader returns n > 0 and io.EOF

### DIFF
--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -19,6 +19,7 @@ package drivertest
 import (
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -172,7 +173,8 @@ func testRead(t *testing.T, newHarness HarnessMaker) {
 			// the expected number of bytes.
 			got := make([]byte, tc.wantReadSize+10)
 			n, err := r.Read(got)
-			if err != nil {
+			// EOF error is optional, see https://golang.org/pkg/io/#Reader.
+			if err != nil && err != io.EOF {
 				t.Errorf("unexpected error during read: %v", err)
 			}
 			if int64(n) != tc.wantReadSize {


### PR DESCRIPTION
Fixes #523 .