### PR TITLE
blob: add empty options to fileblob and s3blob, for future extensibility

### DIFF
--- a/blob/example_test.go
+++ b/blob/example_test.go
@@ -38,7 +38,7 @@ func ExampleBucket_NewReader() {
 		log.Fatal(err)
 	}
 	// Create the file-based bucket.
-	bucket, err := fileblob.OpenBucket(dir)
+	bucket, err := fileblob.OpenBucket(dir, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func ExampleBucket_NewRangeReader() {
 		log.Fatal(err)
 	}
 	// Create the file-based bucket.
-	bucket, err := fileblob.OpenBucket(dir)
+	bucket, err := fileblob.OpenBucket(dir, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func ExampleBucket_NewWriter() {
 	// This example uses the file-based implementation.
 	dir, cleanup := newTempDir()
 	defer cleanup()
-	bucket, err := fileblob.OpenBucket(dir)
+	bucket, err := fileblob.OpenBucket(dir, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func ExampleBucket_ReadAll() {
 	defer cleanup()
 
 	// Create the file-based bucket.
-	bucket, err := fileblob.OpenBucket(dir)
+	bucket, err := fileblob.OpenBucket(dir, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -174,7 +174,7 @@ func ExampleBucket_List() {
 	defer cleanup()
 
 	// Create the file-based bucket.
-	bucket, err := fileblob.OpenBucket(dir)
+	bucket, err := fileblob.OpenBucket(dir, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -220,7 +220,7 @@ func ExampleBucket_List_withDelimiter() {
 	defer cleanup()
 
 	// Create the file-based bucket.
-	bucket, err := fileblob.OpenBucket(dir)
+	bucket, err := fileblob.OpenBucket(dir, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -283,7 +283,7 @@ func ExampleBucket_As() {
 	defer cleanup()
 
 	// Create the file-based bucket.
-	bucket, err := fileblob.OpenBucket(dir)
+	bucket, err := fileblob.OpenBucket(dir, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -60,9 +60,12 @@ const defaultPageSize = 1000
 
 func init() {
 	blob.Register("file", func(_ context.Context, u *url.URL) (driver.Bucket, error) {
-		return openBucket(u.Host + u.Path)
+		return openBucket(u.Host+u.Path, nil)
 	})
 }
+
+// Options sets options for constructing a *blob.Bucket backed by fileblob.
+type Options struct{}
 
 type bucket struct {
 	dir string
@@ -70,7 +73,7 @@ type bucket struct {
 
 // openBucket creates a driver.Bucket that reads and writes to dir.
 // dir must exist.
-func openBucket(dir string) (driver.Bucket, error) {
+func openBucket(dir string, _ *Options) (driver.Bucket, error) {
 	dir = filepath.Clean(dir)
 	info, err := os.Stat(dir)
 	if err != nil {
@@ -84,8 +87,8 @@ func openBucket(dir string) (driver.Bucket, error) {
 
 // OpenBucket creates a *blob.Bucket that reads and writes to dir.
 // dir must exist.
-func OpenBucket(dir string) (*blob.Bucket, error) {
-	drv, err := openBucket(dir)
+func OpenBucket(dir string, opts *Options) (*blob.Bucket, error) {
+	drv, err := openBucket(dir, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -48,7 +48,7 @@ func (h *harness) HTTPClient() *http.Client {
 }
 
 func (h *harness) MakeDriver(ctx context.Context) (driver.Bucket, error) {
-	return openBucket(h.dir)
+	return openBucket(h.dir, nil)
 }
 
 func (h *harness) Close() {
@@ -67,7 +67,7 @@ func TestNewBucket(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer os.RemoveAll(dir)
-		_, gotErr := OpenBucket(filepath.Join(dir, "notfound"))
+		_, gotErr := OpenBucket(filepath.Join(dir, "notfound"), nil)
 		if gotErr == nil {
 			t.Errorf("want error, got nil")
 		}
@@ -78,7 +78,7 @@ func TestNewBucket(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer os.Remove(f.Name())
-		_, gotErr := OpenBucket(f.Name())
+		_, gotErr := OpenBucket(f.Name(), nil)
 		if gotErr == nil {
 			t.Error("want error, got nil")
 		}

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -46,8 +46,11 @@ import (
 
 const defaultPageSize = 1000
 
+// Options sets options for constructing a *blob.Bucket backed by fileblob.
+type Options struct{}
+
 // OpenBucket returns an S3 Bucket.
-func OpenBucket(ctx context.Context, sess client.ConfigProvider, bucketName string) (*blob.Bucket, error) {
+func OpenBucket(ctx context.Context, bucketName string, sess client.ConfigProvider, _ *Options) (*blob.Bucket, error) {
 	if sess == nil {
 		return nil, errors.New("sess must be provided to get bucket")
 	}

--- a/samples/guestbook/inject_aws.go
+++ b/samples/guestbook/inject_aws.go
@@ -51,7 +51,7 @@ func setupAWS(ctx context.Context, flags *cliFlags) (*application, func(), error
 // awsBucket is a Wire provider function that returns the S3 bucket based on the
 // command-line flags.
 func awsBucket(ctx context.Context, cp awsclient.ConfigProvider, flags *cliFlags) (*blob.Bucket, error) {
-	return s3blob.OpenBucket(ctx, cp, flags.bucket)
+	return s3blob.OpenBucket(ctx, flags.bucket, cp, nil)
 }
 
 // awsSQLParams is a Wire provider function that returns the RDS SQL connection

--- a/samples/guestbook/inject_local.go
+++ b/samples/guestbook/inject_local.go
@@ -56,7 +56,7 @@ func setupLocal(ctx context.Context, flags *cliFlags) (*application, func(), err
 // localBucket is a Wire provider function that returns a directory-based bucket
 // based on the command-line flags.
 func localBucket(flags *cliFlags) (*blob.Bucket, error) {
-	return fileblob.OpenBucket(flags.bucket)
+	return fileblob.OpenBucket(flags.bucket, nil)
 }
 
 // dialLocalSQL is a Wire provider function that connects to a MySQL database

--- a/samples/tutorial/setup.go
+++ b/samples/tutorial/setup.go
@@ -67,5 +67,5 @@ func setupAWS(ctx context.Context, bucket string) (*blob.Bucket, error) {
 		Credentials: credentials.NewEnvCredentials(),
 	}
 	s := session.Must(session.NewSession(c))
-	return s3blob.OpenBucket(ctx, s, bucket)
+	return s3blob.OpenBucket(ctx, bucket, s, nil)
 }


### PR DESCRIPTION
This is questionable -- why add an empty `Options` struct? But I think it's wise to do so, because otherwise if we ever want to add options (which seems quite likely at least for `s3blob`), we'll end up with either multiple constructors (`OpenBucketWithOptions`), or a breaking change.

I could be convinced that we'll never add options to `fileblob` so we should leave it off there.

I also re-ordered the arguments to `s3blob.OpenBucket` to be consistent with `gcsblob`.
There are some unrelated changes to `wire_gen.go` because I re-reran `go generate`.

Fixes #592.