### PR TITLE
all/tests: extend some examples/tests to improve coverage

### DIFF
--- a/blob/gcsblob/example_test.go
+++ b/blob/gcsblob/example_test.go
@@ -16,22 +16,35 @@ package gcsblob_test
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/gcsblob"
 	"gocloud.dev/gcp"
+	"golang.org/x/oauth2/google"
 )
+
+// jsonCreds is a fake GCP JSON credentials file.
+const jsonCreds = `
+{
+  "type": "service_account",
+  "project_id": "my-project-id"
+}
+`
 
 func Example() {
 	ctx := context.Background()
 
-	// Load credentials for GCP.
-	// This example uses the default approach; see
-	// https://cloud.google.com/docs/authentication/production
+	// Get GCP credentials.
+	// Here we use a fake JSON credentials file, but you could also use
+	// gcp.DefaultCredentials(ctx) to use the default GCP credentials from
+	// the environment.
+	// See https://cloud.google.com/docs/authentication/production
 	// for more info on alternatives.
-	creds, err := gcp.DefaultCredentials(ctx)
+	creds, err := google.CredentialsFromJSON(ctx, []byte(jsonCreds))
 	if err != nil {
-		return
+		log.Fatal(err)
 	}
 
 	// Create an HTTP client.
@@ -43,9 +56,19 @@ func Example() {
 	}
 
 	// Create a *blob.Bucket.
-	_, _ = gcsblob.OpenBucket(ctx, client, "my-bucket", nil)
+	b, err := gcsblob.OpenBucket(ctx, client, "my-bucket", nil)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	_, err = b.ReadAll(ctx, "my-key")
+	if err != nil {
+		// This is expected due to the fake credentials we used above.
+		fmt.Println("ReadAll failed due to invalid credentials")
+	}
 
 	// Output:
+	// ReadAll failed due to invalid credentials
 }
 
 func Example_open() {

--- a/runtimevar/drivertest/drivertest.go
+++ b/runtimevar/drivertest/drivertest.go
@@ -594,6 +594,10 @@ func testAs(t *testing.T, newHarness HarnessMaker, st AsTest) {
 	if err := st.ErrorCheck(gotErr); err != nil {
 		t.Error(err)
 	}
+	var dummy string
+	if s.As(&dummy) {
+		t.Error(errors.New("want Snapshot.As to return false when Snapshot is zero value"))
+	}
 	if err := v.Close(); err != nil {
 		t.Error(err)
 	}

--- a/runtimevar/etcdvar/etcdvar_test.go
+++ b/runtimevar/etcdvar/etcdvar_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/embed"
+	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	"gocloud.dev/runtimevar"
 	"gocloud.dev/runtimevar/driver"
 	"gocloud.dev/runtimevar/drivertest"
@@ -101,6 +102,11 @@ func (verifyAs) SnapshotCheck(s *runtimevar.Snapshot) error {
 }
 
 func (verifyAs) ErrorCheck(err error) error {
-	// etcdvar returns a fmt.Errorf error for "not found", so we can't do much here.
+	// etcdvar returns a fmt.Errorf error for "not found", so this is expected
+	// to fail.
+	var to rpctypes.EtcdError
+	if runtimevar.ErrorAs(err, &to) {
+		return errors.New("ErrorAs expected to fail")
+	}
 	return nil
 }

--- a/runtimevar/runtimeconfigurator/example_test.go
+++ b/runtimevar/runtimeconfigurator/example_test.go
@@ -16,11 +16,12 @@ package runtimeconfigurator_test
 
 import (
 	"context"
+	"fmt"
 	"log"
 
-	"gocloud.dev/gcp"
 	"gocloud.dev/runtimevar"
 	"gocloud.dev/runtimevar/runtimeconfigurator"
+	"golang.org/x/oauth2/google"
 )
 
 // MyConfig is a sample configuration struct.
@@ -29,11 +30,24 @@ type MyConfig struct {
 	Port   int
 }
 
+// jsonCreds is a fake GCP JSON credentials file.
+const jsonCreds = `
+{
+  "type": "service_account",
+  "project_id": "my-project-id"
+}
+`
+
 func ExampleNewVariable() {
 	ctx := context.Background()
 
 	// Get GCP credentials and dial the server.
-	creds, err := gcp.DefaultCredentials(ctx)
+	// Here we use a fake JSON credentials file, but you could also use
+	// gcp.DefaultCredentials(ctx) to use the default GCP credentials from
+	// the environment.
+	// See https://cloud.google.com/docs/authentication/production
+	// for more info on alternatives.
+	creds, err := google.CredentialsFromJSON(ctx, []byte(jsonCreds))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -63,10 +77,15 @@ func ExampleNewVariable() {
 	defer v.Close()
 
 	// You can now read the current value of the variable from v.
-	snapshot, err := v.Watch(context.Background())
+	snapshot, err := v.Watch(ctx)
 	if err != nil {
-		log.Fatal(err)
+		// This is expected due to the fake credentials we used above.
+		fmt.Println("Watch failed due to invalid credentials")
+		return
 	}
-	// The resulting runtimevar.Snapshot.Value will be of type MyConfig.
+	// The resulting runtimevar.Snapshot.Value would be of type MyConfig.
 	log.Printf("Snapshot.Value: %#v", snapshot.Value.(MyConfig))
+
+	// Output:
+	// Watch failed due to invalid credentials
 }


### PR DESCRIPTION
Example tests don't run at all if there's no expected output, so I've modified a couple of GCP ones to use (dummy) JSON credentials and actually run. The previous method of using default credentials was wonky because it depended on the environment (e.g., behavior is different on my machine vs on Travis).

The other changes are small ones to improve code coverage on runtimevar; hopefully the `coveralls` output shows that.

Updates #676.