### PR TITLE
internal/contributebot: use repository ID for branches in fork check

### DIFF
--- a/internal/contributebot/process.go
+++ b/internal/contributebot/process.go
@@ -189,7 +189,7 @@ func processPullRequestEvent(cfg *repoConfig, data *pullRequestData) *pullReques
 
 	// If the pull request is not from a fork, close it and request that it comes
 	// from a fork instead.
-	if data.Action == "opened" && !pr.GetHead().GetRepo().GetFork() {
+	if data.Action == "opened" && pr.GetHead().GetRepo().GetID() == pr.GetBase().GetRepo().GetID() {
 		edits.Close = true
 		edits.AddComments = append(edits.AddComments, branchesInForkCloseResponse)
 		// Short circuit since we're closing anyway.


### PR DESCRIPTION
Filled out more of the pull request data in tests to make more realistic.

Fixes #1034