### PR TITLE
internal/contributebot: ignore check run and push events

### DIFF
--- a/internal/contributebot/main.go
+++ b/internal/contributebot/main.go
@@ -122,7 +122,7 @@ func (w *worker) receive(ctx context.Context) error {
 			handleErr = w.receiveIssueEvent(ctx, event)
 		case *github.PullRequestEvent:
 			handleErr = w.receivePullRequestEvent(ctx, event)
-		case *github.PingEvent, *github.InstallationEvent, *github.CheckSuiteEvent:
+		case *github.PingEvent, *github.InstallationEvent, *github.CheckRunEvent, *github.CheckSuiteEvent, *github.PushEvent:
 			// No-op.
 		default:
 			log.Printf("Unhandled webhook event type %s (%T) for %s", eventType, event, id)


### PR DESCRIPTION
These events will be necessary for merges, but currently aren't used. Adding them now to clear them from the subscription backlog.

Updates #687