### PR TITLE
all: order cloud client before resource name

### DIFF
--- a/blob/gcsblob/example_test.go
+++ b/blob/gcsblob/example_test.go
@@ -42,7 +42,7 @@ func Example() {
 	}
 
 	// Create a *blob.Bucket.
-	_, _ = gcsblob.OpenBucket(ctx, "my-bucket", client, nil)
+	_, _ = gcsblob.OpenBucket(ctx, client, "my-bucket", nil)
 
 	// Output:
 }

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -109,7 +109,7 @@ func openURL(ctx context.Context, u *url.URL) (driver.Bucket, error) {
 	if err != nil {
 		return nil, err
 	}
-	return openBucket(ctx, u.Host, client, opts)
+	return openBucket(ctx, client, u.Host, opts)
 }
 
 // Options sets options for constructing a *blob.Bucket backed by GCS.
@@ -131,7 +131,7 @@ type Options struct {
 }
 
 // openBucket returns a GCS Bucket that communicates using the given HTTP client.
-func openBucket(ctx context.Context, bucketName string, client *gcp.HTTPClient, opts *Options) (*bucket, error) {
+func openBucket(ctx context.Context, client *gcp.HTTPClient, bucketName string, opts *Options) (*bucket, error) {
 	if client == nil {
 		return nil, errors.New("gcsblob.OpenBucket: client is required")
 	}
@@ -150,8 +150,8 @@ func openBucket(ctx context.Context, bucketName string, client *gcp.HTTPClient, 
 
 // OpenBucket returns a *blob.Bucket backed by GCS. See the package
 // documentation for an example.
-func OpenBucket(ctx context.Context, bucketName string, client *gcp.HTTPClient, opts *Options) (*blob.Bucket, error) {
-	drv, err := openBucket(ctx, bucketName, client, opts)
+func OpenBucket(ctx context.Context, client *gcp.HTTPClient, bucketName string, opts *Options) (*blob.Bucket, error) {
+	drv, err := openBucket(ctx, client, bucketName, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -245,7 +245,7 @@ func TestOpenBucket(t *testing.T) {
 			}
 
 			// Create driver impl.
-			drv, err := openBucket(ctx, test.bucketName, client, nil)
+			drv, err := openBucket(ctx, client, test.bucketName, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)
 			}
@@ -256,7 +256,7 @@ func TestOpenBucket(t *testing.T) {
 			}
 
 			// Create concrete type.
-			_, err = OpenBucket(ctx, test.bucketName, client, nil)
+			_, err = OpenBucket(ctx, client, test.bucketName, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)
 			}

--- a/blob/s3blob/example_test.go
+++ b/blob/s3blob/example_test.go
@@ -36,7 +36,7 @@ func Example() {
 	}
 
 	// Create a *blob.Bucket.
-	_, _ = s3blob.OpenBucket(ctx, "my-bucket", sess, nil)
+	_, _ = s3blob.OpenBucket(ctx, sess, "my-bucket", nil)
 
 	// Output:
 }

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -81,14 +81,14 @@ func openURL(ctx context.Context, u *url.URL) (driver.Bucket, error) {
 	if err != nil {
 		return nil, err
 	}
-	return openBucket(ctx, u.Host, sess, nil)
+	return openBucket(ctx, sess, u.Host, nil)
 }
 
 // Options sets options for constructing a *blob.Bucket backed by fileblob.
 type Options struct{}
 
 // openBucket returns an S3 Bucket.
-func openBucket(ctx context.Context, bucketName string, sess client.ConfigProvider, _ *Options) (*bucket, error) {
+func openBucket(ctx context.Context, sess client.ConfigProvider, bucketName string, _ *Options) (*bucket, error) {
 	if sess == nil {
 		return nil, errors.New("s3blob.OpenBucket: sess is required")
 	}
@@ -104,8 +104,8 @@ func openBucket(ctx context.Context, bucketName string, sess client.ConfigProvid
 
 // OpenBucket returns a *blob.Bucket backed by S3. See the package documentation
 // for an example.
-func OpenBucket(ctx context.Context, bucketName string, sess client.ConfigProvider, opts *Options) (*blob.Bucket, error) {
-	drv, err := openBucket(ctx, bucketName, sess, opts)
+func OpenBucket(ctx context.Context, sess client.ConfigProvider, bucketName string, opts *Options) (*blob.Bucket, error) {
+	drv, err := openBucket(ctx, sess, bucketName, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -62,7 +62,7 @@ func (h *harness) HTTPClient() *http.Client {
 }
 
 func (h *harness) MakeDriver(ctx context.Context) (driver.Bucket, error) {
-	return openBucket(ctx, bucketName, h.session, nil)
+	return openBucket(ctx, h.session, bucketName, nil)
 }
 
 func (h *harness) Close() {
@@ -184,7 +184,7 @@ func TestOpenBucket(t *testing.T) {
 			}
 
 			// Create driver impl.
-			drv, err := openBucket(ctx, test.bucketName, sess, nil)
+			drv, err := openBucket(ctx, sess, test.bucketName, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)
 			}
@@ -195,7 +195,7 @@ func TestOpenBucket(t *testing.T) {
 			}
 
 			// Create concrete type.
-			_, err = OpenBucket(ctx, test.bucketName, sess, nil)
+			_, err = OpenBucket(ctx, sess, test.bucketName, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)
 			}

--- a/runtimevar/paramstore/paramstore.go
+++ b/runtimevar/paramstore/paramstore.go
@@ -34,15 +34,15 @@ import (
 )
 
 // NewVariable constructs a runtimevar.Variable that watches AWS Parameter Store.
-func NewVariable(name string, sess client.ConfigProvider, decoder *runtimevar.Decoder, opts *Options) (*runtimevar.Variable, error) {
-	w, err := newWatcher(name, sess, decoder, opts)
+func NewVariable(sess client.ConfigProvider, name string, decoder *runtimevar.Decoder, opts *Options) (*runtimevar.Variable, error) {
+	w, err := newWatcher(sess, name, decoder, opts)
 	if err != nil {
 		return nil, err
 	}
 	return runtimevar.New(w), nil
 }
 
-func newWatcher(name string, sess client.ConfigProvider, decoder *runtimevar.Decoder, opts *Options) (*watcher, error) {
+func newWatcher(sess client.ConfigProvider, name string, decoder *runtimevar.Decoder, opts *Options) (*watcher, error) {
 	if opts == nil {
 		opts = &Options{}
 	}

--- a/runtimevar/paramstore/paramstore_test.go
+++ b/runtimevar/paramstore/paramstore_test.go
@@ -44,7 +44,7 @@ func newHarness(t *testing.T) (drivertest.Harness, error) {
 }
 
 func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder) (driver.Watcher, error) {
-	return newWatcher(name, h.session, decoder, nil)
+	return newWatcher(h.session, name, decoder, nil)
 }
 
 func (h *harness) CreateVariable(ctx context.Context, name string, val []byte) error {

--- a/runtimevar/runtimeconfigurator/example_test.go
+++ b/runtimevar/runtimeconfigurator/example_test.go
@@ -52,7 +52,7 @@ func Example() {
 	}
 
 	// Create a variable object to watch for changes.
-	v, err := runtimeconfigurator.NewVariable(name, client, decoder, nil)
+	v, err := runtimeconfigurator.NewVariable(client, name, decoder, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/runtimevar/runtimeconfigurator/runtimeconfigurator.go
+++ b/runtimevar/runtimeconfigurator/runtimeconfigurator.go
@@ -59,15 +59,15 @@ func Dial(ctx context.Context, ts gcp.TokenSource) (pb.RuntimeConfigManagerClien
 // NewVariable constructs a runtimevar.Variable object with this package as the driver
 // implementation. Provide a decoder to unmarshal updated configurations into similar
 // objects during the Watch call.
-func NewVariable(name ResourceName, client pb.RuntimeConfigManagerClient, decoder *runtimevar.Decoder, opts *Options) (*runtimevar.Variable, error) {
-	w, err := newWatcher(name, client, decoder, opts)
+func NewVariable(client pb.RuntimeConfigManagerClient, name ResourceName, decoder *runtimevar.Decoder, opts *Options) (*runtimevar.Variable, error) {
+	w, err := newWatcher(client, name, decoder, opts)
 	if err != nil {
 		return nil, err
 	}
 	return runtimevar.New(w), nil
 }
 
-func newWatcher(name ResourceName,client pb.RuntimeConfigManagerClient, decoder *runtimevar.Decoder, opts *Options) (driver.Watcher, error) {
+func newWatcher(client pb.RuntimeConfigManagerClient, name ResourceName, decoder *runtimevar.Decoder, opts *Options) (driver.Watcher, error) {
 	if opts == nil {
 		opts = &Options{}
 	}

--- a/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
+++ b/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
@@ -73,7 +73,7 @@ func newHarness(t *testing.T) (drivertest.Harness, error) {
 }
 
 func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder) (driver.Watcher, error) {
-	return newWatcher(resourceName(name), h.client, decoder, nil)
+	return newWatcher(h.client, resourceName(name), decoder, nil)
 }
 
 func (h *harness) CreateVariable(ctx context.Context, name string, val []byte) error {

--- a/samples/guestbook/inject_aws.go
+++ b/samples/guestbook/inject_aws.go
@@ -52,7 +52,7 @@ func setupAWS(ctx context.Context, flags *cliFlags) (*application, func(), error
 // awsBucket is a Wire provider function that returns the S3 bucket based on the
 // command-line flags.
 func awsBucket(ctx context.Context, cp awsclient.ConfigProvider, flags *cliFlags) (*blob.Bucket, error) {
-	return s3blob.OpenBucket(ctx, flags.bucket, cp, nil)
+	return s3blob.OpenBucket(ctx, cp, flags.bucket, nil)
 }
 
 // awsSQLParams is a Wire provider function that returns the RDS SQL connection
@@ -70,7 +70,7 @@ func awsSQLParams(flags *cliFlags) *rdsmysql.Params {
 // awsMOTDVar is a Wire provider function that returns the Message of the Day
 // variable from SSM Parameter Store.
 func awsMOTDVar(ctx context.Context, sess awsclient.ConfigProvider, flags *cliFlags) (*runtimevar.Variable, error) {
-	return paramstore.NewVariable(flags.motdVar, sess, runtimevar.StringDecoder, &paramstore.Options{
+	return paramstore.NewVariable(sess, flags.motdVar, runtimevar.StringDecoder, &paramstore.Options{
 		WaitDuration: flags.motdVarWaitTime,
 	})
 }

--- a/samples/guestbook/inject_gcp.go
+++ b/samples/guestbook/inject_gcp.go
@@ -53,7 +53,7 @@ func setupGCP(ctx context.Context, flags *cliFlags) (*application, func(), error
 // gcpBucket is a Wire provider function that returns the GCS bucket based on
 // the command-line flags.
 func gcpBucket(ctx context.Context, flags *cliFlags, client *gcp.HTTPClient) (*blob.Bucket, error) {
-	return gcsblob.OpenBucket(ctx, flags.bucket, client, nil)
+	return gcsblob.OpenBucket(ctx, client, flags.bucket, nil)
 }
 
 // gcpSQLParams is a Wire provider function that returns the Cloud SQL
@@ -78,7 +78,7 @@ func gcpMOTDVar(ctx context.Context, client pb.RuntimeConfigManagerClient, proje
 		Config:    flags.runtimeConfigName,
 		Variable:  flags.motdVar,
 	}
-	v, err := runtimeconfigurator.NewVariable(name, client, runtimevar.StringDecoder, &runtimeconfigurator.Options{
+	v, err := runtimeconfigurator.NewVariable(client, name, runtimevar.StringDecoder, &runtimeconfigurator.Options{
 		WaitDuration: flags.motdVarWaitTime,
 	})
 	if err != nil {

--- a/samples/guestbook/wire_gen.go
+++ b/samples/guestbook/wire_gen.go
@@ -216,7 +216,7 @@ var (
 // awsBucket is a Wire provider function that returns the S3 bucket based on the
 // command-line flags.
 func awsBucket(ctx context.Context, cp client.ConfigProvider, flags *cliFlags) (*blob.Bucket, error) {
-	return s3blob.OpenBucket(ctx, flags.bucket, cp, nil)
+	return s3blob.OpenBucket(ctx, cp, flags.bucket, nil)
 }
 
 // awsSQLParams is a Wire provider function that returns the RDS SQL connection
@@ -234,7 +234,7 @@ func awsSQLParams(flags *cliFlags) *rdsmysql.Params {
 // awsMOTDVar is a Wire provider function that returns the Message of the Day
 // variable from SSM Parameter Store.
 func awsMOTDVar(ctx context.Context, sess client.ConfigProvider, flags *cliFlags) (*runtimevar.Variable, error) {
-	return paramstore.NewVariable(flags.motdVar, sess, runtimevar.StringDecoder, &paramstore.Options{
+	return paramstore.NewVariable(sess, flags.motdVar, runtimevar.StringDecoder, &paramstore.Options{
 		WaitDuration: flags.motdVarWaitTime,
 	})
 }
@@ -244,7 +244,7 @@ func awsMOTDVar(ctx context.Context, sess client.ConfigProvider, flags *cliFlags
 // gcpBucket is a Wire provider function that returns the GCS bucket based on
 // the command-line flags.
 func gcpBucket(ctx context.Context, flags *cliFlags, client2 *gcp.HTTPClient) (*blob.Bucket, error) {
-	return gcsblob.OpenBucket(ctx, flags.bucket, client2, nil)
+	return gcsblob.OpenBucket(ctx, client2, flags.bucket, nil)
 }
 
 // gcpSQLParams is a Wire provider function that returns the Cloud SQL
@@ -269,7 +269,7 @@ func gcpMOTDVar(ctx context.Context, client2 runtimeconfig.RuntimeConfigManagerC
 		Config:    flags.runtimeConfigName,
 		Variable:  flags.motdVar,
 	}
-	v, err := runtimeconfigurator.NewVariable(name, client2, runtimevar.StringDecoder, &runtimeconfigurator.Options{
+	v, err := runtimeconfigurator.NewVariable(client2, name, runtimevar.StringDecoder, &runtimeconfigurator.Options{
 		WaitDuration: flags.motdVarWaitTime,
 	})
 	if err != nil {

--- a/samples/tutorial/setup.go
+++ b/samples/tutorial/setup.go
@@ -52,7 +52,7 @@ func setupGCP(ctx context.Context, bucket string) (*blob.Bucket, error) {
 	if err != nil {
 		return nil, err
 	}
-	return gcsblob.OpenBucket(ctx, bucket, c, nil)
+	return gcsblob.OpenBucket(ctx, c, bucket, nil)
 }
 
 // setupAWS creates a connection to Simple Cloud Storage Service (S3).
@@ -67,5 +67,5 @@ func setupAWS(ctx context.Context, bucket string) (*blob.Bucket, error) {
 		Credentials: credentials.NewEnvCredentials(),
 	}
 	s := session.Must(session.NewSession(c))
-	return s3blob.OpenBucket(ctx, bucket, s, nil)
+	return s3blob.OpenBucket(ctx, s, bucket, nil)
 }


### PR DESCRIPTION
This makes more "general" parameters (i.e. what connection is this using) come first in the parameter list so that each argument is increasing specificity. See discussion on #988 for more background.

Fixes #988