### PR TITLE
wire: use multiline instead of one single line for errors with traces

### DIFF
--- a/wire/internal/wire/analyze.go
+++ b/wire/internal/wire/analyze.go
@@ -141,11 +141,12 @@ dfs:
 				index.Set(curr.t, errAbort)
 				continue
 			}
-			neededBy := []string{types.TypeString(curr.t, nil)}
+			sb := new(strings.Builder)
+			fmt.Fprintf(sb, "no provider found for %s", types.TypeString(curr.t, nil))
 			for f := curr.up; f != nil; f = f.up {
-				neededBy = append(neededBy, fmt.Sprintf("%s in %s", types.TypeString(f.t, nil), set.srcMap.At(f.t).(*providerSetSrc).description(fset, f.t)))
+				fmt.Fprintf(sb, "\nneeded by %s in %s", types.TypeString(f.t, nil), set.srcMap.At(f.t).(*providerSetSrc).description(fset, f.t))
 			}
-			ec.add(fmt.Errorf("no provider found for %s", strings.Join(neededBy, ", needed by ")))
+			ec.add(errors.New(sb.String()))
 			index.Set(curr.t, errAbort)
 			continue
 		case pv.IsProvider():
@@ -445,8 +446,8 @@ func bindingConflictError(fset *token.FileSet, typ types.Type, set *ProviderSet,
 	} else {
 		fmt.Fprintf(sb, set.VarName)
 	}
-	fmt.Fprintf(sb, " has multiple bindings for %s (", types.TypeString(typ, nil))
-	fmt.Fprintf(sb, "current binding: %s", strings.Join(cur.trace(fset, typ), " <- "))
-	fmt.Fprintf(sb, "; previous binding: %s", strings.Join(prev.trace(fset, typ), " <- "))
+	fmt.Fprintf(sb, " has multiple bindings for %s\n", types.TypeString(typ, nil))
+	fmt.Fprintf(sb, "current:\n<- %s\n", strings.Join(cur.trace(fset, typ), "\n<- "))
+	fmt.Fprintf(sb, "previous:\n<- %s", strings.Join(prev.trace(fset, typ), "\n<- "))
 	return notePosition(fset.Position(set.Pos), errors.New(sb.String()))
 }

--- a/wire/internal/wire/testdata/MultipleBindings/want/wire_errs.txt
+++ b/wire/internal/wire/testdata/MultipleBindings/want/wire_errs.txt
@@ -1,11 +1,41 @@
-/wire_gopath/src/example.com/foo/wire.go:x:y: wire.Build has multiple bindings for example.com/foo.Foo (current binding: provider "provideFooAgain" (/wire_gopath/src/example.com/foo/foo.go:x:y); previous binding: provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+/wire_gopath/src/example.com/foo/wire.go:x:y: wire.Build has multiple bindings for example.com/foo.Foo
+current:
+<- provider "provideFooAgain" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+previous:
+<- provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y)
 
-/wire_gopath/src/example.com/foo/wire.go:x:y: wire.Build has multiple bindings for example.com/foo.Foo (current binding: provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y); previous binding: provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y) <- provider set "Set" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+/wire_gopath/src/example.com/foo/wire.go:x:y: wire.Build has multiple bindings for example.com/foo.Foo
+current:
+<- provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+previous:
+<- provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+<- provider set "Set" (/wire_gopath/src/example.com/foo/foo.go:x:y)
 
-/wire_gopath/src/example.com/foo/wire.go:x:y: wire.Build has multiple bindings for example.com/foo.Foo (current binding: provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y); previous binding: provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y) <- provider set "Set" (/wire_gopath/src/example.com/foo/foo.go:x:y) <- provider set "SuperSet" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+/wire_gopath/src/example.com/foo/wire.go:x:y: wire.Build has multiple bindings for example.com/foo.Foo
+current:
+<- provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+previous:
+<- provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+<- provider set "Set" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+<- provider set "SuperSet" (/wire_gopath/src/example.com/foo/foo.go:x:y)
 
