### PR TITLE
blob/doc: clean up some docstrings about PageSize

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -366,7 +366,6 @@ func (b *Bucket) ReadAll(ctx context.Context, key string) ([]byte, error) {
 // List returns a ListIterator that can be used to iterate over blobs in a
 // bucket, in lexicographical order of UTF-8 encoded keys. The underlying
 // implementation fetches results in pages.
-// Use ListOptions to control the page size and filtering.
 //
 // A nil ListOptions is treated the same as the zero value.
 //

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -95,7 +95,6 @@ type Attributes struct {
 }
 
 // ListOptions sets options for listing objects in the bucket.
-// TODO(Issue #541): Add Delimiter.
 type ListOptions struct {
 	// Prefix indicates that only results with the given prefix should be
 	// returned.
@@ -114,7 +113,7 @@ type ListOptions struct {
 	Delimiter string
 	// PageSize sets the maximum number of objects to be returned.
 	// 0 means no maximum; driver implementations should choose a reasonable
-	// max.
+	// max. It is guaranteed to be >= 0.
 	PageSize int
 	// PageToken may be filled in with the NextPageToken from a previous
 	// ListPaged call.
@@ -147,7 +146,7 @@ type ListObject struct {
 
 // ListPage represents a page of results return from ListPaged.
 type ListPage struct {
-	// Objects is the slice of objects found. If ListOptions.PageSize != 0,
+	// Objects is the slice of objects found. If ListOptions.PageSize > 0,
 	// it should have at most ListOptions.PageSize entries.
 	//
 	// Objects should be returned in lexicographical order of UTF-8 encoded keys,


### PR DESCRIPTION
Note that the concrete type never actually sets PageSize (PageSize is not exposed to the end user in the concrete type's ListOptions). It is only included as a driver option so that we can test pagination without creating thousands of blobs.