### PR TITLE
tests: run "wire diff" in addition to "wire check"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
 	github.com/google/go-cmp v0.2.0
 	github.com/google/martian v2.1.0+incompatible // indirect
-	github.com/google/wire v0.1.0
+	github.com/google/wire v0.2.0
 	github.com/googleapis/gax-go v2.0.0+incompatible
 	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
 	github.com/gorilla/context v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPg
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/wire v0.1.0 h1:PFFNZLhKJLKe9DHooJzYCxZogNJDIYuB8KfmJmsi/Mk=
 github.com/google/wire v0.1.0/go.mod h1:ptBl5bWD3nzmJHVNwYHV3v4wdtKzBMlU2YbtKQCG9GI=
+github.com/google/wire v0.2.0 h1:l8O+yxT6Kx49nR2KzotgPOQpHFcIvpDY0rGzlCZ1wIE=
+github.com/google/wire v0.2.0/go.mod h1:ptBl5bWD3nzmJHVNwYHV3v4wdtKzBMlU2YbtKQCG9GI=
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=

--- a/internal/contributebot/go.sum
+++ b/internal/contributebot/go.sum
@@ -43,6 +43,7 @@ github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/wire v0.1.0 h1:PFFNZLhKJLKe9DHooJzYCxZogNJDIYuB8KfmJmsi/Mk=
 github.com/google/wire v0.1.0/go.mod h1:ptBl5bWD3nzmJHVNwYHV3v4wdtKzBMlU2YbtKQCG9GI=
+github.com/google/wire v0.2.0/go.mod h1:ptBl5bWD3nzmJHVNwYHV3v4wdtKzBMlU2YbtKQCG9GI=
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -40,12 +40,14 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 else
   go test -race ./... || result=1
 fi
+wire check ./...
 # "wire diff" fails with exit code 1 if any diffs are detected.
 wire diff ./... || (echo "FAIL: wire diff found diffs!" && result=1)
 
 # Run Go tests for each additional module, without coverage.
 for path in "./internal/contributebot" "./samples/appengine"; do
   ( cd "$path" && exec go test ./... ) || result=1
+  ( cd "$path" && exec wire check ./... ) || result=1
   ( cd "$path" && exec wire diff ./... ) || (echo "FAIL: wire diff found diffs!" && result=1)
 done
 exit $result

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -40,11 +40,12 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 else
   go test -race ./... || result=1
 fi
-wire check ./... || result=1
+# "wire diff" fails with exit code 1 if any diffs are detected.
+wire diff ./... || result=1
 
 # Run Go tests for each additional module, without coverage.
 for path in "./internal/contributebot" "./samples/appengine"; do
   ( cd "$path" && exec go test ./... ) || result=1
-  ( cd "$path" && exec wire check ./... ) || result=1
+  ( cd "$path" && exec wire diff ./... ) || result=1
 done
 exit $result

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -41,7 +41,7 @@ else
   go test -race ./... || result=1
 fi
 # "wire diff" fails with exit code 1 if any diffs are detected.
-wire diff ./... || result=1
+wire diff ./... || echo "FAIL: wire diff found diffs!" && result=1
 
 # Run Go tests for each additional module, without coverage.
 for path in "./internal/contributebot" "./samples/appengine"; do

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -41,11 +41,11 @@ else
   go test -race ./... || result=1
 fi
 # "wire diff" fails with exit code 1 if any diffs are detected.
-wire diff ./... || echo "FAIL: wire diff found diffs!" && result=1
+wire diff ./... || (echo "FAIL: wire diff found diffs!" && result=1)
 
 # Run Go tests for each additional module, without coverage.
 for path in "./internal/contributebot" "./samples/appengine"; do
   ( cd "$path" && exec go test ./... ) || result=1
-  ( cd "$path" && exec wire diff ./... ) || result=1
+  ( cd "$path" && exec wire diff ./... ) || (echo "FAIL: wire diff found diffs!" && result=1)
 done
 exit $result

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -40,7 +40,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 else
   go test -race ./... || result=1
 fi
-wire check ./...
+wire check ./... || result=1
 # "wire diff" fails with exit code 1 if any diffs are detected.
 wire diff ./... || (echo "FAIL: wire diff found diffs!" && result=1)
 

--- a/samples/guestbook/wire_gen.go
+++ b/samples/guestbook/wire_gen.go
@@ -119,7 +119,6 @@ func setupGCP(ctx context.Context, flags *cliFlags) (*application, func(), error
 	if err != nil {
 		return nil, nil, err
 	}
-	// This should be gone.
 	params := gcpSQLParams(projectID, flags)
 	db, err := cloudmysql.Open(ctx, remoteCertSource, params)
 	if err != nil {

--- a/samples/guestbook/wire_gen.go
+++ b/samples/guestbook/wire_gen.go
@@ -119,6 +119,7 @@ func setupGCP(ctx context.Context, flags *cliFlags) (*application, func(), error
 	if err != nil {
 		return nil, nil, err
 	}
+	// This should be gone.
 	params := gcpSQLParams(projectID, flags)
 	db, err := cloudmysql.Open(ctx, remoteCertSource, params)
 	if err != nil {


### PR DESCRIPTION
This ensures that the checked-in `wire_gen.go` files in our repository match what a fresh run of `wire` would generate.

Fixes #827.