### PR TITLE
docs: initial page for our GitHub Pages site.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Go Cloud</title>
+  </head>
+  <body>
+    This is the GitHub Page for <a href="https://github.com/google/go-cloud">Go Cloud</a>.
+  </body>
+</html>


### PR DESCRIPTION
We plan to use the GitHub Pages site associated with this repo to
host redirection pages for our gocloud.dev vanity import path.

As a first step, we set up a trivial site to make sure the basic
Pages config is working.

Our site will live in the docs folder of the master branch.