### PR TITLE
runtimevar/test: use driver.WatchVariable directly in some tests

### DIFF
--- a/runtimevar/constantvar/constantvar_test.go
+++ b/runtimevar/constantvar/constantvar_test.go
@@ -34,7 +34,7 @@ func newHarness(t *testing.T) (drivertest.Harness, error) {
 	return &harness{vars: map[string][]byte{}}, nil
 }
 
-func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder, wait time.Duration) (driver.Watcher, error) {
+func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder) (driver.Watcher, error) {
 	rawVal, found := h.vars[name]
 	if !found {
 		// The variable isn't set. Create a Variable that always returns an error.

--- a/runtimevar/etcdvar/etcdvar_test.go
+++ b/runtimevar/etcdvar/etcdvar_test.go
@@ -17,7 +17,6 @@ package etcdvar
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/embed"
@@ -58,7 +57,7 @@ func newHarness(t *testing.T) (drivertest.Harness, error) {
 	return &harness{client: cli}, nil
 }
 
-func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder, _ time.Duration) (driver.Watcher, error) {
+func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder) (driver.Watcher, error) {
 	return newWatcher(name, h.client, decoder), nil
 }
 

--- a/runtimevar/filevar/filevar_test.go
+++ b/runtimevar/filevar/filevar_test.go
@@ -43,9 +43,10 @@ func newHarness(t *testing.T) (drivertest.Harness, error) {
 	}, nil
 }
 
-func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder, wait time.Duration) (driver.Watcher, error) {
-	path := filepath.Join(h.dir, name)
-	return newWatcher(path, decoder, &Options{WaitDuration: wait})
+func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder) (driver.Watcher, error) {
+	// filevar uses a goroutine in the background that poll every WaitDuration if
+	// the file is deleted. Make this fast for tests.
+	return newWatcher(filepath.Join(h.dir, name), decoder, &Options{WaitDuration: 1 * time.Millisecond})
 }
 
 func (h *harness) CreateVariable(ctx context.Context, name string, val []byte) error {

--- a/runtimevar/paramstore/paramstore_test.go
+++ b/runtimevar/paramstore/paramstore_test.go
@@ -17,7 +17,6 @@ package paramstore
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -46,8 +45,8 @@ func newHarness(t *testing.T) (drivertest.Harness, error) {
 	return &harness{client: client, session: sess, closer: done}, nil
 }
 
-func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder, wait time.Duration) (driver.Watcher, error) {
-	return h.client.newWatcher(name, decoder, &Options{WaitDuration: wait})
+func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder) (driver.Watcher, error) {
+	return h.client.newWatcher(name, decoder, nil)
 }
 
 func (h *harness) CreateVariable(ctx context.Context, name string, val []byte) error {

--- a/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
+++ b/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
@@ -17,7 +17,6 @@ package runtimeconfigurator
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/google/go-cloud/internal/testing/setup"
 	"github.com/google/go-cloud/runtimevar"
@@ -73,9 +72,8 @@ func newHarness(t *testing.T) (drivertest.Harness, error) {
 	}, nil
 }
 
-func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder, wait time.Duration) (driver.Watcher, error) {
-	rn := resourceName(name)
-	return h.client.newWatcher(rn, decoder, &Options{WaitDuration: wait})
+func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder) (driver.Watcher, error) {
+	return h.client.newWatcher(resourceName(name), decoder, nil)
 }
 
 func (h *harness) CreateVariable(ctx context.Context, name string, val []byte) error {


### PR DESCRIPTION
Fixes #797.

This simplifies the tests by not generally mucking around with the `WaitDuration`.