### PR TITLE
internal/batcher: New takes reflect.Type

### DIFF
--- a/internal/batcher/batcher.go
+++ b/internal/batcher/batcher.go
@@ -45,18 +45,18 @@ type waiter struct {
 
 // New creates a new Batcher.
 //
-// itemExample is a value of the type that will be batched. For example, if you
-// want to create batches of *Entry, pass &Entry{} for itemExample.
+// itemType is type that will be batched. For example, if you
+// want to create batches of *Entry, pass reflect.TypeOf(&Entry{}) for itemType.
 //
 // maxHandlers is the maximum number of handlers that will run concurrently.
 //
 // handler is a function that will be called on each bundle. If itemExample is
 // of type T, the argument to handler is of type []T.
-func New(itemExample interface{}, maxHandlers int, handler func(interface{}) error) *Batcher {
+func New(itemType reflect.Type, maxHandlers int, handler func(interface{}) error) *Batcher {
 	return &Batcher{
 		maxHandlers:   maxHandlers,
 		handler:       handler,
-		itemSliceZero: reflect.Zero(reflect.SliceOf(reflect.TypeOf(itemExample))),
+		itemSliceZero: reflect.Zero(reflect.SliceOf(itemType)),
 	}
 }
 

--- a/internal/batcher/batcher_test.go
+++ b/internal/batcher/batcher_test.go
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package batcher
+package batcher_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/google/go-cloud/internal/batcher"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -31,7 +35,7 @@ func TestSequential(t *testing.T) {
 	ctx := context.Background()
 	var got []int
 	e := errors.New("e")
-	b := New(int(0), 1, func(items interface{}) error {
+	b := batcher.New(reflect.TypeOf(int(0)), 1, func(items interface{}) error {
 		got = items.([]int)
 		return e
 	})
@@ -57,7 +61,7 @@ func TestSaturation(t *testing.T) {
 		maxBatch         int             // size of largest batch
 		count            = map[int]int{} // how many of each item the handlers observe
 	)
-	b := New(int(0), maxHandlers, func(x interface{}) error {
+	b := batcher.New(reflect.TypeOf(int(0)), maxHandlers, func(x interface{}) error {
 		items := x.([]int)
 		mu.Lock()
 		outstanding++
@@ -113,7 +117,7 @@ func TestShutdown(t *testing.T) {
 	ctx := context.Background()
 	var nAdds int64 // atomic
 	c := make(chan int, 10)
-	b := New(int(0), cap(c), func(x interface{}) error {
+	b := batcher.New(reflect.TypeOf(int(0)), cap(c), func(x interface{}) error {
 		for range x.([]int) {
 			c <- 0
 		}
@@ -140,5 +144,22 @@ func TestShutdown(t *testing.T) {
 	}
 	if err := b.Add(ctx, 1); err == nil {
 		t.Error("got nil, want error from Add after Shutdown")
+	}
+}
+
+func TestItemCanBeInterface(t *testing.T) {
+	readerType := reflect.TypeOf([]io.Reader{}).Elem()
+	called := false
+	b := batcher.New(readerType, 1, func(items interface{}) error {
+		called = true
+		_, ok := items.([]io.Reader)
+		if !ok {
+			t.Fatal("items is not a []io.Reader")
+		}
+		return nil
+	})
+	b.Add(context.Background(), &bytes.Buffer{})
+	if !called {
+		t.Fatal("handler not called")
 	}
 }


### PR DESCRIPTION
This makes it possible to use the batcher with an interface type.