### PR TITLE
blob: remove ListOptions.PageSize

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -171,20 +171,12 @@ func (w *Writer) open(p []byte) (n int, err error) {
 	return w.w.Write(p)
 }
 
-// MaxPageSize is the maximum value for ListOptions.PageSize.
-const MaxPageSize = 1000
-
 // ListOptions sets options for listing objects.
 // TODO(Issue #541): Add Delimiter.
 type ListOptions struct {
 	// Prefix indicates that only objects with a key starting with this prefix
 	// should be returned.
 	Prefix string
-
-	// PageSize sets the maximum number of objects that will be retrieved
-	// at a time from the provider.
-	// Must be >= 0 and <= MaxPageSize; 0 defaults to MaxPageSize.
-	PageSize int
 
 	// BeforeList is a callback that will be called before each call to the
 	// the underlying provider's list functionality.
@@ -306,18 +298,8 @@ func (b *Bucket) List(ctx context.Context, opt *ListOptions) (*ListIterator, err
 	if opt == nil {
 		opt = &ListOptions{}
 	}
-	if opt.PageSize < 0 {
-		return nil, errors.New("ListOptions.PageSize must be >= 0")
-	}
-	if opt.PageSize > MaxPageSize {
-		return nil, fmt.Errorf("ListOptions.PageSize must be < %d", MaxPageSize)
-	}
-	if opt.PageSize == 0 {
-		opt.PageSize = MaxPageSize
-	}
 	dopt := &driver.ListOptions{
 		Prefix:     opt.Prefix,
-		PageSize:   opt.PageSize,
 		BeforeList: opt.BeforeList,
 	}
 	return &ListIterator{b: b, opt: dopt}, nil

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -113,9 +113,11 @@ type ListOptions struct {
 	// Prefix indicates that only results with the given prefix should be
 	// returned.
 	Prefix string
-	// PageSize sets the maximum number of objects that will be returned in
-	// a single call. It is guaranteed to be > 0 and <= blob.MaxPageSize.
+	// PageSize sets the maximum number of objects to be returned.
+	// 0 means no maximum; driver implementations should choose a reasonable
+	// max.
 	PageSize int
+
 	// PageToken may be filled in with the NextPageToken from a previous
 	// ListPaged call.
 	PageToken []byte
@@ -142,8 +144,8 @@ type ListObject struct {
 
 // ListPage represents a page of results return from ListPaged.
 type ListPage struct {
-	// Objects is the slice of objects found. It should have at most
-	// ListOptions.PageSize entries.
+	// Objects is the slice of objects found. If ListOptions.PageSize != 0,
+	// it should have at most ListOptions.PageSize entries.
 	Objects []*ListObject
 	// NextPageToken should be left empty unless there are more objects
 	// to return. The value may be returned as ListOptions.PageToken on a

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -38,6 +38,8 @@ import (
 	"github.com/google/go-cloud/blob/driver"
 )
 
+const defaultPageSize = 1000
+
 type bucket struct {
 	dir string
 }
@@ -111,6 +113,10 @@ func (b *bucket) ListPaged(ctx context.Context, opt *driver.ListOptions) (*drive
 	if err != nil {
 		return nil, err
 	}
+	pageSize := opt.PageSize
+	if pageSize == 0 {
+		pageSize = defaultPageSize
+	}
 	var result driver.ListPage
 	for _, info := range fileinfos {
 		// Skip the self-generated attribute files.
@@ -127,7 +133,7 @@ func (b *bucket) ListPaged(ctx context.Context, opt *driver.ListOptions) (*drive
 		}
 		// If we've got a full page of results, and there are more
 		// to come, set NextPageToken and stop here.
-		if opt.PageSize != 0 && len(result.Objects) == opt.PageSize {
+		if len(result.Objects) == pageSize {
 			result.NextPageToken = []byte(info.Name())
 			break
 		}

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -41,6 +41,8 @@ import (
 	"google.golang.org/api/option"
 )
 
+const defaultPageSize = 1000
+
 // Options sets options for constructing a *blob.Bucket backed by GCS.
 type Options struct {
 	// GoogleAccessID represents the authorizer for SignedURL.
@@ -130,9 +132,12 @@ func (b *bucket) ListPaged(ctx context.Context, opt *driver.ListOptions) (*drive
 			return nil, err
 		}
 	}
+	pageSize := opt.PageSize
+	if pageSize == 0 {
+		pageSize = defaultPageSize
+	}
 	iter := bkt.Objects(ctx, query)
-	pager := iterator.NewPager(iter, opt.PageSize, string(opt.PageToken))
-
+	pager := iterator.NewPager(iter, pageSize, string(opt.PageToken))
 	var objects []*storage.ObjectAttrs
 	nextPageToken, err := pager.NextPage(&objects)
 	if err != nil {

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -42,6 +42,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
+const defaultPageSize = 1000
+
 // OpenBucket returns an S3 Bucket.
 func OpenBucket(ctx context.Context, sess client.ConfigProvider, bucketName string) (*blob.Bucket, error) {
 	if sess == nil {
@@ -163,9 +165,13 @@ type bucket struct {
 
 // ListPaged implements driver.ListPaged.
 func (b *bucket) ListPaged(ctx context.Context, opt *driver.ListOptions) (*driver.ListPage, error) {
+	pageSize := opt.PageSize
+	if pageSize == 0 {
+		pageSize = defaultPageSize
+	}
 	in := &s3.ListObjectsV2Input{
 		Bucket:  aws.String(b.name),
-		MaxKeys: aws.Int64(int64(opt.PageSize)),
+		MaxKeys: aws.Int64(int64(pageSize)),
 	}
 	if len(opt.PageToken) > 0 {
 		in.ContinuationToken = aws.String(string(opt.PageToken))


### PR DESCRIPTION
Given that we don't think there's a major performance cost to retrieving extra blob attributes, and that the concrete type interface is an iterator, there's no need to expose the page size.

This PR removes this option from the concrete type.

The driver interface is still paged, so `PageSize` is still exposed on the driver's `ListOptions`. It is only used in tests. I think it's reasonable to have the driver expose a paged interface still; otherwise, each driver would need to implement an iterator over what is likely a paged/bulk interface to the backend.

Fixes #564.