### PR TITLE
blob/azureblob: fill in MD5 for ListObject and Attributes

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -375,6 +375,7 @@ func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes,
 		ContentLanguage:    blobPropertiesResponse.ContentLanguage(),
 		ContentType:        blobPropertiesResponse.ContentType(),
 		Size:               blobPropertiesResponse.ContentLength(),
+		MD5:                blobPropertiesResponse.ContentMD5(),
 		ModTime:            blobPropertiesResponse.LastModified(),
 		Metadata:           blobPropertiesResponse.NewMetadata(),
 		AsFunc: func(i interface{}) bool {
@@ -447,6 +448,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 			Key:     blobInfo.Name,
 			ModTime: blobInfo.Properties.LastModified,
 			Size:    *blobInfo.Properties.ContentLength,
+			MD5:     blobInfo.Properties.ContentMD5,
 			IsDir:   false,
 			AsFunc: func(i interface{}) bool {
 				p, ok := i.(*azblob.BlobItem)


### PR DESCRIPTION
I think this got lost in the shuffle because it was added to `blob` while the Azure Pull Request was in flight. The conformance tests didn't notice because `MD5` is not a required field, so `nil` was accepted as valid.

Fixes #1087.