### PR TITLE
blob/test: add more example tests

### DIFF
--- a/blob/fileblob/example_test.go
+++ b/blob/fileblob/example_test.go
@@ -12,38 +12,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package s3blob_test
+package fileblob_test
 
 import (
 	"context"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"gocloud.dev/blob"
-	"gocloud.dev/blob/s3blob"
+	"gocloud.dev/blob/fileblob"
 )
 
 func Example() {
-	ctx := context.Background()
 
-	// Create an AWS session.
-	// This example uses defaults for finding credentials, which region to use,
-	// etc.
-	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
-	// for more info on available options.
-	sess, err := session.NewSession()
+	// For this example, create a temporary directory.
+	dir, err := ioutil.TempDir("", "go-cloud-fileblob-example")
 	if err != nil {
-		// Handle errror.
-		return
+		log.Fatal(err)
 	}
+	defer os.RemoveAll(dir)
 
-	// Create a *blob.Bucket.
-	_, _ = s3blob.OpenBucket(ctx, "my-bucket", sess, nil)
+	// Create a file-based bucket.
+	_, err = fileblob.OpenBucket(dir, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Output:
 }
 
 func Example_open() {
-	_, _ = blob.Open(context.Background(), "s3://my-bucket")
+	// For this example, create a temporary directory.
+	dir, err := ioutil.TempDir("", "go-cloud-fileblob-example")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	_, err = blob.Open(context.Background(), path.Join("file://", dir))
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Output:
 }

--- a/blob/gcsblob/example_test.go
+++ b/blob/gcsblob/example_test.go
@@ -17,6 +17,7 @@ package gcsblob_test
 import (
 	"context"
 
+	"gocloud.dev/blob"
 	"gocloud.dev/blob/gcsblob"
 	"gocloud.dev/gcp"
 )
@@ -43,6 +44,12 @@ func Example() {
 
 	// Create a *blob.Bucket.
 	_, _ = gcsblob.OpenBucket(ctx, "my-bucket", client, nil)
+
+	// Output:
+}
+
+func Example_open() {
+	_, _ = blob.Open(context.Background(), "gs://my-bucket")
 
 	// Output:
 }

--- a/blob/memblob/example_test.go
+++ b/blob/memblob/example_test.go
@@ -12,38 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package s3blob_test
+package memblob_test
 
 import (
 	"context"
+	"log"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"gocloud.dev/blob"
-	"gocloud.dev/blob/s3blob"
+	"gocloud.dev/blob/memblob"
 )
 
 func Example() {
-	ctx := context.Background()
 
-	// Create an AWS session.
-	// This example uses defaults for finding credentials, which region to use,
-	// etc.
-	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
-	// for more info on available options.
-	sess, err := session.NewSession()
-	if err != nil {
-		// Handle errror.
-		return
-	}
-
-	// Create a *blob.Bucket.
-	_, _ = s3blob.OpenBucket(ctx, "my-bucket", sess, nil)
+	// Create an in-memory bucket.
+	_ = memblob.OpenBucket(nil)
 
 	// Output:
 }
 
 func Example_open() {
-	_, _ = blob.Open(context.Background(), "s3://my-bucket")
-
+	_, err := blob.Open(context.Background(), "mem://")
+	if err != nil {
+		log.Fatal(err)
+	}
 	// Output:
+
 }


### PR DESCRIPTION
These are kind of lame examples, but IMHO they are still useful as concrete examples of how to use the constructors, and it's nice to be consistent about providing them.