### PR TITLE
server/sdserver: add cleanup func for Stackdriver exporter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,4 +16,5 @@ Google LLC
 Oleg Kovalov <iamolegkovalov@gmail.com>
 oliverpool <oliverpool@hotmail.fr>
 Sendil Kumar N <sendilkumarn@live.com> <sendil.kn@gmail.com>
+Steve Jiang <steve.jiang@vungle.com>
 Zachary Romero <zacromero3@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -39,6 +39,7 @@ oliverpool <oliverpool@hotmail.fr>
 Robert van Gent <rvangent@google.com> <vangent@gmail.com>
 Ross Light <light@google.com> <ross@zombiezen.com>
 Sendil Kumar N <sendilkumarn@live.com> <sendil.kn@gmail.com>
+Steve Jiang <steve.jiang@vungle.com>
 Tuo Shan <shantuo@google.com> <sturbo89@gmail.com>
 Tyler Bui-Palsulich <26876514+tbpg@users.noreply.github.com>
 Vivek Sekhar <vsekhar@google.com>

--- a/server/sdserver/server.go
+++ b/server/sdserver/server.go
@@ -44,6 +44,9 @@ var Set = wire.NewSet(
 )
 
 // NewExporter returns a new OpenCensus Stackdriver exporter.
+//
+// The second return value is a Wire cleanup function that calls Flush
+// on the exporter.
 func NewExporter(id gcp.ProjectID, ts gcp.TokenSource, mr monitoredresource.Interface) (*stackdriver.Exporter, func(), error) {
 	tokOpt := option.WithTokenSource(oauth2.TokenSource(ts))
 	exp, err := stackdriver.NewExporter(stackdriver.Options{

--- a/server/sdserver/server.go
+++ b/server/sdserver/server.go
@@ -59,11 +59,7 @@ func NewExporter(id gcp.ProjectID, ts gcp.TokenSource, mr monitoredresource.Inte
 		return nil, nil, err
 	}
 
-	cleanup := func() {
-		exp.Flush()
-	}
-
-	return exp, cleanup, err
+	return exp, func() { exp.Flush() }, err
 }
 
 // NewRequestLogger returns a request logger that sends entries to stdout.

--- a/tests/gcp/app/app.go
+++ b/tests/gcp/app/app.go
@@ -42,10 +42,11 @@ func main() {
 	flag.StringVar(&projectID, "project", "", "Project ID to use for the test app")
 
 	flag.Parse()
-	srv, err := initialize(context.Background())
+	srv, cleanup, err := initialize(context.Background())
 	if err != nil {
 		log.Fatalf("unable to initialize server: %v", err)
 	}
+	defer cleanup()
 
 	m := http.NewServeMux()
 	m.HandleFunc("/", handleMain)

--- a/tests/gcp/app/inject.go
+++ b/tests/gcp/app/inject.go
@@ -25,11 +25,11 @@ import (
 	"github.com/google/go-cloud/wire"
 )
 
-func initialize(ctx context.Context) (*server.Server, error) {
+func initialize(ctx context.Context) (*server.Server, func(), error) {
 	wire.Build(
 		appSet,
 		gcpcloud.Services,
 		gcp.DefaultIdentity,
 	)
-	return nil, nil
+	return nil, nil, nil
 }


### PR DESCRIPTION
Adds a cleanup function fto the Stackdriver exporter, so that client
doesn't have to be aware of exporter.Flush() call.

This change also aligns to xrayserver.NewExporter's return signature.

Samples are updated and regenerated as well.

Fixes #867. 

NOTE: I can't seem to find specific tests needed to validate `sdserver`, (or `xrayserver`). Not sure if I had missed something obvious.
