### PR TITLE
internal/contributebot: make fork branch check configurable

### DIFF
--- a/internal/contributebot/README.md
+++ b/internal/contributebot/README.md
@@ -50,6 +50,11 @@ The configuration file is in JSON format and has the following keys:
     match the title pattern. This can use
     <a href="https://help.github.com/articles/about-writing-and-formatting-on-github/">GitHub-flavored Markdown</a>.
   </dd>
+  <dt><code>require_pull_request_fork_branch</code></dt>
+  <dd>
+    If <code>true</code>, then pull requests coming from branches on the same
+    repository will be automatically closed. Defaults to <code>true</code>.
+  </dd>
 </dl>
 
 ## DevOps Setup

--- a/internal/contributebot/process.go
+++ b/internal/contributebot/process.go
@@ -33,19 +33,21 @@ const inProgressLabel = "in progress"
 const branchesInForkCloseResponse = "Please create pull requests from your own fork instead of from branches in the main repository. Also, please delete this branch."
 
 type repoConfig struct {
-	IssueTitlePattern        string `json:"issue_title_pattern"`
-	IssueTitleResponse       string `json:"issue_title_response"`
-	PullRequestTitlePattern  string `json:"pull_request_title_pattern"`
-	PullRequestTitleResponse string `json:"pull_request_title_response"`
+	RequirePullRequestForkBranch bool   `json:"require_pull_request_fork_branch"`
+	IssueTitlePattern            string `json:"issue_title_pattern"`
+	IssueTitleResponse           string `json:"issue_title_response"`
+	PullRequestTitlePattern      string `json:"pull_request_title_pattern"`
+	PullRequestTitleResponse     string `json:"pull_request_title_response"`
 }
 
 func defaultRepoConfig() *repoConfig {
 	const titlePattern = `^([a-z0-9./-]+|[A-Z_]+): .*$`
 	return &repoConfig{
-		IssueTitlePattern:        titlePattern,
-		IssueTitleResponse:       "Please edit the title of this issue with the name of the affected package, or \"all\", followed by a colon, followed by a short summary of the issue. Example: `blob/gcsblob: not blobby enough`.",
-		PullRequestTitlePattern:  titlePattern,
-		PullRequestTitleResponse: "Please edit the title of this pull request with the name of the affected package, or \"all\", followed by a colon, followed by a short summary of the change. Example: `blob/gcsblob: improve comments`.",
+		RequirePullRequestForkBranch: true,
+		IssueTitlePattern:            titlePattern,
+		IssueTitleResponse:           "Please edit the title of this issue with the name of the affected package, or \"all\", followed by a colon, followed by a short summary of the issue. Example: `blob/gcsblob: not blobby enough`.",
+		PullRequestTitlePattern:      titlePattern,
+		PullRequestTitleResponse:     "Please edit the title of this pull request with the name of the affected package, or \"all\", followed by a colon, followed by a short summary of the change. Example: `blob/gcsblob: improve comments`.",
 	}
 }
 
@@ -185,7 +187,7 @@ func processPullRequestEvent(cfg *repoConfig, data *pullRequestData) *pullReques
 
 	// If the pull request is not from a fork, close it and request that it comes
 	// from a fork instead.
-	if data.Action == "opened" && pr.GetHead().GetRepo().GetID() == pr.GetBase().GetRepo().GetID() {
+	if cfg.RequirePullRequestForkBranch && data.Action == "opened" && pr.GetHead().GetRepo().GetID() == pr.GetBase().GetRepo().GetID() {
 		edits.Close = true
 		edits.AddComments = append(edits.AddComments, branchesInForkCloseResponse)
 		// Short circuit since we're closing anyway.


### PR DESCRIPTION
This simplifies development testing on test repositories, since a fork
would require a different user or organization.