### PR TITLE
travis: only generate coverage data for the linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ install:
   - "git config --global core.autocrlf input"
   - "git checkout -- ."
   - "go install github.com/google/wire/cmd/wire"
-  - "go install github.com/mattn/goveralls"
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      go install github.com/mattn/goveralls"
+    fi
 
 script:
   - 'internal/testing/runchecks.sh'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - "git checkout -- ."
   - "go install github.com/google/wire/cmd/wire"
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      go install github.com/mattn/goveralls"
+      go install github.com/mattn/goveralls
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - "git checkout -- ."
   - "go install github.com/google/wire/cmd/wire"
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      go install github.com/mattn/goveralls
+      go install github.com/mattn/goveralls;
     fi
 
 script:

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -28,12 +28,17 @@ fi
 
 result=0
 
-# Run Go tests for the root, including coverage.
-go test -race -coverpkg=./... -coverprofile=coverage.out ./... || result=1
-if [ -f coverage.out ]; then
-  # Filter out test and sample packages.
-  grep -v test coverage.out | grep -v samples > coverage2.out
-  goveralls -coverprofile=coverage2.out -service=travis-ci
+# Run Go tests for the root. Only do coverage for the Linux build because it
+# is slow, and Coveralls will only save the last one anyway.
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  go test -race -coverpkg=./... -coverprofile=coverage.out ./... || result=1
+  if [ -f coverage.out ]; then
+    # Filter out test and sample packages.
+    grep -v test coverage.out | grep -v samples > coverage2.out
+    goveralls -coverprofile=coverage2.out -service=travis-ci
+  fi
+else
+  go test -race ./... || result=1
 fi
 wire check ./... || result=1
 

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -28,8 +28,8 @@ fi
 
 result=0
 
-# Run Go tests for the root. Only do coverage for the Linux build because it
-# is slow, and Coveralls will only save the last one anyway.
+# Run Go tests for the root. Only do race and coverage for the Linux build
+# because they are slow, and Coveralls will only save the last one anyway.
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   go test -race -coverpkg=./... -coverprofile=coverage.out ./... || result=1
   if [ -f coverage.out ]; then
@@ -38,7 +38,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     goveralls -coverprofile=coverage2.out -service=travis-ci
   fi
 else
-  go test -race ./... || result=1
+  go test ./... || result=1
 fi
 wire check ./... || result=1
 

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -28,8 +28,8 @@ fi
 
 result=0
 
-# Run Go tests for the root. Only do race and coverage for the Linux build
-# because they are slow, and Coveralls will only save the last one anyway.
+# Run Go tests for the root. Only do coverage for the Linux build
+# because it is slow, and Coveralls will only save the last one anyway.
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   go test -race -coverpkg=./... -coverprofile=coverage.out ./... || result=1
   if [ -f coverage.out ]; then
@@ -38,7 +38,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     goveralls -coverprofile=coverage2.out -service=travis-ci
   fi
 else
-  go test ./... || result=1
+  go test -race ./... || result=1
 fi
 wire check ./... || result=1
 


### PR DESCRIPTION
Now we'll only run `-race` and coverage -> Coveralls for the `linux` build.

Updates #862.