### PR TITLE
internal/contributebot: add link to deployment details in README

### DIFF
--- a/internal/contributebot/README.md
+++ b/internal/contributebot/README.md
@@ -98,6 +98,11 @@ kubectl apply -f prod/k8s
 # Send a PR with the updated .yaml file.
 ```
 
+To check that the deploy was successful, consult the contributebot-worker [Deployment Details][]
+
+[Deployment Details]: https://pantheon.corp.google.com/kubernetes/deployment/us-central1-c/contributebot-cluster/default/contributebot-worker?project=go-cloud-contribute-bot&tab=history&deployment_overview_active_revisions_tablesize=50&duration=PT1H&pod_summary_list_tablesize=20&deployment_revision_history_tablesize=50
+
+
 ### Somewhere else
 
 If you want to deploy to your own cluster, modify `k8s/contributebot.yaml` to

--- a/internal/contributebot/prod/k8s/contributebot.yaml
+++ b/internal/contributebot/prod/k8s/contributebot.yaml
@@ -39,7 +39,7 @@ spec:
           secretName: worker-service-account
       containers:
       - name: contributebot
-        image: gcr.io/go-cloud-contribute-bot/contributebot:a3d6e8bd-f366-4324-9f9b-7c608b5741c2
+        image: gcr.io/go-cloud-contribute-bot/contributebot:c74aa599-7e05-41a6-bb08-dd33b8207617
         args:
         - "-project=go-cloud-contribute-bot"
         - "-github_app=15206"


### PR DESCRIPTION
This PR updates the container image tag and adds a link to the contributebot README for viewing deployment details.