### PR TITLE
pubsub: add MessageValue type and Message.Value()

### DIFF
--- a/internal/pubsub/drivertest/drivertest.go
+++ b/internal/pubsub/drivertest/drivertest.go
@@ -17,7 +17,6 @@
 package drivertest // import "gocloud.dev/internal/pubsub/drivertest"
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"strconv"
@@ -184,7 +183,7 @@ func testSendReceive(t *testing.T, newHarness HarnessMaker) {
 	defer cleanup()
 
 	// Send to the topic.
-	var want []*pubsub.Message
+	var want []pubsub.MessageValue
 	for i := 0; i < 3; i++ {
 		m := &pubsub.Message{
 			Body:     []byte(strconv.Itoa(i)),
@@ -193,23 +192,23 @@ func testSendReceive(t *testing.T, newHarness HarnessMaker) {
 		if err := top.Send(ctx, m); err != nil {
 			t.Fatal(err)
 		}
-		want = append(want, m)
+		want = append(want, m.Value())
 	}
 
 	// Receive from the subscription.
-	var got []*pubsub.Message
+	var got []pubsub.MessageValue
 	for i := 0; i < len(want); i++ {
 		m, err := sub.Receive(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		got = append(got, m)
+		got = append(got, m.Value())
 		m.Ack()
 	}
 
 	// Check that the received messages match the sent ones.
-	less := func(x, y *pubsub.Message) bool { return bytes.Compare(x.Body, y.Body) < 0 }
-	if diff := cmp.Diff(got, want, cmpopts.SortSlices(less), cmpopts.IgnoreUnexported(pubsub.Message{})); diff != "" {
+	less := func(x, y pubsub.MessageValue) bool { return x.Body < y.Body }
+	if diff := cmp.Diff(got, want, cmpopts.SortSlices(less)); diff != "" {
 		t.Error(diff)
 	}
 }

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -61,6 +61,24 @@ func (m *Message) Ack() {
 	m.isAcked = true
 }
 
+// Value returns a MessageValue based on the Message receiver.
+func (m *Message) Value() MessageValue {
+	return MessageValue{
+		Body:     string(m.Body),
+		Metadata: m.Metadata,
+	}
+}
+
+// MessageValue contains the exported fields of a Message with a UTF8 Body, making it
+// easier to read and compare in diffs and other output.
+type MessageValue struct {
+	// Body contains the content of the message.
+	Body string
+
+	// Metadata has key/value metadata for the message.
+	Metadata map[string]string
+}
+
 // Topic publishes messages to all its subscribers.
 type Topic struct {
 	driver  driver.Topic


### PR DESCRIPTION
Fixes #979 

Here is a crude comparison of how the diffs look before and after this change. These are from different test failures but hopefully the idea comes across anyway:

Before:
```
[ ~/src/gocloud.dev/internal/pubsub/gcppubsub ] go test -record
--- FAIL: TestConformance (1.78s)
    --- FAIL: TestConformance/TestSendReceive (1.14s)
        replay.go:196: Recording into golden file testdata/TestConformance/TestSendReceive.replay
        drivertest.go:213: {[]*pubsub.Message}[0->?]:
            	-: &pubsub.Message{Body: []uint8{0x34, 0x31}, ack: (func())(0x01436670), isAcked: true}
            	+: <non-existent>
```

After:
```
[ ~/src/gocloud.dev/internal/pubsub/gcppubsub ] go test -record ./...
--- FAIL: TestConformance (4.05s)
    --- FAIL: TestConformance/TestSendReceive (3.45s)
        replay.go:196: Recording into golden file testdata/TestConformance/TestSendReceive.replay
        drivertest.go:212: {[]pubsub.MessageValue}:
            	-: []pubsub.MessageValue(nil)
            	+: []pubsub.MessageValue{{Body: "0", Metadata: map[string]string{"a": "0"}}, {Body: "1", Metadata: map[string]string{"a": "1"}}, {Body: "2", Metadata: map[string]string{"a": "2"}}}
```