### PR TITLE
wire: update README installation instructions 

### DIFF
--- a/wire/README.md
+++ b/wire/README.md
@@ -20,6 +20,8 @@ Install Wire by running:
 go get github.com/google/go-cloud/wire/cmd/wire
 ```
 
+and ensure that `$GOPATH/bin` is added to your `$PATH`.
+
 ## Basics
 
 Wire has two core concepts: providers and injectors.

--- a/wire/README.md
+++ b/wire/README.md
@@ -20,7 +20,7 @@ Install Wire by running:
 go get github.com/google/go-cloud/wire/cmd/wire
 ```
 
-and ensure that `$GOPATH/bin` is added to your `$PATH`.
+and ensuring that `$GOPATH/bin` is added to your `$PATH`.
 
 ## Basics
 


### PR DESCRIPTION
This PR makes explicit in the `README` that you must add `$GOPATH/bin` to your `$PATH`, since that differs between `go generate` and other `go` commands.