### PR TITLE
travis: don't run wire checks or non-core module tests except on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-os:
-  - linux
-  - osx
-
 language: go
 go_import_path: gocloud.dev
 go: "1.11.x"
@@ -37,6 +33,8 @@ env:
 
 jobs:
   include:
+    - os: linux
+    - os: osx
     # Only run Windows build job on master. This would be listed in `os:` above,
     # but matrix expansion does not allow conditionals. See:
     # https://docs.travis-ci.com/user/conditional-builds-stages-jobs/#conditional-jobs

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
     # but matrix expansion does not allow conditionals. See:
     # https://docs.travis-ci.com/user/conditional-builds-stages-jobs/#conditional-jobs
     - os: windows
-      if: branch = master #AND type = push
+      if: branch = master AND type = push
     # Generate imports for GitHub Pages.
     - stage: imports
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
     # but matrix expansion does not allow conditionals. See:
     # https://docs.travis-ci.com/user/conditional-builds-stages-jobs/#conditional-jobs
     - os: windows
-      if: branch = master AND type = push
+      if: branch = master #AND type = push
     # Generate imports for GitHub Pages.
     - stage: imports
       os: linux

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -39,7 +39,10 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   fi
 else
   go test -race ./... || result=1
+  # No need to run wire checks or other module tests on OSs other than linux.
+  exit $result
 fi
+
 wire check ./... || result=1
 # "wire diff" fails with exit code 1 if any diffs are detected.
 wire diff ./... || { echo "FAIL: wire diff found diffs!" && result=1; }


### PR DESCRIPTION
There's no real reason to keep ContributeBot running on windows, and there's no reason to do the wire checks per-OS either.

Also configure the OSs to run all in one place. Pretty sure the semantics are the same, but I think this is more clear.

Updates #920.