### PR TITLE
blob/all: consistently return raw errors from drivers instead of creating new ones

### DIFF
--- a/blob/fileblob/attrs.go
+++ b/blob/fileblob/attrs.go
@@ -16,10 +16,13 @@ package fileblob
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 )
 
 const attrsExt = ".attrs"
+
+var errAttrsExt = fmt.Errorf("file extension %q is reserved", attrsExt)
 
 // xattrs stores extended attributes for an object. The format is like
 // filesystem extended attributes, see

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -86,10 +86,10 @@ func openBucket(dir string, _ *Options) (driver.Bucket, error) {
 	dir = filepath.Clean(dir)
 	info, err := os.Stat(dir)
 	if err != nil {
-		return nil, fmt.Errorf("open file bucket: %v", err)
+		return nil, err
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("open file bucket: %s is not a directory", dir)
+		return nil, fmt.Errorf("%s is not a directory", dir)
 	}
 	return &bucket{dir}, nil
 }
@@ -257,7 +257,7 @@ func (b *bucket) forKey(key string) (string, os.FileInfo, *xattrs, error) {
 	relpath := escape(key)
 	path := filepath.Join(b.dir, relpath)
 	if strings.HasSuffix(path, attrsExt) {
-		return "", nil, nil, fmt.Errorf("open file blob %s: extension %q cannot be directly read", key, attrsExt)
+		return "", nil, nil, errAttrsExt
 	}
 	info, err := os.Stat(path)
 	if err != nil {
@@ -265,7 +265,7 @@ func (b *bucket) forKey(key string) (string, os.FileInfo, *xattrs, error) {
 	}
 	xa, err := getAttrs(path)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("open file attributes %s: %v", key, err)
+		return "", nil, nil, err
 	}
 	return path, info, &xa, nil
 }
@@ -401,11 +401,11 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 	}
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("open file blob %s: %v", key, err)
+		return nil, err
 	}
 	if offset > 0 {
 		if _, err := f.Seek(offset, io.SeekStart); err != nil {
-			return nil, fmt.Errorf("open file blob %s: %v", key, err)
+			return nil, err
 		}
 	}
 	r := io.Reader(f)
