### PR TITLE
wire/tests: add a test for wire.Bind on an injector arg

### DIFF
--- a/wire/internal/wire/testdata/BindInjectorArg/foo/foo.go
+++ b/wire/internal/wire/testdata/BindInjectorArg/foo/foo.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/wire/internal/wire/testdata/BindInjectorArg/foo/foo.go
+++ b/wire/internal/wire/testdata/BindInjectorArg/foo/foo.go
@@ -1,0 +1,42 @@
+// Copyright 2018 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println(inject(&Foo{"hello"}).Name)
+}
+
+type Fooer interface {
+	Foo() string
+}
+
+type Foo struct {
+	f string
+}
+
+func (f *Foo) Foo() string {
+	return f.f
+}
+
+type Bar struct {
+	Name string
+}
+
+func NewBar(fooer Fooer) *Bar {
+	return &Bar{Name: fooer.Foo()}
+}

--- a/wire/internal/wire/testdata/BindInjectorArg/foo/wire.go
+++ b/wire/internal/wire/testdata/BindInjectorArg/foo/wire.go
@@ -1,0 +1,29 @@
+// Copyright 2018 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//+build wireinject
+package main
+
+import (
+	"github.com/google/go-cloud/wire"
+)
+
+func inject(foo *Foo) *Bar {
+	// Currently fails because wire.Bind can't see injector args (#547).
+	wire.Build(
+		NewBar,
+		wire.Bind(new(Fooer), &Foo{}),
+	)
+	return nil
+}

--- a/wire/internal/wire/testdata/BindInjectorArg/foo/wire.go
+++ b/wire/internal/wire/testdata/BindInjectorArg/foo/wire.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 //+build wireinject
+
 package main
 
 import (

--- a/wire/internal/wire/testdata/BindInjectorArg/pkg
+++ b/wire/internal/wire/testdata/BindInjectorArg/pkg
@@ -1,0 +1,1 @@
+example.com/foo

--- a/wire/internal/wire/testdata/BindInjectorArg/want/wire_errs.txt
+++ b/wire/internal/wire/testdata/BindInjectorArg/want/wire_errs.txt
@@ -1,0 +1,1 @@
+example.com/foo/wire.go:x:y: no binding for *example.com/foo.Foo


### PR DESCRIPTION
The test current produces a wire error due to #547. It will be updated to actually work as part of fixing that bug.

Updates #547.