### PR TITLE
postgres/cloudpostgres: use structured parameters instead of connection string

### DIFF
--- a/postgres/cloudpostgres/cloudpostgres.go
+++ b/postgres/cloudpostgres/cloudpostgres.go
@@ -21,6 +21,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"net"
 	"net/url"
 	"time"
@@ -56,9 +57,10 @@ func Open(ctx context.Context, certSource proxy.CertSource, params *Params) (*sq
 	vals := make(url.Values)
 	for k, v := range params.Values {
 		// Only permit parameters that do not conflict with other behavior.
-		if k != "user" && k != "password" && k != "dbname" && k != "host" && k != "port" && k != "sslmode" && k != "sslcert" && k != "sslkey" && k != "sslrootcert" {
-			vals[k] = v
+		if k == "user" || k == "password" || k == "dbname" || k == "host" || k == "port" || k == "sslmode" || k == "sslcert" || k == "sslkey" || k == "sslrootcert" {
+			return nil, fmt.Errorf("cloudpostgres: open: extra parameter %s not allowed; use Params fields instead", k)
 		}
+		vals[k] = v
 	}
 	vals.Set("sslmode", "disable")
 

--- a/postgres/cloudpostgres/cloudpostgres.go
+++ b/postgres/cloudpostgres/cloudpostgres.go
@@ -22,6 +22,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"net"
+	"net/url"
 	"time"
 
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/proxy"
@@ -30,21 +31,59 @@ import (
 
 // Params specifies how to connect to a Cloud SQL database.
 type Params struct {
+	// ProjectID is the project the instance is located in.
 	ProjectID string
-	Region    string
-	Instance  string
-	PQConn    string // format is documented at https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
+	// Region is the region the instance is located in.
+	Region string
+	// Instance is the name of the instance.
+	Instance string
+
+	// User is the database user to connect as.
+	User string
+	// Password is the database user password to use.
+	// May be empty, see https://cloud.google.com/sql/docs/sql-proxy#user
+	Password string
+	// Database is the PostgreSQL database name to connect to.
+	Database string
+
+	// Values sets additional parameters, as documented in
+	// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS.
+	Values url.Values
 }
 
 // Open opens a Cloud SQL database.
 func Open(ctx context.Context, certSource proxy.CertSource, params *Params) (*sql.DB, error) {
+	vals := make(url.Values)
+	for k, v := range params.Values {
+		// Only permit parameters that do not conflict with other behavior.
+		if k != "user" && k != "password" && k != "dbname" && k != "host" && k != "port" && k != "sslmode" && k != "sslcert" && k != "sslkey" && k != "sslrootcert" {
+			vals[k] = v
+		}
+	}
+	vals.Set("sslmode", "disable")
+
+	var user *url.Userinfo
+	if params.User != "" && params.Password != "" {
+		if params.Password != "" {
+			user = url.UserPassword(params.User, params.Password)
+		} else {
+			user = url.User(params.User)
+		}
+	}
+	u := url.URL{
+		Scheme:   "postgres",
+		User:     user,
+		Host:     "cloudsql",
+		Path:     "/" + params.Database,
+		RawQuery: vals.Encode(),
+	}
 	return sql.OpenDB(connector{
 		client: &proxy.Client{
 			Port:  3307,
 			Certs: certSource,
 		},
 		instance: params.ProjectID + ":" + params.Region + ":" + params.Instance,
-		pqConn:   "sslmode=disable " + params.PQConn,
+		pqConn:   u.String(),
 	}), nil
 }
 

--- a/postgres/cloudpostgres/cloudpostgres_test.go
+++ b/postgres/cloudpostgres/cloudpostgres_test.go
@@ -59,7 +59,9 @@ func TestOpen(t *testing.T) {
 		ProjectID: project,
 		Region:    region,
 		Instance:  instance,
-		PQConn:    "dbname='" + databaseName + "' user='" + username + "' password='" + password + "'",
+		Database:  databaseName,
+		User:      username,
+		Password:  password,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/postgres/cloudpostgres/cloudpostgres_test.go
+++ b/postgres/cloudpostgres/cloudpostgres_test.go
@@ -17,6 +17,8 @@ package cloudpostgres
 import (
 	"context"
 	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cloud/gcp"
@@ -71,5 +73,64 @@ func TestOpen(t *testing.T) {
 	}
 	if err := db.Close(); err != nil {
 		t.Error("Close:", err)
+	}
+}
+
+func TestOpenBadValue(t *testing.T) {
+	// This test will be skipped unless the project is set up with Terraform.
+
+	tfOut, err := terraform.ReadOutput(".")
+	if err != nil {
+		t.Skipf("Could not obtain harness info: %v", err)
+	}
+	project, _ := tfOut["project"].Value.(string)
+	region, _ := tfOut["region"].Value.(string)
+	instance, _ := tfOut["instance"].Value.(string)
+	username, _ := tfOut["username"].Value.(string)
+	password, _ := tfOut["password"].Value.(string)
+	databaseName, _ := tfOut["database"].Value.(string)
+	if project == "" || region == "" || instance == "" || username == "" || databaseName == "" {
+		t.Fatalf("Missing one or more required Terraform outputs; got project=%q region=%q instance=%q username=%q database=%q", project, region, instance, username, databaseName)
+	}
+
+	ctx := context.Background()
+	creds, err := gcp.DefaultCredentials(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := gcp.NewHTTPClient(http.DefaultTransport, creds.TokenSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certSource := cloudsql.NewCertSource(client)
+
+	tests := []struct {
+		name, value string
+	}{
+		{"user", "foo"},
+		{"password", "foo"},
+		{"dbname", "foo"},
+		{"host", "localhost"},
+		{"port", "1234"},
+		{"sslmode", "require"},
+	}
+	for _, test := range tests {
+		t.Run(test.name+"="+test.value, func(t *testing.T) {
+			db, err := Open(ctx, certSource, &Params{
+				ProjectID: project,
+				Region:    region,
+				Instance:  instance,
+				Database:  databaseName,
+				User:      username,
+				Password:  password,
+				Values:    url.Values{test.name: {test.value}},
+			})
+			if err == nil || !strings.Contains(err.Error(), test.name) {
+				t.Errorf("error = %v; want to contain %q", err, test.name)
+			}
+			if db != nil {
+				db.Close()
+			}
+		})
 	}
 }

--- a/postgres/cloudpostgres/example_test.go
+++ b/postgres/cloudpostgres/example_test.go
@@ -36,7 +36,8 @@ func Example() {
 		ProjectID: "example-project",
 		Region:    "us-central1",
 		Instance:  "my-instance01",
-		PQConn:    "dbname=test user=myrole",
+		User:      "myrole",
+		Database:  "test",
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Brings consistency with the MySQL dialers and avoids pushing the user to escape usernames and passwords properly.