### PR TITLE
mempubsub: fail in driver methods on nonexistent topic

### DIFF
--- a/internal/pubsub/mempubsub/mem_test.go
+++ b/internal/pubsub/mempubsub/mem_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cloud/internal/pubsub"
 	"github.com/google/go-cloud/internal/pubsub/driver"
 )
 
@@ -73,5 +74,20 @@ func TestReceive(t *testing.T) {
 	msgs = sub.receiveNoWait(now, 10)
 	if got, want := len(msgs), 0; got != want {
 		t.Fatalf("got %d, want %d", got, want)
+	}
+}
+
+func TestNotExist(t *testing.T) {
+	ctx := context.Background()
+	b := NewBroker([]string{"t"})
+	top := OpenTopic(b, "x")
+	err := top.Send(ctx, &pubsub.Message{Body: []byte("x")})
+	if err != errNotExist {
+		t.Errorf("got %v, want %v", err, errNotExist)
+	}
+	sub := OpenSubscription(b, "x", time.Second)
+	_, err = sub.Receive(ctx)
+	if err != errNotExist {
+		t.Errorf("got %v, want %v", err, errNotExist)
 	}
 }


### PR DESCRIPTION
All driver methods check for a non-existent topic and return an error.
(Non-existent subscription doesn't make sense for this package.)

Addresses #759 for mempubsub.

gcppubsub is TBD.