### PR TITLE
all: only run coverage for the root module

### DIFF
--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -29,8 +29,8 @@ fi
 result=0
 
 # Run Go tests for the root, including coverage.
-( exec go test -v -covermode=count -coverprofile=coverage.out ./... && exec goveralls -coverprofile=coverage.out -service=travis-ci) || result=1
-( exec wire check ./... ) || result=1
+go test -v -covermode=count -coverprofile=coverage.out ./... && goveralls -coverprofile=coverage.out -service=travis-ci || result=1
+wire check ./... || result=1
 
 # Run Go tests for each additional module, without coverage.
 for path in "./internal/contributebot" "./samples/appengine"; do

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -26,10 +26,15 @@ if [[ $# -gt 0 ]]; then
   exit 64
 fi
 
-# Run Go tests for each module.
 result=0
-for path in "." "./internal/contributebot" "./samples/appengine"; do
-  ( cd "$path" && exec go test -v -covermode=count -coverprofile=coverage.out ./... && goveralls -coverprofile=coverage.out -service=travis-ci) || result=1
+
+# Run Go tests for the root, including coverage.
+( exec go test -v -covermode=count -coverprofile=coverage.out ./... && goveralls -coverprofile=coverage.out -service=travis-ci) || result=1
+( exec wire check ./... ) || result=1
+
+# Run Go tests for each additional module, without coverage.
+for path in "./internal/contributebot" "./samples/appengine"; do
+  ( cd "$path" && exec go test -v ./... ) || result=1
   ( cd "$path" && exec wire check ./... ) || result=1
 done
 exit $result

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -29,7 +29,7 @@ fi
 result=0
 
 # Run Go tests for the root, including coverage.
-( exec go test -v -covermode=count -coverprofile=coverage.out ./... && goveralls -coverprofile=coverage.out -service=travis-ci) || result=1
+( exec go test -v -covermode=count -coverprofile=coverage.out ./... && exec goveralls -coverprofile=coverage.out -service=travis-ci) || result=1
 ( exec wire check ./... ) || result=1
 
 # Run Go tests for each additional module, without coverage.


### PR DESCRIPTION
Fixes #625.

The previous code had a bug; doing `exec <cmd> && <cmd2>` never runs `cmd2`. We also only want to do code coverage on the root module.