### PR TITLE
docs: remove

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,8 +1,0 @@
-<html>
-  <head>
-    <title>Go Cloud</title>
-  </head>
-  <body>
-    This is the GitHub Page for <a href="https://github.com/google/go-cloud">Go Cloud</a>.
-  </body>
-</html>


### PR DESCRIPTION
We don't need a docs directory now that our Github Page comes from the gh-pages branch.