### PR TITLE
wire: serialize test execution

### DIFF
--- a/wire/internal/wire/wire_test.go
+++ b/wire/internal/wire/wire_test.go
@@ -70,8 +70,9 @@ func TestWire(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			// TODO(light): These tests should be parallelizable, but seems to flake.
-			// See https://github.com/google/go-cloud/issues/669 for details.
+			// TODO(light): These tests should be parallelizable, but this causes
+			// intermittent failures. See https://github.com/google/go-cloud/issues/669
+			// for details.
 
 			// Materialize a temporary GOPATH directory.
 			gopath, err := ioutil.TempDir("", "wire_test")

--- a/wire/internal/wire/wire_test.go
+++ b/wire/internal/wire/wire_test.go
@@ -70,7 +70,8 @@ func TestWire(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+			// TODO(light): These tests should be parallelizable, but seems to flake.
+			// See https://github.com/google/go-cloud/issues/669 for details.
 
 			// Materialize a temporary GOPATH directory.
 			gopath, err := ioutil.TempDir("", "wire_test")


### PR DESCRIPTION
We are seeing errors of the form "failed to cache compiled Go files" when running the tests on Travis. Hopefully this should reduce or eliminate the flakiness.

Updates #669