### PR TITLE
docs: add CNAME file

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+gocloud.dev


### PR DESCRIPTION
The CNAME file is part of configuring GitHub Pages to serve from a custom domain.

The [GitHub Help page](https://help.github.com/articles/adding-or-removing-a-custom-domain-for-your-github-pages-site/)
describes how to do this via the UI, but that doesn't work: GitHub complains about committing
to a protected branch. So instead we create CNAME file manually. It's described (vaguely) at
https://help.github.com/articles/troubleshooting-custom-domains.