### PR TITLE
internal/contributebot: update issue/PR title regex

### DIFF
--- a/internal/contributebot/process.go
+++ b/internal/contributebot/process.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	issueTitleRegexp       = regexp.MustCompile(`^[a-z0-9./-]+: .*$`)
+	issueTitleRegexp       = regexp.MustCompile(`^([a-z0-9./-]+|[A-Z_]+): .*$`)
 	pullRequestTitleRegexp = issueTitleRegexp
 )
 


### PR DESCRIPTION
This PR updates regex used to match allowable titles for issues and PRs so eg README and CODE_OF_CONDUCT are considered valid package names to start titles with.

fixes #559

