### PR TITLE
internal/pubsub/drivertest: minor improvements

### DIFF
--- a/internal/pubsub/drivertest/drivertest.go
+++ b/internal/pubsub/drivertest/drivertest.go
@@ -48,7 +48,7 @@ type Harness interface {
 //
 // newHarness is called exactly once per test to construct a Harness; its Close method
 // will be called when the test is complete.
-func RunConformanceTests(t *testing.T, newHarness func(context.Context) (Harness, error)) {
+func RunConformanceTests(t *testing.T, newHarness func(context.Context, *testing.T) (Harness, error)) {
 	ctx := context.Background()
 	for _, test := range []struct {
 		name string
@@ -59,7 +59,7 @@ func RunConformanceTests(t *testing.T, newHarness func(context.Context) (Harness
 		{"TestErrorOnReceiveFromClosedSubscription", testErrorOnReceiveFromClosedSubscription},
 		{"TestCancelSendReceive", testCancelSendReceive},
 	} {
-		h, err := newHarness(ctx)
+		h, err := newHarness(ctx, t)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/pubsub/mempubsub/conformance_test.go
+++ b/internal/pubsub/mempubsub/conformance_test.go
@@ -38,7 +38,7 @@ func (h *harness) MakeSubscription(_ context.Context, dt driver.Topic) (driver.S
 func (h *harness) Close() {}
 
 func TestConformance(t *testing.T) {
-	drivertest.RunConformanceTests(t, func(context.Context) (drivertest.Harness, error) {
+	drivertest.RunConformanceTests(t, func(context.Context, *testing.T) (drivertest.Harness, error) {
 		return &harness{b: NewBroker([]string{"t"})}, nil
 	})
 }

--- a/internal/pubsub/mempubsub/conformance_test.go
+++ b/internal/pubsub/mempubsub/conformance_test.go
@@ -27,24 +27,18 @@ type harness struct {
 	b *Broker
 }
 
-func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
-	return &harness{b: NewBroker([]string{"t"})}, nil
+func (h *harness) MakeTopic(context.Context) (driver.Topic, error) {
+	return h.b.topic("t"), nil
 }
 
-func (h *harness) MakeTopic(ctx context.Context) (driver.Topic, error) {
-	dt := h.b.topic("t")
-	return dt, nil
+func (h *harness) MakeSubscription(_ context.Context, dt driver.Topic) (driver.Subscription, error) {
+	return newSubscription(dt.(*topic), time.Second), nil
 }
 
-func (h *harness) MakeSubscription(ctx context.Context, dt driver.Topic) (driver.Subscription, error) {
-	t := dt.(*topic)
-	ds := newSubscription(t, time.Second)
-	return ds, nil
-}
-
-func (h *harness) Close() {
-}
+func (h *harness) Close() {}
 
 func TestConformance(t *testing.T) {
-	drivertest.RunConformanceTests(t, newHarness)
+	drivertest.RunConformanceTests(t, func(context.Context) (drivertest.Harness, error) {
+		return &harness{b: NewBroker([]string{"t"})}, nil
+	})
 }


### PR DESCRIPTION
- Make the test table-driven, allowing harness creation/close to happen in one place.

- Remove the HarnessMaker type.

- Remove the testing.T arg from the harness maker (it can just return an error).

- Change empty slices to nil slices (more idiomatic).