### PR TITLE
travis: run Windows only on master and ignore failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 os:
   - linux
   - osx
-  - windows
 
 language: go
 go_import_path: gocloud.dev
@@ -38,6 +37,12 @@ env:
 
 jobs:
   include:
+    # Only run Windows build job on master. This would be listed in `os:` above,
+    # but matrix expansion does not allow conditionals. See:
+    # https://docs.travis-ci.com/user/conditional-builds-stages-jobs/#conditional-jobs
+    - os: windows
+      if: branch = master AND type = push
+    # Generate imports for GitHub Pages.
     - stage: imports
       os: linux
       script: ./internal/imports/makeimports.sh
@@ -51,8 +56,12 @@ jobs:
         verbose: true  # temporarily, while verifying
         on:
           branch: master
+  # Windows is in early access and has been unreliable. Don't block builds on it,
+  # but provide data (for now).
+  allow_failures:
+    - os: windows
       
 stages:
   - test
   - name: imports
-    if: branch = master
+    if: branch = master AND type = push

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -28,11 +28,6 @@ fi
 
 result=0
 
-if [[ "$TRAVIS_OS_NAME" == "windows" && ( "$TRAVIS_EVENT_TYPE" == "push" || "$TRAVIS_EVENT_TYPE" == "pull_request" ) ]]; then
-	echo "Skipping windows build for event type '$TRAVIS_EVENT_TYPE'"
-	exit 0
-fi
-
 # Run Go tests for the root. Only do coverage for the Linux build
 # because it is slow, and Coveralls will only save the last one anyway.
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then


### PR DESCRIPTION
There is a low false positive rate, but a very high false negative rate to Windows builds. This allows us to keep the information, but prevents failures from emitting build errors.

(Not sending this out for review immediately because I want to observe the Travis behavior first.)

Fixes #920