### PR TITLE
wire: add back README.md

### DIFF
--- a/wire/README.md
+++ b/wire/README.md
@@ -1,0 +1,7 @@
+# Wire has moved!
+
+Wire has moved to its own repository: [github.com/google/wire](https://github.com/google/wire)
+
+Read the [announcement][] for more details.
+
+[announcement]: https://groups.google.com/d/msg/go-cloud/4HuWfjDAkOY/Y2tUQdB_BQAJ


### PR DESCRIPTION
Some links may still exist to this directory, so I want to preserve the README to point elsewhere.