### PR TITLE
internal/pubsub/rabbitpubsub: Subscription

### DIFF
--- a/internal/pubsub/rabbitpubsub/doc.go
+++ b/internal/pubsub/rabbitpubsub/doc.go
@@ -20,5 +20,6 @@
 // A Pub/Sub topic is an AMQP exchange. The exchange kind should be "fanout" to match
 // the Pub/Sub model, although publishing will work with any kind of exchange.
 //
-// TODO(jba): describe the subscription side.
+// A Pub/Sub subscription is an AMQP queue. The queue should be bound to exchange
+// that is the topic of the subscription. See the package example for details.
 package rabbitpubsub

--- a/internal/pubsub/rabbitpubsub/examples_test.go
+++ b/internal/pubsub/rabbitpubsub/examples_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/google/go-cloud/internal/pubsub"
 	"github.com/google/go-cloud/internal/pubsub/rabbitpubsub"
@@ -26,7 +27,7 @@ import (
 
 const rabbitURL = "amqp://guest:guest@localhost:5672/"
 
-func Example_publish() {
+func Example() {
 	// Connect to RabbitMQ.
 	conn, err := amqp.Dial(rabbitURL)
 	if err != nil {
@@ -35,7 +36,7 @@ func Example_publish() {
 	}
 	defer conn.Close()
 
-	// Declare a fanout exchange to be used as a Pub/Sub topic.
+	// Declare an exchange and a queue. Bind the queue to the exchange.
 	ch, err := conn.Channel()
 	if err != nil {
 		log.Fatalf("creating channel: %v", err)
@@ -52,9 +53,26 @@ func Example_publish() {
 	if err != nil {
 		log.Fatalf("declaring exchange: %v", err)
 	}
-	ch.Close()
+	const queueName = "my-subscription"
+	q, err := ch.QueueDeclare(
+		queueName,
+		false, // durable
+		false, // delete when unused
+		false, // exclusive
+		false, // no-wait
+		nil)   // arguments
+	if err != nil {
+		log.Fatalf("declaring queue: %v", err)
+	}
+	err = ch.QueueBind(q.Name, q.Name, exchangeName,
+		false, // no-wait
+		nil)   // args
+	if err != nil {
+		log.Fatalf("binding queue: %v", err)
+	}
+	ch.Close() // OpenSubscription will create its own channels.
 
-	// Open a topic, using the exchange name.
+	// Publish a message to the exchange (that is, topic).
 	topic, err := rabbitpubsub.OpenTopic(conn, exchangeName)
 	if err != nil {
 		log.Fatalf("opening topic: %v", err)
@@ -67,5 +85,21 @@ func Example_publish() {
 	if err := topic.Close(); err != nil {
 		log.Fatalf("closing topic: %v", err)
 	}
-	fmt.Println("message sent")
+
+	// Receive the message from the queue (that is, subscription).
+	sub, err := rabbitpubsub.OpenSubscription(conn, queueName)
+	if err != nil {
+		log.Fatalf("opening subscription: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	msg, err := sub.Receive(ctx)
+	if err != nil {
+		log.Fatalf("opening subscription: %v", err)
+	}
+	fmt.Println(string(msg.Body))
+	msg.Ack()
+	if err := sub.Close(); err != nil {
+		log.Fatalf("closing subscription: %v", err)
+	}
 }

--- a/internal/pubsub/rabbitpubsub/rabbit.go
+++ b/internal/pubsub/rabbitpubsub/rabbit.go
@@ -38,7 +38,7 @@ const (
 	// If the message can't be enqueued, return it to the sender rather than silently dropping it.
 	mandatory = true
 
-	// If there are no waiting consumers, enqueue the message instead of dropping it
+	// If there are no waiting consumers, enqueue the message instead of dropping it.
 	notImmediate = false
 )
 

--- a/internal/pubsub/rabbitpubsub/rabbit.go
+++ b/internal/pubsub/rabbitpubsub/rabbit.go
@@ -3,7 +3,10 @@ package rabbitpubsub
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/google/go-cloud/internal/pubsub"
 	"github.com/google/go-cloud/internal/pubsub/driver"
@@ -177,6 +180,169 @@ func toPublishing(m *driver.Message) amqp.Publishing {
 
 // IsRetryable implements driver.Topic.IsRetryable.
 func (*topic) IsRetryable(error) bool {
+	// TODO(jba): figure out what errors can be retried.
+	return false
+}
+
+// OpenSubscription returns a *pubsub.Subscription corresponding to the named queue. The
+// queue must have been previously created (for instance, by using
+// amqp.Channel.QueueDeclare) and bound to an exchange.
+//
+// OpenSubscription uses the supplied amqp.Connection for all communication. It is
+// the caller's responsibility to establish this connection before calling OpenTopic,
+// and to close it when Close has been called on all Subscriptions opened with it.
+//
+// The documentation of the amqp package recommends using separate connections for
+// publishing and subscribing.
+func OpenSubscription(conn *amqp.Connection, name string) (*pubsub.Subscription, error) {
+	// TODO(jba): support context.Context
+	s, err := newSubscription(conn, name)
+	if err != nil {
+		return nil, err
+	}
+	return pubsub.NewSubscription(s), nil
+}
+
+type subscription struct {
+	conn     *amqp.Connection
+	queue    string // the AMQP queue name
+	consumer string // the client-generated name for this particular subscriber
+
+	mu   sync.Mutex
+	ch   *amqp.Channel // AMQP channel used for all communication.
+	delc <-chan amqp.Delivery
+}
+
+var nextConsumer int64 // atomic
+
+func newSubscription(conn *amqp.Connection, name string) (*subscription, error) {
+	s := &subscription{
+		conn:     conn,
+		queue:    name,
+		consumer: fmt.Sprintf("c%d", atomic.AddInt64(&nextConsumer, 1)),
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.establishChannel(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Must be called with s.mu held.
+func (s *subscription) establishChannel() error {
+	// TODO(jba): support context.Context
+	if s.ch != nil {
+		// We already have a channel; nothing to do.
+		return nil
+	}
+	// Create a new channel.
+	ch, err := s.conn.Channel()
+	if err != nil {
+		return err
+	}
+	// Subscribe to messages from the queue.
+	s.delc, err = ch.Consume(s.queue, s.consumer,
+		false, // autoAck
+		false, // exclusive
+		false, // noLocal
+		wait,
+		nil) // args
+	if err != nil {
+		return err
+	}
+	s.ch = ch
+	return nil
+}
+
+// ReceiveBatch implements driver.Subscription.ReceiveBatch.
+func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*driver.Message, error) {
+	// TODO(jba): Improve the timing characteristics of this implementation:
+	// If messages come at a rate just below the timeout, then we can take a long time to gather maxMessages.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.establishChannel(); err != nil {
+		return nil, err
+	}
+
+	// Get all the waiting messages, up to maxMessages.
+	var ms []*driver.Message
+loop:
+	for len(ms) < maxMessages {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+
+		case d, ok := <-s.delc:
+			if !ok { // channel closed
+				s.ch = nil // re-establish the channel
+				if len(ms) > 0 {
+					return ms, nil
+				}
+				// TODO(jba): get more information for a better message
+				return nil, errors.New("delivery channel closed")
+			}
+			ms = append(ms, toMessage(d))
+		default:
+			break loop
+		}
+	}
+	if len(ms) > 0 {
+		return ms, nil
+	}
+	// No messages; sleep for a bit so that the concrete implementation doesn't busy-wait.
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(50 * time.Millisecond):
+		return nil, nil
+	}
+}
+
+// toMessage converts an amqp.Delivery (a received message) to a driver.Message.
+func toMessage(d amqp.Delivery) *driver.Message {
+	// Delivery.Headers is a map[string]interface{}, so we have to
+	// convert each value to a string.
+	md := map[string]string{}
+	for k, v := range d.Headers {
+		md[k] = fmt.Sprint(v)
+	}
+	return &driver.Message{
+		Body:     d.Body,
+		AckID:    d.DeliveryTag,
+		Metadata: md,
+	}
+}
+
+// SendAcks implements driver.Subscription.SendAcks.
+func (s *subscription) SendAcks(ctx context.Context, ackIDs []driver.AckID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.establishChannel(); err != nil {
+		return err
+	}
+
+	// The Ack call doesn't wait for a response, so this loop should execute relatively
+	// quickly.
+	// It wouldn't help to make it concurrent, because Channel.Ack grabs a channel-wide mutex.
+	// (We could consider using multiple channels if performance becomes an issue.)
+	for _, id := range ackIDs {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		err := s.ch.Ack(id.(uint64), false) // multiple=false: acking only this ID
+		if err != nil {
+			s.ch = nil // re-establish channel after an error
+			return err
+		}
+	}
+	return nil
+}
+
+// IsRetryable implements driver.Subscription.IsRetryable.
+func (*subscription) IsRetryable(error) bool {
 	// TODO(jba): figure out what errors can be retried.
 	return false
 }


### PR DESCRIPTION
Implement driver.Subscription: the ReceiveBatch and SendAcks methods.

* internal/pubsub/rabbitpubsub: get returned messages

RabbitMQ will "return" undeliverable messages. The client we're using
exposes these returns as a channel. Receive from this channel so we
can provide a good error when a message us undeliverable.