### PR TITLE
runtimevar/filevar: always add files to the notifier after errors

### DIFF
--- a/runtimevar/filevar/filevar.go
+++ b/runtimevar/filevar/filevar.go
@@ -152,8 +152,6 @@ func (w *watcher) updateState(s, prev *state) *state {
 // It exits when ctx is canceled, and writes any shutdown errors (or
 // nil if there weren't any) to w.closeCh.
 func (w *watcher) watch(ctx context.Context, notifier *fsnotify.Watcher, file string, decoder *runtimevar.Decoder, wait time.Duration) {
-	// addedToNotifier is true iff file has been added to the notifier.
-	addedToNotifier := false
 	var cur *state
 
 	for {
@@ -169,25 +167,20 @@ func (w *watcher) watch(ctx context.Context, notifier *fsnotify.Watcher, file st
 			}
 		}
 
-		// If needed, add the file to the notifier to be watched.
-		if !addedToNotifier {
-			if err := notifier.Add(file); err != nil {
-				// File probably does not exist. Try again later.
-				cur = w.updateState(&state{err: err}, cur)
-				continue
-			}
-			addedToNotifier = true
+		// Add the file to the notifier to be watched. It's fine to be
+		// added multiple times, and fsnotifier is a bit flaky about when
+		// it's needed during renames, so just always try.
+		if err := notifier.Add(file); err != nil {
+			// File probably does not exist. Try again later.
+			cur = w.updateState(&state{err: err}, cur)
+			continue
 		}
 
 		// Read the file.
 		b, err := ioutil.ReadFile(file)
 		if err != nil {
+			// It's likely that the file was deleted.
 			cur = w.updateState(&state{err: err}, cur)
-			// It's likely that the file was deleted. fsnotifier
-			// stops watching a deleted file, so we'll need to
-			// re-add the file once it exists again.
-			notifier.Remove(file)
-			addedToNotifier = false
 			continue
 		}
 


### PR DESCRIPTION
The current code turns out to be broken, as I discovered with Printfs while adding #812. During that test, the `filevar` implementation blocks as it's supposed to, but it does it because it doesn't even notice the `Rename`, not because it notices it and then notices that the errors are the same. It is difficult to test because it's hard to inject different errors.

Updates #812.