### PR TITLE
runtimevar/doc: refresh runtimevar concrete type documentation

### DIFF
--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -12,8 +12,26 @@
 // See the License for the specific language governing permissions and
 // limtations under the License.
 
-// Package runtimevar provides an interface for reading runtime variables and
-// ability to detect changes and get updates on those variables.
+// Package runtimevar provides an easy and portable way to watch runtime
+// configuration variables.
+//
+// It provides a blocking method that returns a Snapshot of the variable value
+// whenever a change is detected.
+//
+// Subpackages contain distinct implementations of runtimevar for various
+// providers, including Cloud and on-prem solutions. For example, "etcdvar"
+// supports variables stored in etcd. Your application should import one of
+// these provider-specific subpackages and use its exported function(s) to
+// create a *Variable; do not use the New function in this package. For example:
+//
+//  v, err := etcdvar.New("my variable", etcdClient, runtimevar.JSONDecode, nil)
+//  ...
+//
+// Then, write your application code using the *Variable type. You can
+// easily reconfigure your initialization code to choose a different provider.
+// You can develop your application locally using filevar or constantvar, and
+// deploy it to multiple Cloud providers. You may find
+// http://github.com/google/wire useful for managing your initialization code.
 package runtimevar // import "gocloud.dev/runtimevar"
 
 import (
@@ -27,47 +45,45 @@ import (
 	"gocloud.dev/runtimevar/driver"
 )
 
-// Snapshot contains a variable and metadata about it.
+// Snapshot contains a snapshot of a variable's value and metadata about it.
+// It is intended to be read-only for users.
 type Snapshot struct {
-	// Value is an object containing a runtime variable  The type of
-	// this object is set by the driver and it should always be the same type for the same Variable
-	// object. A driver implementation can provide the ability to configure the object type and a
-	// decoding scheme where variables are stored as bytes in the backend service.  Clients
-	// should not mutate this object as it can be accessed by multiple goroutines.
+	// Value contains the value of the variable.
+	// The type for Value depends on the provider; for most providers, it depends
+	// on the decoder used when creating Variable.
 	Value interface{}
 
-	// UpdateTime is the time when the last changed was detected.
+	// UpdateTime is the time when the last change was detected.
 	UpdateTime time.Time
 }
 
-// Variable provides the ability to read runtime variables with its blocking Watch method.
+// Variable provides an easy and portable way to watch runtime configuration
+// variables. To create a Variable, use constructors found in provider-specific
+// subpackages.
 type Variable struct {
 	watcher  driver.Watcher
 	nextCall time.Time
 	prev     driver.State
 }
 
-// New constructs a Variable object given a driver.Watcher implementation.
+// New creates a new *Variable based on a specific driver implementation.
+// End users should use subpackages to construct a *Variable instead of this
+// function; see the package documentation for details.
 func New(w driver.Watcher) *Variable {
 	return &Variable{watcher: w}
 }
 
-// Watch blocks until there are variable changes, the Context's Done channel
-// closes or a new error occurs.
+// Watch returns a Snapshot of the current value of the variable.
 //
-// If the variable changes, the method returns a Snapshot object containing the
-// updated value.
+// The first call to Watch will block while reading the variable from the
+// provider, and will return the resulting Snapshot or error. If an error is
+// returned, the returned Snapshot is a zero value and should be ignored.
 //
-// If method returns an error, the returned Snapshot object is a zero value and cannot be used.
+// Subsequent calls will block until the variable's value changes or a different
+// error occurs.
 //
-// The first call to this method should return the current variable unless there are errors in
-// retrieving the value.
-//
-// Users should not call this method from multiple goroutines as implementations may not guarantee
-// safety in data access.  It is typical to use only one goroutine calling this method in a loop.
-//
-// To stop this function from blocking, caller can passed in Context object constructed via
-// WithCancel and call the cancel function.
+// Watch is not goroutine-safe; typical use is to call it in a single
+// goroutine in a loop.
 func (c *Variable) Watch(ctx context.Context) (Snapshot, error) {
 	for {
 		wait := c.nextCall.Sub(time.Now())
@@ -96,7 +112,7 @@ func (c *Variable) Watch(ctx context.Context) (Snapshot, error) {
 	}
 }
 
-// Close cleans up any resources used by the Variable object.
+// Close closes the Variable; don't call Watch after this.
 func (c *Variable) Close() error {
 	err := c.watcher.Close()
 	return wrapError(err)

--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -24,7 +24,9 @@
 // these provider-specific subpackages and use its exported function(s) to
 // create a *Variable; do not use the New function in this package. For example:
 //
-//  v, err := etcdvar.New("my variable", etcdClient, runtimevar.JSONDecode, nil)
+//  var v *runtimevar.Variable
+//  var err error
+//  v, err = etcdvar.New("my variable", etcdClient, runtimevar.JSONDecode, nil)
 //  ...
 //
 // Then, write your application code using the *Variable type. You can
@@ -148,7 +150,7 @@ type Decode func([]byte, interface{}) error
 // construct other Decoders.
 type Decoder struct {
 	typ reflect.Type
-	fn Decode
+	fn  Decode
 }
 
 // NewDecoder returns a Decoder that uses fn to decode a slice of bytes into


### PR DESCRIPTION
Hopefully this makes it more consistent with blob and improves the overall documentation for the major types.

I'll send separate updates to the Decoder stuff down below in this file, and to the providers + driver + example.

Updates #896.