### PR TITLE
wire: in tests, don't copy wire_gen.go into the temporary GOPATH

### DIFF
--- a/wire/internal/wire/wire_test.go
+++ b/wire/internal/wire/wire_test.go
@@ -488,12 +488,16 @@ func loadTestCase(root string, wireGoSrc []byte) (*testCase, error) {
 		if err != nil {
 			return err
 		}
-		if !info.Mode().IsRegular() || filepath.Ext(src) != ".go" {
-			return nil
-		}
 		rel, err := filepath.Rel(root, src)
 		if err != nil {
 			return err // unlikely
+		}
+		if info.Mode().IsDir() && rel == "want" {
+			// The "want" directory should not be included in goFiles.
+			return filepath.SkipDir
+		}
+		if !info.Mode().IsRegular() || filepath.Ext(src) != ".go" {
+			return nil
 		}
 		data, err := ioutil.ReadFile(src)
 		if err != nil {


### PR DESCRIPTION
This does not change the results of the test, but should not be happening. I discovered this as a red herring while debugging #623.