### PR TITLE
.travis.yml: generate gh-pages import redirects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,24 @@ env:
   global:
   - GOPROXY=https://storage.googleapis.com/go-cloud-modules/
   - GO111MODULE=on
+
+jobs:
+  include:
+    - stage: imports
+      os: linux
+      script: ./internal/imports/makeimports.sh
+      deploy:
+        provider: pages
+        fqdn: gocloud.dev
+        skip-cleanup: true
+        local-dir: makeimports-output
+        github-token: $GITHUB_TOKEN  # set in the Settings page of the repo
+        keep-history: true
+        verbose: true  # temporarily, while verifying
+        on:
+          branch: master
+      
+stages:
+  - test
+  - name: imports
+    if: branch = master


### PR DESCRIPTION
Provide the necessary Travis config to create our gh-pages site,
with import-path redirects for our packages, on pushes to master.

Requires a personal GitHub access token, which I've already set up
on the Travis settings page.

The only way to test this is to submit the PR and see what happens.