### PR TITLE
all: make the User-Agent we sent to GCP include the api name

### DIFF
--- a/blob/fileblob/attrs.go
+++ b/blob/fileblob/attrs.go
@@ -30,7 +30,7 @@ var errAttrsExt = fmt.Errorf("file extension %q is reserved", attrsExt)
 type xattrs struct {
 	ContentType string            `json:"user.content_type"`
 	Metadata    map[string]string `json:"user.metadata"`
-	MD5         []byte `json:"md5"`
+	MD5         []byte            `json:"md5"`
 }
 
 // setAttrs creates a "path.attrs" file along with blob to store the attributes,

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -140,7 +140,7 @@ func openBucket(ctx context.Context, client *gcp.HTTPClient, bucketName string, 
 		return nil, errors.New("gcsblob.OpenBucket: bucketName is required")
 	}
 	// We wrap the provided http.Client to add a Go Cloud User-Agent.
-	c, err := storage.NewClient(ctx, option.WithHTTPClient(useragent.HTTPClient(&client.Client)))
+	c, err := storage.NewClient(ctx, option.WithHTTPClient(useragent.HTTPClient(&client.Client, "blob")))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pubsub/gcppubsub/gcppubsub_test.go
+++ b/internal/pubsub/gcppubsub/gcppubsub_test.go
@@ -25,7 +25,6 @@ import (
 	"gocloud.dev/internal/pubsub/driver"
 	"gocloud.dev/internal/pubsub/drivertest"
 	"gocloud.dev/internal/testing/setup"
-	"google.golang.org/api/option"
 )
 
 const (
@@ -54,12 +53,12 @@ type harness struct {
 }
 
 func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
-	conn, done := setup.NewGCPgRPCConn(ctx, t, EndPoint)
-	pubClient, err := raw.NewPublisherClient(ctx, option.WithGRPCConn(conn))
+	conn, done := setup.NewGCPgRPCConn(ctx, t, endPoint, "pubsub")
+	pubClient, err := PublisherClient(ctx, conn)
 	if err != nil {
 		return nil, fmt.Errorf("making publisher client: %v", err)
 	}
-	subClient, err := raw.NewSubscriberClient(ctx, option.WithGRPCConn(conn))
+	subClient, err := SubscriberClient(ctx, conn)
 	if err != nil {
 		return nil, fmt.Errorf("making subscription client: %v", err)
 	}

--- a/internal/testing/setup/setup.go
+++ b/internal/testing/setup/setup.go
@@ -117,14 +117,14 @@ func NewGCPClient(ctx context.Context, t *testing.T) (client *gcp.HTTPClient, rt
 // results are recorded in a replay file.
 // Otherwise, the session reads a replay file and runs the test as a replay,
 // which never makes an outgoing RPC and uses fake credentials.
-func NewGCPgRPCConn(ctx context.Context, t *testing.T, endPoint string) (*grpc.ClientConn, func()) {
+func NewGCPgRPCConn(ctx context.Context, t *testing.T, endPoint, api string) (*grpc.ClientConn, func()) {
 	mode := recorder.ModeReplaying
 	if *Record {
 		mode = recorder.ModeRecording
 	}
 
 	opts, done := replay.NewGCPDialOptions(t, mode, t.Name()+".replay")
-	opts = append(opts, grpc.WithUserAgent(useragent.GoCloudUserAgent))
+	opts = append(opts, useragent.GRPCDialOption(api))
 	if mode == recorder.ModeRecording {
 		// Add credentials for real RPCs.
 		creds, err := gcp.DefaultCredentials(ctx)

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -17,16 +17,37 @@
 package useragent // import "gocloud.dev/internal/useragent"
 
 import (
+	"fmt"
 	"net/http"
+
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
 )
 
-// GoCloudUserAgent is the User-Agent to set for Go Cloud requests to GCP.
-const GoCloudUserAgent = "go-cloud/0.1"
+const (
+	prefix  = "go-cloud"
+	version = "0.9.0"
+)
+
+// ClientOption returns an option.ClientOption that sets a Go Cloud User-Agent.
+func ClientOption(api string) option.ClientOption {
+	return option.WithUserAgent(userAgentString(api))
+}
+
+// GRPCDialOption returns a grpc.DialOption that sets a Go Cloud User-Agent.
+func GRPCDialOption(api string) grpc.DialOption {
+	return grpc.WithUserAgent(userAgentString(api))
+}
+
+func userAgentString(api string) string {
+	return fmt.Sprintf("%s/%s/%s", prefix, api, version)
+}
 
 // userAgentTransport wraps an http.RoundTripper, adding a User-Agent header
 // to each request.
 type userAgentTransport struct {
 	base http.RoundTripper
+	api  string
 }
 
 func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -37,14 +58,14 @@ func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error
 		newReq.Header[k] = vv
 	}
 	// Append to the User-Agent string to preserve other information.
-	newReq.Header.Set("User-Agent", req.UserAgent()+" "+GoCloudUserAgent)
+	newReq.Header.Set("User-Agent", req.UserAgent()+" "+userAgentString(t.api))
 	return t.base.RoundTrip(&newReq)
 }
 
-// HTTPClient wraps client and appends GoCloudUserAgent to the User-Agent header
-// for all requests.
-func HTTPClient(client *http.Client) *http.Client {
+// HTTPClient wraps client and appends a Go Cloud string to the User-Agent
+// header for all requests.
+func HTTPClient(client *http.Client, api string) *http.Client {
 	c := *client
-	c.Transport = &userAgentTransport{base: c.Transport}
+	c.Transport = &userAgentTransport{base: c.Transport, api: api}
 	return &c
 }

--- a/runtimevar/runtimeconfigurator/runtimeconfigurator.go
+++ b/runtimevar/runtimeconfigurator/runtimeconfigurator.go
@@ -57,7 +57,7 @@ func Dial(ctx context.Context, ts gcp.TokenSource) (pb.RuntimeConfigManagerClien
 	conn, err := grpc.DialContext(ctx, endPoint,
 		grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")),
 		grpc.WithPerRPCCredentials(oauth.TokenSource{TokenSource: ts}),
-		grpc.WithUserAgent(useragent.GoCloudUserAgent),
+		useragent.GRPCDialOption("runtimevar"),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
+++ b/runtimevar/runtimeconfigurator/runtimeconfigurator_test.go
@@ -54,7 +54,7 @@ type harness struct {
 
 func newHarness(t *testing.T) (drivertest.Harness, error) {
 	ctx := context.Background()
-	conn, done := setup.NewGCPgRPCConn(ctx, t, endPoint)
+	conn, done := setup.NewGCPgRPCConn(ctx, t, endPoint, "runtimevar")
 	client := pb.NewRuntimeConfigManagerClient(conn)
 	rn := resourceName("")
 	// Ignore errors if the config already exists.

--- a/server/sdserver/server.go
+++ b/server/sdserver/server.go
@@ -51,7 +51,7 @@ var Set = wire.NewSet(
 func NewExporter(id gcp.ProjectID, ts gcp.TokenSource, mr monitoredresource.Interface) (*stackdriver.Exporter, func(), error) {
 	opts := []option.ClientOption{
 		option.WithTokenSource(oauth2.TokenSource(ts)),
-		option.WithUserAgent(useragent.GoCloudUserAgent),
+		useragent.ClientOption("server"),
 	}
 	exp, err := stackdriver.NewExporter(stackdriver.Options{
 		ProjectID:               string(id),


### PR DESCRIPTION
This will allow us to differentiate between requests from different APIs.

I also added a couple of helpers for `gcppubsub` that set the option.

Fixes #941.
Fixes #144.