### PR TITLE
.travis.yml: remove windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 os:
   - linux
   - osx
-  - windows
 
 language: go
 go_import_path: gocloud.dev


### PR DESCRIPTION
Temporary, so we can observe the gh-pages deploy.