### PR TITLE
runtimevar/filevar: rename NewVariable -> New

### DIFF
--- a/runtimevar/example_test.go
+++ b/runtimevar/example_test.go
@@ -31,7 +31,7 @@ type DBConfig struct {
 
 func initVariable() (*runtimevar.Variable, func()) {
 	// Construct a runtimevar.Variable object.
-	v, err := filevar.NewVariable("/etc/myapp/db.json", runtimevar.NewDecoder(&DBConfig{}, runtimevar.JSONDecode), nil)
+	v, err := filevar.New("/etc/myapp/db.json", runtimevar.NewDecoder(&DBConfig{}, runtimevar.JSONDecode), nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/runtimevar/filevar/example_test.go
+++ b/runtimevar/filevar/example_test.go
@@ -26,9 +26,9 @@ type MyAppConfig struct {
 	MsgOfTheDay string `json:"msg_of_the_day"`
 }
 
-func ExampleNewVariable() {
+func ExampleNew() {
 	// Configure a JSON decoder for myapp.json to unmarshal into a MyAppConfig object.
-	v, err := filevar.NewVariable("/etc/myapp/myapp.json", runtimevar.NewDecoder(&MyAppConfig{}, runtimevar.JSONDecode), nil)
+	v, err := filevar.New("/etc/myapp/myapp.json", runtimevar.NewDecoder(&MyAppConfig{}, runtimevar.JSONDecode), nil)
 	if err != nil {
 		log.Fatalf("Error in constructing variable: %v", err)
 	}

--- a/runtimevar/filevar/filevar.go
+++ b/runtimevar/filevar/filevar.go
@@ -48,10 +48,10 @@ import (
 // defaultWait is the default value for WatchOptions.WaitTime.
 const defaultWait = 30 * time.Second
 
-// NewVariable constructs a runtimevar.Variable object with this package as the driver
+// New constructs a runtimevar.Variable object with this package as the driver
 // implementation.  The decoder argument allows users to dictate the decoding function to parse the
 // file as well as the type to unmarshal into.
-func NewVariable(file string, decoder *runtimevar.Decoder, opts *WatchOptions) (*runtimevar.Variable, error) {
+func New(file string, decoder *runtimevar.Decoder, opts *WatchOptions) (*runtimevar.Variable, error) {
 	w, err := newWatcher(file, decoder, opts)
 	if err != nil {
 		return nil, err

--- a/samples/guestbook/inject_local.go
+++ b/samples/guestbook/inject_local.go
@@ -76,7 +76,7 @@ func dialLocalSQL(flags *cliFlags) (*sql.DB, error) {
 // localRuntimeVar is a Wire provider function that returns the Message of the
 // Day variable based on a local file.
 func localRuntimeVar(flags *cliFlags) (*runtimevar.Variable, func(), error) {
-	v, err := filevar.NewVariable(flags.motdVar, runtimevar.StringDecoder, &filevar.WatchOptions{
+	v, err := filevar.New(flags.motdVar, runtimevar.StringDecoder, &filevar.WatchOptions{
 		WaitTime: flags.motdVarWaitTime,
 	})
 	if err != nil {

--- a/samples/guestbook/wire_gen.go
+++ b/samples/guestbook/wire_gen.go
@@ -269,7 +269,7 @@ func dialLocalSQL(flags *cliFlags) (*sql.DB, error) {
 }
 
 func localRuntimeVar(flags *cliFlags) (*runtimevar.Variable, func(), error) {
-	v, err := filevar.NewVariable(flags.motdVar, runtimevar.StringDecoder, &filevar.WatchOptions{
+	v, err := filevar.New(flags.motdVar, runtimevar.StringDecoder, &filevar.WatchOptions{
 		WaitTime: flags.motdVarWaitTime,
 	})
 	if err != nil {


### PR DESCRIPTION
For consistency with `etcdvar` and `constantvar`.

`filevar.NewVariable` stutters; `filevar.New` is better.

I left `NewVariable` for `runtimeconfigurator` and `paramstore` because for those packages, it is not a top-level function, but rather a method of `Client`.