### PR TITLE
internal/admin: add "ready to submit" label

### DIFF
--- a/internal/admin/main.tf
+++ b/internal/admin/main.tf
@@ -46,6 +46,7 @@ module "go_cloud_repo" {
     "go",
     "aws",
     "gcp",
+    "azure",
   ]
 }
 

--- a/internal/admin/repository/main.tf
+++ b/internal/admin/repository/main.tf
@@ -158,3 +158,10 @@ resource "github_issue_label" "needs_info" {
   color       = "d876e3"
   description = "Further discussion or clarification is necessary"
 }
+
+resource "github_issue_label" "ready_to_submit" {
+  repository  = "${github_repository.repo.name}"
+  name        = "ready to submit"
+  color       = "0e8a16"
+  description = "Pull request has been approved and should be merged once tests pass"
+}


### PR DESCRIPTION
Contribute Bot will use this to track pull requests that should be kept in sync with the head branch. Adding the label before Contribute Bot uses it.

Also add "azure" label to Go Cloud repository, since that seems to have been added manually.

Updates #687

Output from `terraform plan`:

```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + module.go_cloud_repo.github_issue_label.ready_to_submit
      id:          <computed>
      color:       "0e8a16"
      description: "Pull request has been approved and should be merged once tests pass"
      etag:        <computed>
      name:        "ready to submit"
      repository:  "go-cloud"
      url:         <computed>

  + module.wire_repo.github_issue_label.ready_to_submit
      id:          <computed>
      color:       "0e8a16"
      description: "Pull request has been approved and should be merged once tests pass"
      etag:        <computed>
      name:        "ready to submit"
      repository:  "wire"
      url:         <computed>


Plan: 2 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------
```