### PR TITLE
pubsub: make failure output of TestSendReceive more readable

### DIFF
--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -48,6 +48,10 @@ type Message struct {
 	isAcked bool
 }
 
+func (m *Message) String() string {
+	return fmt.Sprintf("{%q %v}", m.Body, m.Metadata)
+}
+
 // Ack acknowledges the message, telling the server that it does not need to be
 // sent again to the associated Subscription. It returns immediately, but the
 // actual ack is sent in the background, and is not guaranteed to succeed.


### PR DESCRIPTION
Fixes #979 

Here's a failing run of the newly added test showing how Messages printed out before this change:
```
[ ~/src/gocloud.dev/internal/pubsub ] go test
--- FAIL: TestMessageString (0.00s)
    pubsub_test.go:40: got &{Body:[] Metadata:map[] ack:<nil> mu:{state:0 sema:0} isAcked:false}, want {"" map[]}
    pubsub_test.go:40: got &{Body:[97 108 108 32 115 121 115 116 101 109 115 32 97 114 101 32 103 111] Metadata:map[] ack:<nil> mu:{state:0 sema:0} isAcked:false}, want {"all systems are go" map[]}
    pubsub_test.go:40: got &{Body:[] Metadata:map[x:1] ack:<nil> mu:{state:0 sema:0} isAcked:false}, want {"" map[x:1]}
FAIL
exit status
```