### PR TITLE
blob/tests: modify drivertest harness to use a driver.Bucket, not a *blob.Bucket

### DIFF
--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-cloud/blob"
+	"github.com/google/go-cloud/blob/driver"
 	"github.com/google/go-cloud/blob/drivertest"
 )
 
@@ -47,8 +47,8 @@ func (h *harness) HTTPClient() *http.Client {
 	return nil
 }
 
-func (h *harness) MakeBucket(ctx context.Context) (*blob.Bucket, error) {
-	return NewBucket(h.dir)
+func (h *harness) MakeDriver(ctx context.Context) (driver.Bucket, error) {
+	return &bucket{h.dir}, nil
 }
 
 func (h *harness) Close() {

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -25,10 +25,12 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/google/go-cloud/blob"
+	"github.com/google/go-cloud/blob/driver"
 	"github.com/google/go-cloud/blob/drivertest"
 	"github.com/google/go-cloud/gcp"
 	"github.com/google/go-cloud/internal/testing/setup"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 )
 
 const (
@@ -82,8 +84,12 @@ func (h *harness) HTTPClient() *http.Client {
 	return &http.Client{Transport: h.rt}
 }
 
-func (h *harness) MakeBucket(ctx context.Context) (*blob.Bucket, error) {
-	return OpenBucket(ctx, bucketName, h.client, h.opts)
+func (h *harness) MakeDriver(ctx context.Context) (driver.Bucket, error) {
+	c, err := storage.NewClient(ctx, option.WithHTTPClient(&h.client.Client))
+	if err != nil {
+		return nil, err
+	}
+	return &bucket{name: bucketName, client: c, opts: h.opts}, nil
 }
 
 func (h *harness) Close() {

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/google/go-cloud/blob"
+	"github.com/google/go-cloud/blob/driver"
 	"github.com/google/go-cloud/blob/drivertest"
 	"github.com/google/go-cloud/internal/testing/setup"
 )
@@ -57,8 +58,8 @@ func (h *harness) HTTPClient() *http.Client {
 	return &http.Client{Transport: h.rt}
 }
 
-func (h *harness) MakeBucket(ctx context.Context) (*blob.Bucket, error) {
-	return OpenBucket(ctx, h.session, bucketName)
+func (h *harness) MakeDriver(ctx context.Context) (driver.Bucket, error) {
+	return &bucket{name: bucketName, sess: h.session, client: s3.New(h.session)}, nil
 }
 
 func (h *harness) Close() {


### PR DESCRIPTION
This change just changes the `drivertest.Harness` interface to have a `MakeDriver` instead of `MakeBucket`. All of the tests still use the driver.Interface to immediately create a `*blob.Bucket`, so they are unchanged. In most cases, I think testing using the concrete type is fine; it allows for testing of the concrete type functionality as well, and provides a better end-to-end test. However, this change opens the door for more direct testing of the driver interface as well.