### PR TITLE
internal/docs/pubsub: add description of what happens if SendAcks returns an unrecoverable …

### DIFF
--- a/internal/docs/pubsub/design.md
+++ b/internal/docs/pubsub/design.md
@@ -470,7 +470,11 @@ Topics will gather messages into batches for sending. The batch size will be
 dynamically tuned according to how many messages are being sent concurrently.
 
 Subscriptions will gather message acks into batches the same way, also
-dynamically tuning the batch size.
+dynamically tuning the batch size. If sending acks back to the server fails
+transiently then it will be retried, most likely within a loop in the concrete
+API. If an unrecoverable error occurs while sending acks then a flag will be
+set on the `pubsub.Subscription` saying that the whole `Subscription` is no
+longer usable. Calls to `Receive` will fail from then on.
 
 ## Alternative designs considered
 


### PR DESCRIPTION
Fixes #719 