### PR TITLE
wire: fix typo in example code

### DIFF
--- a/wire/README.md
+++ b/wire/README.md
@@ -245,7 +245,7 @@ type FooerPlus interface {
   Bar() String
 }
 
-func ProviderFooerPlus() FooerPlus {
+func ProvideFooerPlus() FooerPlus {
   ...
 }
 


### PR DESCRIPTION
I found a small typo ;)