### PR TITLE
internal/proxy: add step to copy from GCS

### DIFF
--- a/internal/proxy/README.md
+++ b/internal/proxy/README.md
@@ -24,23 +24,30 @@ dependency to the proxy:
 # https://github.com/go-modules-by-example/index/tree/master/012_modvendor
 
 # Create a temporary directory where we'll create a module download cache.
-tgp=$(mktemp -d)
+tgp="$(mktemp -d)"
+
+# Copy current module cache into temporary directory as basis.
+# Periodically, someone on the project should go through this process without
+# running this step to prune unused dependencies.
+mkdir -p "$tgp/pkg/mod/cache/download"
+gsutil -m rsync -r gs://go-cloud-modules "$tgp/pkg/mod/cache/download"
 
 # Run this command in the master branch.
 # It runs "go mod download" in every module that we have in our repo,
 # filling the cache with all of the module dependencies we need.
-./internal/proxy/makeproxy.sh $tgp
+./internal/proxy/makeproxy.sh "$tgp"
 
 # Run the above command again in your branch that's adding a new dependency,
 # to ensure the cache has any new dependencies.
 
 # Move the temporary cache to modvendor/.
 rm -rf modvendor
-cp -rp $tgp/pkg/mod/cache/download/ modvendor
+cp -rp "$tgp/pkg/mod/cache/download/" modvendor
 
 # Clean up the temporary cache.
-GOPATH=$tgp go clean -modcache
-rm -rf $tgp
+GOPATH="$tgp" go clean -modcache
+rm -rf "$tgp"
+unset tgp
 
 # Synchronize modvendor to the proxy.
 


### PR DESCRIPTION
Instead of starting from zero, instruct proxy updaters to start from the current module cache by copying from the remote bucket. In common cases, this should reduce the probability of accidental removal of dependencies that other collaborators depend on in in-flight PRs.

There is still the possibility that someone else runs these steps concurrently and clobbers work, but that seems much more remote, and the resolution would be to go through the process again.

Fixes #661