@@ -453,14 +453,14 @@ func (r reader) As(i interface{}) bool { return false }
 func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType string, opts *driver.WriterOptions) (driver.Writer, error) {
 	path := filepath.Join(b.dir, escape(key))
 	if strings.HasSuffix(path, attrsExt) {
-		return nil, fmt.Errorf("open file blob %s: extension %q is reserved and cannot be used", key, attrsExt)
+		return nil, errAttrsExt
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
-		return nil, fmt.Errorf("open file blob %s: %v", key, err)
+		return nil, err
 	}
 	f, err := ioutil.TempFile("", "fileblob")
 	if err != nil {
-		return nil, fmt.Errorf("open file blob %s: %v", key, err)
+		return nil, err
 	}
 	if opts.BeforeWrite != nil {
 		if err := opts.BeforeWrite(func(interface{}) bool { return false }); err != nil {
@@ -500,7 +500,7 @@ type writer struct {
 func (w writer) Write(p []byte) (n int, err error) {
 	if w.md5hash != nil {
 		if _, err := w.md5hash.Write(p); err != nil {
-			return 0, fmt.Errorf("updating md5 hash: %v", err)
+			return 0, err
 		}
 	}
 	return w.f.Write(p)
@@ -535,12 +535,12 @@ func (w writer) Close() error {
 	}
 	// Write the attributes file.
 	if err := setAttrs(w.path, w.attrs); err != nil {
-		return fmt.Errorf("write blob attributes: %v", err)
+		return err
 	}
 	// Rename the temp file to path.
 	if err := os.Rename(w.f.Name(), w.path); err != nil {
 		_ = os.Remove(w.path + attrsExt)
-		return fmt.Errorf("rename during Close: %v", err)
+		return err
 	}
 	return nil
 }
@@ -549,14 +549,14 @@ func (w writer) Close() error {
 func (b *bucket) Delete(ctx context.Context, key string) error {
 	path := filepath.Join(b.dir, escape(key))
 	if strings.HasSuffix(path, attrsExt) {
-		return fmt.Errorf("delete file blob %s: extension %q cannot be directly deleted", key, attrsExt)
+		return errAttrsExt
 	}
 	err := os.Remove(path)
 	if err != nil {
 		return err
 	}
 	if err = os.Remove(path + attrsExt); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("delete file blob %s: %v", key, err)
+		return err
 	}
 	return nil
 }

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -36,7 +36,7 @@ package gcsblob
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/url"
@@ -69,7 +69,7 @@ func init() {
 		if keyPath := q["private_key_path"]; len(keyPath) > 0 {
 			pk, err := ioutil.ReadFile(keyPath[0])
 			if err != nil {
-				return nil, fmt.Errorf("reading private key: %v", err)
+				return nil, err
 			}
 			opts.PrivateKey = pk
 		}
@@ -84,11 +84,11 @@ func init() {
 		} else {
 			jsonCreds, err := ioutil.ReadFile(credPath[0])
 			if err != nil {
-				return nil, fmt.Errorf("reading credentials: %v", err)
+				return nil, err
 			}
 			creds, err = google.CredentialsFromJSON(ctx, jsonCreds)
 			if err != nil {
-				return nil, fmt.Errorf("loading credentials: %v", err)
+				return nil, err
 			}
 		}
 
@@ -121,7 +121,7 @@ type Options struct {
 // openBucket returns a GCS Bucket that communicates using the given HTTP client.
 func openBucket(ctx context.Context, bucketName string, client *gcp.HTTPClient, opts *Options) (driver.Bucket, error) {
 	if client == nil {
-		return nil, fmt.Errorf("OpenBucket requires an HTTP client")
+		return nil, errors.New("OpenBucket requires an HTTP client")
 	}
 	c, err := storage.NewClient(ctx, option.WithHTTPClient(&client.Client))
 	if err != nil {
@@ -347,7 +347,7 @@ func (b *bucket) Delete(ctx context.Context, key string) error {
 
 func (b *bucket) SignedURL(ctx context.Context, key string, dopts *driver.SignedURLOptions) (string, error) {
 	if b.opts.GoogleAccessID == "" || (b.opts.PrivateKey == nil && b.opts.SignBytes == nil) {
-		return "", fmt.Errorf("to use SignedURL, you must call OpenBucket with a valid Options.GoogleAccessID and exactly one of Options.PrivateKey or Options.SignBytes")
+		return "", errors.New("to use SignedURL, you must call OpenBucket with a valid Options.GoogleAccessID and exactly one of Options.PrivateKey or Options.SignBytes")
 	}
 	opts := &storage.SignedURLOptions{
 		Expires:        time.Now().Add(dopts.Expiry),

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -132,8 +132,9 @@ func TestCallCancel(t *testing.T) {
 		if gotCount != 0 {
 			t.Errorf("retry count: got %d, want 0", gotCount)
 		}
-		if gotErr != context.Canceled {
-			t.Errorf("error: got %v, want context.Canceled", gotErr)
+		wantErr := &ContextError{CtxErr: context.Canceled}
+		if !equalContextError(gotErr, wantErr) {
+			t.Errorf("error: got %v, want %v", gotErr, wantErr)
 		}
 	})
 	t.Run("done in sleep", func(t *testing.T) {
@@ -145,15 +146,17 @@ func TestCallCancel(t *testing.T) {
 		if gotCount != 1 {
 			t.Errorf("retry count: got %d, want 1", gotCount)
 		}
-		cerr, ok := gotErr.(*ContextError)
-		if !ok {
-			t.Fatalf("got error %v, not a *ContextError", gotErr)
-		}
-		if cerr.CtxErr != context.Canceled {
-			t.Errorf("CtxErr: got %v, want context.Canceled", cerr.CtxErr)
-		}
-		if cerr.FuncErr != errRetry {
-			t.Errorf("FuncErr: got %v, want errRetry", cerr.FuncErr)
+		wantErr := &ContextError{CtxErr: context.Canceled, FuncErr: errRetry}
+		if !equalContextError(gotErr, wantErr) {
+			t.Errorf("error: got %v, want %v", gotErr, wantErr)
 		}
 	})
+}
+
+func equalContextError(got error, want *ContextError) bool {
+	cerr, ok := got.(*ContextError)
+	if !ok {
+		return false
+	}
+	return cerr.CtxErr == want.CtxErr && cerr.FuncErr == want.FuncErr
 }


### PR DESCRIPTION
Updates #750.

This is needed to make sure `As` works correctly.