### PR TITLE
rabbit: tweak file comments

### DIFF
--- a/internal/pubsub/rabbitpubsub/doc.go
+++ b/internal/pubsub/rabbitpubsub/doc.go
@@ -22,4 +22,8 @@
 //
 // A Pub/Sub subscription is an AMQP queue. The queue should be bound to the exchange
 // that is the topic of the subscription. See the package example for details.
+//
+// This package exposes the following types for As:
+// Topic: *amqp.Connection
+// Subscription: *amqp.Connection
 package rabbitpubsub // import "gocloud.dev/internal/pubsub/rabbitpubsub"

--- a/internal/pubsub/rabbitpubsub/rabbit.go
+++ b/internal/pubsub/rabbitpubsub/rabbit.go
@@ -1,6 +1,17 @@
-// It exposes the following types for As:
-// Topic: *amqp.Connection
-// Subscription: *amqp.Connection
+// Copyright 2018 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rabbitpubsub
 
 import (


### PR DESCRIPTION
A previous PR accidentally lopped off the license comment at the top
of rabbit.go. Restore it.