### PR TITLE
blob/s3blob: add query options to url parsing

### DIFF
--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -25,6 +25,9 @@
 // https://docs.aws.amazon.com/sdk-for-go/api/aws/session/.
 // The following query options are supported:
 //  - region: The AWS region for requests; sets aws.Config.Region.
+//  - endpoint: The endpoint URL (hostname only or fully qualified URI); sets aws.Config.Endpoint.
+//  - disableSSL: A value of "true" disables SSL when sending requests; sets aws.Config.DisableSSL.
+//  - s3ForcePathStyle: A value of "true" forces the request to use path-style addressing; sets aws.Config.S3ForcePathStyle.
 // Example URL:
 //  s3://mybucket?region=us-east-1
 //
@@ -76,6 +79,15 @@ func openURL(ctx context.Context, u *url.URL) (driver.Bucket, error) {
 
 	if region := q["region"]; len(region) > 0 {
 		cfg.Region = aws.String(region[0])
+	}
+	if endpoint := q["endpoint"]; len(endpoint) > 0 {
+		cfg.Endpoint = aws.String(endpoint[0])
+	}
+	if disableSSL := q["disableSSL"]; len(disableSSL) > 0 {
+		cfg.DisableSSL = aws.Bool(disableSSL[0] == "true")
+	}
+	if s3ForcePathStyle := q["s3ForcePathStyle"]; len(s3ForcePathStyle) > 0 {
+		cfg.S3ForcePathStyle = aws.Bool(s3ForcePathStyle[0] == "true")
 	}
 	sess, err := session.NewSession(cfg)
 	if err != nil {


### PR DESCRIPTION
Adds endpoint, disableSSL, and s3ForcePathStyle query options.

There are more options in aws.Config, but these three are the ones I needed in order to use the package with a local minio instance.

At least endpoint would be required by other s3-compatible services.
