### PR TITLE
wire: add a test for using a function argument as a provider

### DIFF
--- a/wire/internal/wire/parse.go
+++ b/wire/internal/wire/parse.go
@@ -426,7 +426,7 @@ func (oc *objectCache) get(obj types.Object) (val interface{}, errs []error) {
 	switch obj := obj.(type) {
 	case *types.Var:
 		spec := oc.varDecl(obj)
-		if len(spec.Values) == 0 {
+		if spec == nil || len(spec.Values) == 0 {
 			return nil, []error{fmt.Errorf("%v is not a provider or a provider set", obj)}
 		}
 		var i int

--- a/wire/internal/wire/testdata/FuncArgProvider/foo/foo.go
+++ b/wire/internal/wire/testdata/FuncArgProvider/foo/foo.go
@@ -1,0 +1,36 @@
+// Copyright 2018 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	bar := injectBar(func() *Foo { return &Foo{42} })
+	fmt.Println(bar.Name)
+}
+
+type Foo struct {
+	Val int
+}
+
+type Bar struct {
+	Name string
+}
+
+func NewBar(f *Foo) *Bar {
+	return &Bar{Name: fmt.Sprintf("foo value %d", f.Val)}
+}

--- a/wire/internal/wire/testdata/FuncArgProvider/foo/wire.go
+++ b/wire/internal/wire/testdata/FuncArgProvider/foo/wire.go
@@ -1,0 +1,26 @@
+// Copyright 2018 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build wireinject
+
+package main
+
+import (
+	"github.com/google/go-cloud/wire"
+)
+
+func injectBar(fn func() *Foo) *Bar {
+	// fails because it doesn't identify fn as a Provider; see #723.
+	panic(wire.Build(fn, NewBar))
+}

--- a/wire/internal/wire/testdata/FuncArgProvider/pkg
+++ b/wire/internal/wire/testdata/FuncArgProvider/pkg
@@ -1,0 +1,1 @@
+example.com/foo

--- a/wire/internal/wire/testdata/FuncArgProvider/want/wire_errs.txt
+++ b/wire/internal/wire/testdata/FuncArgProvider/want/wire_errs.txt
@@ -1,0 +1,1 @@
+example.com/foo/wire.go:x:y: var fn func() *example.com/foo.Foo is not a provider or a provider set


### PR DESCRIPTION
This adds a test for using a function argument as a provider in an injector.

Before the PR, this test would panic:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
```

at the updated line. After the PR, wire still fails, but the test captures the error and passes. Fixing this to actually work is left as a future PR.

Updates #723.