### PR TITLE
blob: add blob.Open for creating arbitrary provider blobs from URLs

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -524,7 +524,8 @@ type WriterOptions struct {
 	BeforeWrite func(asFunc func(interface{}) bool) error
 }
 
-// FromURLFn allows providers to convert a parsed URL to a *Bucket.
+// FromURLFn is for use by provider implementations.
+// It allows providers to convert a parsed URL from Open to a driver.Bucket.
 // It takes a bucket name and a map of key/value options. The map is guaranteed
 // to be non-nil, and all keys will be in lowercase.
 type FromURLFn func(context.Context, string, map[string]string) (driver.Bucket, error)

--- a/blob/blob_test.go
+++ b/blob/blob_test.go
@@ -1,0 +1,131 @@
+// Copyright 2018 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blob
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cloud/blob/driver"
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestOpen tests blob.Open.
+func TestOpen(t *testing.T) {
+	ctx := context.Background()
+	var gotBucket string
+	var gotOptions map[string]string
+
+	// Register protocol foo to always return nil.
+	// Sets gotBucket and gotOptions as a side effect
+	if err := Register("foo", func(_ context.Context, bucket string, opts map[string]string) (driver.Bucket, error) {
+		gotBucket = bucket
+		gotOptions = opts
+		return nil, nil
+	}); err != nil {
+		t.Fatalf("failed to register foo: %v", err)
+	}
+
+	// Register protocol err to always return an error.
+	if err := Register("err", func(_ context.Context, _ string, _ map[string]string) (driver.Bucket, error) {
+		return nil, errors.New("fail")
+	}); err != nil {
+		t.Fatalf("failed to register foo: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		url         string
+		wantErr     bool
+		wantBucket  string
+		wantOptions map[string]string
+	}{
+		{
+			name:    "empty URL",
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL",
+			url:     "foo",
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL missing bucket",
+			url:     "foo://",
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL empty bucket",
+			url:     "foo://?xxx=yyy&bbb",
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL bad option",
+			url:     "foo://mybucket?xxx=yyy&bbb",
+			wantErr: true,
+		},
+		{
+			name:    "unregistered protocol",
+			url:     "bar://mybucket",
+			wantErr: true,
+		},
+		{
+			name:    "fn returns error",
+			url:     "err://mybucket",
+			wantErr: true,
+		},
+		{
+			name:        "no options",
+			url:         "foo://mybucket",
+			wantBucket:  "mybucket",
+			wantOptions: map[string]string{},
+		},
+		{
+			name:        "empty options",
+			url:         "foo://mybucket?",
+			wantBucket:  "mybucket",
+			wantOptions: map[string]string{},
+		},
+		{
+			name:        "options",
+			url:         "foo://mybucket?aAa=bBb&cCc=dDd",
+			wantBucket:  "mybucket",
+			wantOptions: map[string]string{"aaa": "bBb", "ccc": "dDd"},
+		},
+		{
+			name:        "fancy bucket name",
+			url:         "foo:///foo/bar/baz",
+			wantBucket:  "/foo/bar/baz",
+			wantOptions: map[string]string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, gotErr := Open(ctx, tc.url)
+			if (gotErr != nil) != tc.wantErr {
+				t.Fatalf("got err %v, want error %v", gotErr, tc.wantErr)
+			}
+			if gotErr != nil {
+				return
+			}
+			if gotBucket != tc.wantBucket {
+				t.Errorf("got bucket name %q want %q", gotBucket, tc.wantBucket)
+			}
+			if diff := cmp.Diff(gotOptions, tc.wantOptions); diff != "" {
+				t.Errorf("got\n%v\nwant\n%v\ndiff\n%s", gotOptions, tc.wantOptions, diff)
+			}
+		})
+	}
+}

--- a/blob/example_test.go
+++ b/blob/example_test.go
@@ -321,6 +321,29 @@ func ExampleBucket_As() {
 	// fileblob does not support the `*string` type for WriterOptions.BeforeWrite
 }
 
+func ExampleOpen() {
+	// Connect to a bucket using a URL.
+	// This example uses the file-based implementation, which registers for
+	// the "file" protocol.
+	dir, cleanup := newTempDir()
+	defer cleanup()
+
+	ctx := context.Background()
+	if _, err := blob.Open(ctx, "file:///nonexistentpath"); err == nil {
+		log.Fatal("Expected an error opening nonexistent path")
+	}
+	fmt.Println("Error opening nonexistentpath")
+
+	if _, err := blob.Open(ctx, "file://" + dir); err != nil {
+		log.Fatal(err)
+	} else {
+		fmt.Println("Got bucket for valid path")
+	}
+	// Output:
+	// Error opening nonexistentpath
+	// Got bucket for valid path
+}
+
 func newTempDir() (string, func()) {
 	dir, err := ioutil.TempDir("", "go-cloud-blob-example")
 	if err != nil {

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -48,7 +48,7 @@ func (h *harness) HTTPClient() *http.Client {
 }
 
 func (h *harness) MakeDriver(ctx context.Context) (driver.Bucket, error) {
-	return &bucket{h.dir}, nil
+	return openBucket(h.dir)
 }
 
 func (h *harness) Close() {


### PR DESCRIPTION
The concrete type defines a registry, and provider implementations use `blob.Register` in their package `init()` function to register to handle specific protocols (e.g. "s3" or "gcs"). In `Open`, the concrete type parses the URL into a protocol, bucket name, and map of options, and uses the protocol to identify which provider to call.

This PR only adds the "file" protocol; "gcs" and "s3" will be added in subsequent PRs because I think it makes sense to do some refactoring (i.e., #597) first.