### PR TITLE
internal/pubsub/rabbitpubsub: succeed on open of non-existent resource

### DIFF
--- a/internal/pubsub/rabbitpubsub/examples_test.go
+++ b/internal/pubsub/rabbitpubsub/examples_test.go
@@ -76,10 +76,7 @@ func Example() {
 	ch.Close() // OpenSubscription will create its own channels.
 
 	// Publish a message to the exchange (that is, topic).
-	topic, err := rabbitpubsub.OpenTopic(conn, exchangeName)
-	if err != nil {
-		log.Fatalf("opening topic: %v", err)
-	}
+	topic := rabbitpubsub.OpenTopic(conn, exchangeName)
 	ctx := context.Background()
 	err = topic.Send(ctx, &pubsub.Message{Body: []byte("hello")})
 	if err != nil {
@@ -90,10 +87,7 @@ func Example() {
 	}
 
 	// Receive the message from the queue (that is, subscription).
-	sub, err := rabbitpubsub.OpenSubscription(conn, queueName)
-	if err != nil {
-		log.Fatalf("opening subscription: %v", err)
-	}
+	sub := rabbitpubsub.OpenSubscription(conn, queueName)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	msg, err := sub.Receive(ctx)

--- a/internal/pubsub/rabbitpubsub/rabbit_test.go
+++ b/internal/pubsub/rabbitpubsub/rabbit_test.go
@@ -140,11 +140,8 @@ func TestUnroutable(t *testing.T) {
 	if err := declareExchange(conn, "u"); err != nil {
 		t.Fatal(err)
 	}
-	top, err := newTopic(conn, "u")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = top.SendBatch(ctx, []*driver.Message{{Body: []byte("")}})
+	top := newTopic(conn, "u")
+	err := top.SendBatch(ctx, []*driver.Message{{Body: []byte("")}})
 	if err == nil || !strings.Contains(err.Error(), "NO_ROUTE") {
 		t.Errorf("got %v, want an error with 'NO_ROUTE'", err)
 	}


### PR DESCRIPTION
OpenTopic and OpenSubscription now succeed even if the resource doesn't exist.
They no longer need to return an error.

Also, implement the test harness MakeNonexitentSubscription method.