### PR TITLE
pubsub: return after t.Error call in goroutine to avoid nil dereference

### DIFF
--- a/internal/pubsub/pubsub_test.go
+++ b/internal/pubsub/pubsub_test.go
@@ -152,6 +152,7 @@ func TestConcurrentReceivesGetAllTheMessages(t *testing.T) {
 						return
 					}
 					t.Error(err)
+					return
 				}
 				mu.Lock()
 				receivedMsgs[string(m.Body)]++


### PR DESCRIPTION
Fixes #829 