-/wire_gopath/src/example.com/foo/foo.go:x:y: SetWithDuplicateBindings has multiple bindings for example.com/foo.Foo (current binding: provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y) <- provider set "Set" (/wire_gopath/src/example.com/foo/foo.go:x:y) <- provider set "SuperSet" (/wire_gopath/src/example.com/foo/foo.go:x:y); previous binding: provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y) <- provider set "Set" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+/wire_gopath/src/example.com/foo/foo.go:x:y: SetWithDuplicateBindings has multiple bindings for example.com/foo.Foo
+current:
+<- provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+<- provider set "Set" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+<- provider set "SuperSet" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+previous:
+<- provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+<- provider set "Set" (/wire_gopath/src/example.com/foo/foo.go:x:y)
 
-/wire_gopath/src/example.com/foo/wire.go:x:y: wire.Build has multiple bindings for example.com/foo.Foo (current binding: wire.Value (/wire_gopath/src/example.com/foo/wire.go:x:y); previous binding: provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+/wire_gopath/src/example.com/foo/wire.go:x:y: wire.Build has multiple bindings for example.com/foo.Foo
+current:
+<- wire.Value (/wire_gopath/src/example.com/foo/wire.go:x:y)
+previous:
+<- provider "provideFoo" (/wire_gopath/src/example.com/foo/foo.go:x:y)
 
-/wire_gopath/src/example.com/foo/wire.go:x:y: wire.Build has multiple bindings for example.com/foo.Bar (current binding: wire.Bind (/wire_gopath/src/example.com/foo/wire.go:x:y); previous binding: provider "provideBar" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+/wire_gopath/src/example.com/foo/wire.go:x:y: wire.Build has multiple bindings for example.com/foo.Bar
+current:
+<- wire.Bind (/wire_gopath/src/example.com/foo/wire.go:x:y)
+previous:
+<- provider "provideBar" (/wire_gopath/src/example.com/foo/foo.go:x:y)

--- a/wire/internal/wire/testdata/MultipleMissingInputs/want/wire_errs.txt
+++ b/wire/internal/wire/testdata/MultipleMissingInputs/want/wire_errs.txt
@@ -1,7 +1,12 @@
 /wire_gopath/src/example.com/foo/wire.go:x:y: inject injectMissingOutputType: no provider found for example.com/foo.Foo, output of injector
 
-/wire_gopath/src/example.com/foo/wire.go:x:y: inject injectMultipleMissingTypes: no provider found for example.com/foo.Foo, needed by example.com/foo.Baz in provider "provideBaz" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+/wire_gopath/src/example.com/foo/wire.go:x:y: inject injectMultipleMissingTypes: no provider found for example.com/foo.Foo
+needed by example.com/foo.Baz in provider "provideBaz" (/wire_gopath/src/example.com/foo/foo.go:x:y)
 
-/wire_gopath/src/example.com/foo/wire.go:x:y: inject injectMultipleMissingTypes: no provider found for example.com/foo.Bar, needed by example.com/foo.Baz in provider "provideBaz" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+/wire_gopath/src/example.com/foo/wire.go:x:y: inject injectMultipleMissingTypes: no provider found for example.com/foo.Bar
+needed by example.com/foo.Baz in provider "provideBaz" (/wire_gopath/src/example.com/foo/foo.go:x:y)
 
-/wire_gopath/src/example.com/foo/wire.go:x:y: inject injectMissingRecursiveType: no provider found for example.com/foo.Foo, needed by example.com/foo.Zip in provider "provideZip" (/wire_gopath/src/example.com/foo/foo.go:x:y), needed by example.com/foo.Zap in provider "provideZap" (/wire_gopath/src/example.com/foo/foo.go:x:y), needed by example.com/foo.Zop in provider "provideZop" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+/wire_gopath/src/example.com/foo/wire.go:x:y: inject injectMissingRecursiveType: no provider found for example.com/foo.Foo
+needed by example.com/foo.Zip in provider "provideZip" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+needed by example.com/foo.Zap in provider "provideZap" (/wire_gopath/src/example.com/foo/foo.go:x:y)
+needed by example.com/foo.Zop in provider "provideZop" (/wire_gopath/src/example.com/foo/foo.go:x:y)


### PR DESCRIPTION
Fixes #570 .