### PR TITLE
blob: add support for content-md5

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -484,6 +484,10 @@ type WriterOptions struct {
 	// http://mimesniff.spec.whatwg.org/
 	ContentType string
 
+	// Content-MD5 which may be used as a message integrity check (MIC)
+	// https://tools.ietf.org/html/rfc1864
+	ContentMD5 string
+
 	// Metadata are key/value strings to be associated with the blob, or nil.
 	// Keys may not be empty, and are lowercased before being written.
 	// Duplicate case-insensitive keys (e.g., "foo" and "FOO") are an error.

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -389,6 +389,7 @@ func (b *Bucket) NewWriter(ctx context.Context, key string, opt *WriterOptions) 
 	var w driver.Writer
 	if opt != nil {
 		dopt = &driver.WriterOptions{
+			ContentMD5:  opt.ContentMD5,
 			BufferSize:  opt.BufferSize,
 			BeforeWrite: opt.BeforeWrite,
 		}
@@ -486,7 +487,7 @@ type WriterOptions struct {
 
 	// Content-MD5 which may be used as a message integrity check (MIC)
 	// https://tools.ietf.org/html/rfc1864
-	ContentMD5 string
+	ContentMD5 []byte
 
 	// Metadata are key/value strings to be associated with the blob, or nil.
 	// Keys may not be empty, and are lowercased before being written.

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -67,7 +67,7 @@ type WriterOptions struct {
 	BufferSize int
 	// Content-MD5 which may be used as a message integrity check (MIC)
 	// https://tools.ietf.org/html/rfc1864
-	ContentMD5 string
+	ContentMD5 []byte
 	// Metadata holds key/value strings to be associated with the blob.
 	// Keys are guaranteed to be non-empty and lowercased.
 	Metadata map[string]string

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -65,6 +65,9 @@ type WriterOptions struct {
 	// write in a single request, if supported. Larger objects will be split into
 	// multiple requests.
 	BufferSize int
+	// Content-MD5 which may be used as a message integrity check (MIC)
+	// https://tools.ietf.org/html/rfc1864
+	ContentMD5 string
 	// Metadata holds key/value strings to be associated with the blob.
 	// Keys are guaranteed to be non-empty and lowercased.
 	Metadata map[string]string

--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -637,6 +637,7 @@ func testWrite(t *testing.T, newHarness HarnessMaker) {
 			// Write the content.
 			opts := &blob.WriterOptions{
 				ContentType: tc.contentType,
+				ContentMD5:  tc.contentMD5,
 			}
 			w, err := b.NewWriter(ctx, tc.key, opts)
 			if err == nil {

--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -19,6 +19,7 @@ package drivertest
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"errors"
 	"fmt"
 	"io"
@@ -536,12 +537,14 @@ func testWrite(t *testing.T, newHarness HarnessMaker) {
 	smallText := loadTestData(t, "test-small.txt")
 	mediumHTML := loadTestData(t, "test-medium.html")
 	largeJpg := loadTestData(t, "test-large.jpg")
-
+	content := []byte("hello world")
+	contentMD5 := md5.Sum(content)
 	tests := []struct {
 		name            string
 		key             string
 		content         []byte
 		contentType     string
+		contentMD5      []byte
 		firstChunk      int
 		wantContentType string
 		wantErr         bool
@@ -572,6 +575,19 @@ func testWrite(t *testing.T, newHarness HarnessMaker) {
 			content:         mediumHTML,
 			contentType:     "application/json",
 			wantContentType: "application/json",
+		},
+		{
+			name:       "Content md5 match",
+			key:        key,
+			content:    content,
+			contentMD5: contentMD5[:],
+		},
+		{
+			name:       "Content md5 did not match",
+			key:        key,
+			content:    []byte("hello worl"),
+			contentMD5: contentMD5[:],
+			wantErr:    true,
 		},
 		{
 			name:            "a small text file",

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -234,6 +234,9 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType str
 	if opts != nil {
 		w.ChunkSize = bufferSize(opts.BufferSize)
 		w.Metadata = opts.Metadata
+		if opts.ContentMD5 != nil {
+			w.MD5 = opts.ContentMD5
+		}
 	}
 	if opts != nil && opts.BeforeWrite != nil {
 		asFunc := func(i interface{}) bool {

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -25,6 +25,7 @@ package s3blob
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -334,6 +335,9 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType str
 		ContentType: aws.String(contentType),
 		Key:         aws.String(key),
 		Metadata:    metadata,
+	}
+	if opts != nil && opts.ContentMD5 != nil {
+		req.ContentMD5 = aws.String(base64.StdEncoding.EncodeToString(opts.ContentMD5))
 	}
 	if opts != nil && opts.BeforeWrite != nil {
 		asFunc := func(i interface{}) bool {


### PR DESCRIPTION
see #569
Because blob import "github.com/google/go-cloud/blob/driver"
```go
dopt = &driver.WriterOptions{
  ContentMD5:  opt.ContentMD5,
  BufferSize:  opt.BufferSize,
  BeforeWrite: opt.BeforeWrite,
}
```
at next merge