### PR TITLE
travis: don't allow windows builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,11 +56,7 @@ jobs:
         verbose: true  # temporarily, while verifying
         on:
           branch: master
-  # Windows is in early access and has been unreliable. Don't block builds on it,
-  # but provide data (for now).
-  allow_failures:
-    - os: windows
-      
+
 stages:
   - test
   - name: imports

--- a/internal/contributebot/go.mod
+++ b/internal/contributebot/go.mod
@@ -3,7 +3,7 @@ module gocloud.dev/internal/contributebot
 replace gocloud.dev => ../..
 
 require (
-	cloud.google.com/go v0.30.0
+	cloud.google.com/go v0.34.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/google/go-cmp v0.2.0
 	github.com/google/go-github v17.0.0+incompatible

--- a/internal/contributebot/go.sum
+++ b/internal/contributebot/go.sum
@@ -1,10 +1,12 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-cloud.google.com/go v0.30.0 h1:xKvyLgk56d0nksWq49J0UyGEeUIicTl4+UBiX1NPX9g=
-cloud.google.com/go v0.30.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
+cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 contrib.go.opencensus.io/exporter/aws v0.0.0-20180906190126-dd54a7ef511e/go.mod h1:uu1P0UCM/6RbsMrgPa98ll8ZcHM858i/AD06a9aLRCA=
 contrib.go.opencensus.io/exporter/stackdriver v0.6.0/go.mod h1:QeFzMJDAw8TXt5+aRaSuE8l5BwaMIOIlaVkBOPRuMuw=
 contrib.go.opencensus.io/integrations/ocsql v0.1.2/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+github.com/Azure/azure-pipeline-go v0.1.8/go.mod h1:XA1kFWRVhSK+KNFiOhfv83Fv8L9achrP7OxIzeTn1Yg=
+github.com/Azure/azure-storage-blob-go v0.0.0-20181023070848-cf01652132cc/go.mod h1:oGfmITT1V6x//CswqY2gtAHND+xIP64/qL7a5QJix0Y=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20181009230506-ac834ce67862/go.mod h1:aJ4qN3TfrelA6NZ6AXsXRfmEVaYin3EDbSPJrKS8OXo=
 github.com/aws/aws-sdk-go v1.15.27/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.15.57 h1:inht07/mRNnvV4uAjjVgTVD7/rF+j0mXllYcNQxDgGA=
@@ -47,6 +49,7 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
+github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.2.0 h1:l8O+yxT6Kx49nR2KzotgPOQpHFcIvpDY0rGzlCZ1wIE=
 github.com/google/wire v0.2.0/go.mod h1:ptBl5bWD3nzmJHVNwYHV3v4wdtKzBMlU2YbtKQCG9GI=
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
@@ -146,6 +149,7 @@ google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmE
 google.golang.org/grpc v1.15.0 h1:Az/KuahOM4NAidTEuJCv/RonAA7rYsTPkqXVjr+8OOw=
 google.golang.org/grpc v1.15.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.39.0 h1:Jf2sFGT+sAd7i+4ftUN1Jz90uw8XNH8NXbbOY16taA8=

--- a/internal/contributebot/sync.go
+++ b/internal/contributebot/sync.go
@@ -156,7 +156,8 @@ func gitSync(ctx context.Context, gitPath string, dst, src remoteGitBranch) erro
 // runCommand starts a subprocess and waits for it to finish. If the subprocess
 // exits with failure, the returned error's message will include the combined
 // stdout and stderr. If the context is cancelled, then runCommand sends the
-// subprocess SIGTERM (this differs from CommandContext, which sends SIGKILL).
+// subprocess os.Interrupt (this differs from CommandContext, which sends
+// os.Kill).
 func runCommand(ctx context.Context, dir string, exe string, args []string) error {
 	c := exec.Command(exe, args...)
 	c.Dir = dir

--- a/internal/contributebot/sync.go
+++ b/internal/contributebot/sync.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/google/go-github/github"
-	"golang.org/x/sys/unix"
 )
 
 // syncParams is the set of parameters to syncPullRequest.
@@ -174,7 +173,7 @@ func runCommand(ctx context.Context, dir string, exe string, args []string) erro
 		select {
 		case <-ctx.Done():
 			// Ignore error: if we can't signal, it's likely because the process already exited.
-			_ = c.Process.Signal(unix.SIGTERM)
+			_ = c.Process.Signal(os.Interrupt)
 		case <-waitDone:
 		}
 		// No further synchronization back to the main goroutine, because signal is uninterruptable and


### PR DESCRIPTION
It seems that by setting this, the windows builds are not even running. They get started, and then are aborted to continue to the next stage. See any build [here](https://travis-ci.com/google/go-cloud/builds).

The Windows build is actually broken right now due to a Contribute use of `unix`, and we didn't notice at all; I'd rather have occasional flakiness.

Fixes #920.