### PR TITLE
internal/contributebot: populate cache

### DIFF
--- a/internal/contributebot/main.go
+++ b/internal/contributebot/main.go
@@ -237,6 +237,7 @@ func (w *worker) repoConfig(ctx context.Context, client *github.Client, owner, r
 		ready:  done,
 		config: *defaultRepoConfig(),
 	}
+	w.configCache[cacheKey] = ent
 	w.mu.Unlock()
 	defer func() {
 		ent.fetched = time.Now()


### PR DESCRIPTION
The configCache was never populated.