### PR TITLE
azure: rework azureblob constructors and make them usable via Wire

### DIFF
--- a/azure/azurecloud/azurecloud.go
+++ b/azure/azurecloud/azurecloud.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package azurecloud contains Wire providers for GCP services.
+// Package azurecloud contains Wire providers for Azure services.
 package azurecloud // import "gocloud.dev/azure/azurecloud"
 
 import (

--- a/azure/azurecloud/azurecloud.go
+++ b/azure/azurecloud/azurecloud.go
@@ -1,0 +1,28 @@
+// Copyright 2019 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package azurecloud contains Wire providers for GCP services.
+package azurecloud // import "gocloud.dev/azure/azurecloud"
+
+import (
+	"github.com/google/wire"
+	"gocloud.dev/blob/azureblob"
+)
+
+// Azure is a Wire provider set that includes the default wiring for all
+// Microsoft Azure services in this repository, but does not include
+// credentials. Individual services may require additional configuration.
+var Azure = wire.NewSet(
+	azureblob.NewPipeline,
+)

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -60,13 +60,16 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/google/uuid"
+	"github.com/google/wire"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/driver"
 
@@ -77,9 +80,12 @@ import (
 type Options struct {
 	// Credential represents the authorizer for SignedURL.
 	// Required to use SignedURL.
-	// See https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1#shared-access-signature-parameters.
-	// A SharedKeyCredential can be constructed with azblob.NewSharedKeyCredential("AccountName", "AccountKey").
 	Credential *azblob.SharedKeyCredential
+
+	// SASToken can be provided along with anonymous credentials to use
+	// delegated privileges.
+	// See https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1#shared-access-signature-parameters.
+	SASToken SASToken
 }
 
 // Azure does not handle backslashes in the blob key well. As a workaround, all
@@ -108,105 +114,110 @@ const (
 	defaultUploadBlockSize          = 8 * 1024 * 1024 // configure the upload buffer size
 )
 
-// ServiceURLFromAccountKey returns a URL to an Azure Blob Service using shared key authorization.
-// For more information, see https://godoc.org/github.com/Azure/azure-storage-blob-go/azblob.
-func ServiceURLFromAccountKey(accountName, accountKey string) (*azblob.ServiceURL, error) {
-	if accountName == "" {
-		return nil, errors.New("azureblob: accountName is required")
-	}
-	if accountKey == "" {
-		return nil, errors.New("azureblob: accountKey is required")
-	}
-	credential, _ := azblob.NewSharedKeyCredential(accountName, accountKey)
-	pipeline := azblob.NewPipeline(credential, azblob.PipelineOptions{
-		Telemetry: azblob.TelemetryOptions{
-			Value: useragent.AzureUserAgentPrefix("blob"),
-		},
-	})
-	blobURL := makeBlobStorageURL(accountName)
-	serviceURL := azblob.NewServiceURL(*blobURL, pipeline)
-	return &serviceURL, nil
-}
-
-// ServiceURLFromSASToken returns a URL to an Azure Blob Service using shared access signature authorization.
-// For more information, see https://godoc.org/github.com/Azure/azure-storage-blob-go/azblob.
-func ServiceURLFromSASToken(accountName, sasToken string) (*azblob.ServiceURL, error) {
-	if accountName == "" {
-		return nil, errors.New("azureblob: accountName is required")
-	}
-	if sasToken == "" {
-		return nil, errors.New("azureblob: sasToken is required")
-	}
-	credential := azblob.NewAnonymousCredential()
-	pipeline := azblob.NewPipeline(credential, azblob.PipelineOptions{
-		Telemetry: azblob.TelemetryOptions{
-			Value: useragent.AzureUserAgentPrefix("blob"),
-		},
-	})
-
-	blobURL := makeBlobStorageURL(accountName)
-	blobURL.RawQuery = sasToken
-	serviceURL := azblob.NewServiceURL(*blobURL, pipeline)
-
-	return &serviceURL, nil
-}
-
-func makeBlobStorageURL(accountName string) *url.URL {
-	endpoint := fmt.Sprintf("https://%s.blob.core.windows.net", accountName)
-	u, _ := url.Parse(endpoint)
-	return u
-}
-
 func init() {
 	blob.Register("azblob", openURL)
 }
 
 func openURL(ctx context.Context, u *url.URL) (driver.Bucket, error) {
-	// local type to unmarshal cred_file
 	type AzureCreds struct {
-		AccountName string
-		AccountKey  string
-		SASToken    string
+		AccountName AccountName
+		AccountKey  AccountKey
+		SASToken    SASToken
+	}
+	ac := AzureCreds{}
+	if credPath := u.Query()["cred_path"]; len(credPath) > 0 {
+		f, err := ioutil.ReadFile(credPath[0])
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(f, &ac)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Use default credential info from the environment.
+		ac.AccountKey = DefaultAccountKey()
+		ac.AccountName = DefaultAccountName()
+		ac.SASToken = DefaultSASToken()
 	}
 
-	q := u.Query()
-	opts := &Options{}
-	ac := &AzureCreds{}
-	credPath := q["cred_path"]
-	if len(credPath) == 0 {
-		return nil, errors.New("azureblob: cred_path query parameter is required")
-	}
-
-	f, err := ioutil.ReadFile(credPath[0])
-	if err != nil {
-		return nil, err
-	}
-
-	err = json.Unmarshal(f, ac)
-	if err != nil {
-		return nil, err
-	}
-
+	// azblob.Credential is an interface; we will use either a SharedKeyCredential
+	// or anonymous credentials. If the former, we will also fill in
+	// Options.Credential so that SignedURL will work.
+	var credential azblob.Credential
+	var sharedKeyCred *azblob.SharedKeyCredential
 	if ac.AccountKey != "" {
-		serviceURL, err := ServiceURLFromAccountKey(ac.AccountName, ac.AccountKey)
+		var err error
+		sharedKeyCred, err = NewCredential(ac.AccountName, ac.AccountKey)
 		if err != nil {
 			return nil, err
 		}
-
-		credential, err := azblob.NewSharedKeyCredential(ac.AccountName, ac.AccountKey)
-		if err != nil {
-			return nil, err
-		}
-
-		opts.Credential = credential
-		return openBucket(ctx, serviceURL, u.Host, opts)
+		credential = sharedKeyCred
+	} else {
+		credential = azblob.NewAnonymousCredential()
 	}
+	pipeline := NewPipeline(credential, azblob.PipelineOptions{})
+	return openBucket(ctx, pipeline, ac.AccountName, u.Host, &Options{
+		Credential: sharedKeyCred,
+		SASToken:   ac.SASToken,
+	})
+}
 
-	serviceURL, err := ServiceURLFromSASToken(ac.AccountName, ac.SASToken)
-	if err != nil {
-		return nil, err
-	}
-	return openBucket(ctx, serviceURL, u.Host, opts)
+// DefaultIdentity is a Wire provider set that provides an Azure storage
+// account name, key, and SharedKeyCredential from environment variables.
+var DefaultIdentity = wire.NewSet(
+	DefaultAccountName,
+	DefaultAccountKey,
+	NewCredential,
+	wire.Value(azblob.PipelineOptions{}),
+)
+
+// SASTokenIdentity is a Wire provider set that provides an Azure storage
+// account name, SASToken, and anonymous credential from environment variables.
+var SASTokenIdentity = wire.NewSet(
+	DefaultAccountName,
+	DefaultSASToken,
+	azblob.NewAnonymousCredential,
+	wire.Value(azblob.PipelineOptions{}),
+)
+
+// AccountName is an Azure storage account name.
+type AccountName string
+
+// AccountKey is an Azure storage account key (primary or secondary).
+type AccountKey string
+
+// SASToken is an Azure shared access signature.
+// https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1
+type SASToken string
+
+// DefaultAccountName loads the Azure storage account name from the
+// AZURE_STORAGE_ACCOUNT environment variable.
+func DefaultAccountName() AccountName {
+	return AccountName(os.Getenv("AZURE_STORAGE_ACCOUNT"))
+}
+
+// DefaultAccountKey loads the Azure storage account key (primary or secondary)
+// from the AZURE_STORAGE_KEY environment variable.
+func DefaultAccountKey() AccountKey {
+	return AccountKey(os.Getenv("AZURE_STORAGE_KEY"))
+}
+
+// DefaultSASToken loads a Azure SAS token from the AZURE_STORAGE_SAS_TOKEN
+// environment variable.
+func DefaultSASToken() SASToken {
+	return SASToken(os.Getenv("AZURE_STORAGE_SAS_TOKEN"))
+}
+
+// NewCredential created a SharedKeyCredential.
+func NewCredential(accountName AccountName, accountKey AccountKey) (*azblob.SharedKeyCredential, error) {
+	return azblob.NewSharedKeyCredential(string(accountName), string(accountKey))
+}
+
+// NewPipeline creates a Pipeline for making HTTP requests to Azure.
+func NewPipeline(credential azblob.Credential, opts azblob.PipelineOptions) pipeline.Pipeline {
+	opts.Telemetry.Value = useragent.AzureUserAgentPrefix("blob") + opts.Telemetry.Value
+	return azblob.NewPipeline(credential, opts)
 }
 
 // bucket represents a Azure Storage Account Container, which handles read,
@@ -221,26 +232,42 @@ type bucket struct {
 }
 
 // OpenBucket returns a *blob.Bucket backed by Azure Storage Account. See the package
-// documentation for an example.
-func OpenBucket(ctx context.Context, serviceURL *azblob.ServiceURL, containerName string, opts *Options) (*blob.Bucket, error) {
-	b, err := openBucket(ctx, serviceURL, containerName, opts)
+// documentation for an example and
+// https://godoc.org/github.com/Azure/azure-storage-blob-go/azblob
+// for more details.
+func OpenBucket(ctx context.Context, pipeline pipeline.Pipeline, accountName AccountName, containerName string, opts *Options) (*blob.Bucket, error) {
+	b, err := openBucket(ctx, pipeline, accountName, containerName, opts)
 	if err != nil {
 		return nil, err
 	}
 	return blob.NewBucket(b), nil
 }
 
-func openBucket(ctx context.Context, serviceURL *azblob.ServiceURL, containerName string, opts *Options) (*bucket, error) {
-	if serviceURL == nil {
-		return nil, errors.New("azureblob.OpenBucket: serviceURL is required")
+func openBucket(ctx context.Context, pipeline pipeline.Pipeline, accountName AccountName, containerName string, opts *Options) (*bucket, error) {
+	if pipeline == nil {
+		return nil, errors.New("azureblob.OpenBucket: pipeline is required")
+	}
+	if accountName == "" {
+		return nil, errors.New("azureblob.OpenBucket: accountName is required")
 	}
 	if containerName == "" {
 		return nil, errors.New("azureblob.OpenBucket: containerName is required")
 	}
+	if opts == nil {
+		opts = &Options{}
+	}
+	blobURL, err := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net", accountName))
+	if err != nil {
+		return nil, err
+	}
+	serviceURL := azblob.NewServiceURL(*blobURL, pipeline)
+	if opts.SASToken != "" {
+		blobURL.RawQuery = string(opts.SASToken)
+	}
 	return &bucket{
 		name:         containerName,
 		pageMarkers:  map[string]azblob.Marker{},
-		serviceURL:   serviceURL,
+		serviceURL:   &serviceURL,
 		containerURL: serviceURL.NewContainerURL(containerName),
 		opts:         opts,
 	}, nil
@@ -487,7 +514,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 // SignedURL implements driver.SignedURL.
 func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedURLOptions) (string, error) {
 	if b.opts.Credential == nil {
-		return "", errors.New("to use SignedURL, you must call OpenBucket with a valid Options.Credential")
+		return "", errors.New("to use SignedURL, you must call OpenBucket with a non-nil Options.Credential")
 	}
 	blockBlobURL := b.blockBlobURL(key)
 	srcBlobParts := azblob.NewBlobURLParts(blockBlobURL.URL())

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -169,6 +169,7 @@ var DefaultIdentity = wire.NewSet(
 	DefaultAccountName,
 	DefaultAccountKey,
 	NewCredential,
+	wire.Bind(new(azblob.Credential), new(azblob.SharedKeyCredential)),
 	wire.Value(azblob.PipelineOptions{}),
 )
 
@@ -209,7 +210,7 @@ func DefaultSASToken() SASToken {
 	return SASToken(os.Getenv("AZURE_STORAGE_SAS_TOKEN"))
 }
 
-// NewCredential created a SharedKeyCredential.
+// NewCredential creates a SharedKeyCredential.
 func NewCredential(accountName AccountName, accountKey AccountKey) (*azblob.SharedKeyCredential, error) {
 	return azblob.NewSharedKeyCredential(string(accountName), string(accountKey))
 }

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -211,7 +211,7 @@ func (verifyContentLanguage) ListObjectCheck(o *blob.ListObject) error {
 func TestOpenBucket(t *testing.T) {
 	tests := []struct {
 		description   string
-		nilPipeline bool
+		nilPipeline   bool
 		accountName   AccountName
 		containerName string
 		want          string
@@ -219,7 +219,7 @@ func TestOpenBucket(t *testing.T) {
 	}{
 		{
 			description:   "nil pipeline results in error",
-			nilPipeline: true,
+			nilPipeline:   true,
 			accountName:   "myaccount",
 			containerName: "foo",
 			wantErr:       true,

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -16,6 +16,7 @@ package azureblob
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -59,29 +60,27 @@ import (
 
 const (
 	bucketName  = "go-cloud-bucket"
-	accountName = "gocloudblobtests"
+	accountName = AccountName("gocloudblobtests")
 )
 
 var pathToSettingsFile = flag.String("settingsfile", "", "path to .json file containing Azure Storage AccountKey and AccountName(required for --record)")
 
-// TestSettings sets the Azure Storage Account name and Key for constructing the test harness.
-type TestSettings struct {
-	AccountName string
-	AccountKey  string
-	pipeline    pipeline.Pipeline
-}
-
 type harness struct {
-	settings   TestSettings
+	pipeline   pipeline.Pipeline
+	credential *azblob.SharedKeyCredential
 	closer     func()
 	httpClient *http.Client
 }
 
 func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
-	s := &TestSettings{}
-
+	var key AccountKey
 	if *setup.Record {
-		// Fetch the AccountName and AccountKey settings from the setting file.
+		// In Record mode, we load credentials from a JSON settings file.
+		type TestSettings struct {
+			AccountName AccountName
+			AccountKey  AccountKey
+		}
+		s := &TestSettings{}
 		if *pathToSettingsFile == "" {
 			t.Fatalf("--settingsfile is required in --record mode.")
 		}
@@ -93,16 +92,20 @@ func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
 		if err != nil {
 			t.Fatalf("Cannot load settings file %v: %v", *pathToSettingsFile, err)
 		}
+		if s.AccountName != accountName {
+			t.Fatalf("Please update the accountName constant to match your settings file so future records work (%q vs %q)", s.AccountName, accountName)
+		}
+		key = s.AccountKey
 	} else {
-		// In replay mode, the AccountName must match the name used for recording.
-		s.AccountName = accountName
-		s.AccountKey = "FAKE_KEY"
+		// In replay mode, we use fake credentials.
+		key = AccountKey(base64.StdEncoding.EncodeToString([]byte("FAKECREDS")))
 	}
-
-	p, done, httpClient := setup.NewAzureTestPipeline(ctx, t, "blob", s.AccountName, s.AccountKey)
-	s.pipeline = p
-
-	return &harness{settings: *s, closer: done, httpClient: httpClient}, nil
+	credential, err := NewCredential(accountName, key)
+	if err != nil {
+		return nil, err
+	}
+	p, done, httpClient := setup.NewAzureTestPipeline(ctx, t, "blob", credential, string(accountName))
+	return &harness{pipeline: p, credential: credential, closer: done, httpClient: httpClient}, nil
 }
 
 func (h *harness) HTTPClient() *http.Client {
@@ -110,14 +113,7 @@ func (h *harness) HTTPClient() *http.Client {
 }
 
 func (h *harness) MakeDriver(ctx context.Context) (driver.Bucket, error) {
-	serviceURL, _ := ServiceURLFromAccountKey(h.settings.AccountName, h.settings.AccountKey)
-	serviceURLForRecorder := serviceURL.WithPipeline(h.settings.pipeline)
-
-	creds, _ := azblob.NewSharedKeyCredential(h.settings.AccountName, h.settings.AccountKey)
-	opts := Options{
-		Credential: creds,
-	}
-	return openBucket(ctx, &serviceURLForRecorder, bucketName, &opts)
+	return openBucket(ctx, h.pipeline, accountName, bucketName, &Options{Credential: h.credential})
 }
 
 func (h *harness) Close() {
@@ -215,23 +211,32 @@ func (verifyContentLanguage) ListObjectCheck(o *blob.ListObject) error {
 func TestOpenBucket(t *testing.T) {
 	tests := []struct {
 		description   string
+		nilPipeline bool
+		accountName   AccountName
 		containerName string
-		nilServiceURL bool
 		want          string
 		wantErr       bool
 	}{
 		{
-			description: "empty container name results in error",
-			wantErr:     true,
-		},
-		{
-			description:   "nil serviceURL results in error",
+			description:   "nil pipeline results in error",
+			nilPipeline: true,
+			accountName:   "myaccount",
 			containerName: "foo",
-			nilServiceURL: true,
 			wantErr:       true,
 		},
 		{
+			description:   "empty account name results in error",
+			containerName: "foo",
+			wantErr:       true,
+		},
+		{
+			description: "empty container name results in error",
+			accountName: "myaccount",
+			wantErr:     true,
+		},
+		{
 			description:   "success",
+			accountName:   "myaccount",
 			containerName: "foo",
 			want:          "foo",
 		},
@@ -240,22 +245,20 @@ func TestOpenBucket(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			var serviceURL *azblob.ServiceURL
-			if !test.nilServiceURL {
-				serviceURL, _ = ServiceURLFromAccountKey("x", "y")
+			var p pipeline.Pipeline
+			if !test.nilPipeline {
+				p = NewPipeline(azblob.NewAnonymousCredential(), azblob.PipelineOptions{})
 			}
-
 			// Create driver impl.
-			drv, err := openBucket(ctx, serviceURL, test.containerName, nil)
+			drv, err := openBucket(ctx, p, test.accountName, test.containerName, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)
 			}
 			if err == nil && drv != nil && drv.name != test.want {
 				t.Errorf("got %q want %q", drv.name, test.want)
 			}
-
 			// Create concrete type.
-			_, err = OpenBucket(ctx, serviceURL, test.containerName, nil)
+			_, err = OpenBucket(ctx, p, test.accountName, test.containerName, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)
 			}

--- a/samples/tutorial/setup.go
+++ b/samples/tutorial/setup.go
@@ -17,11 +17,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/Azure/azure-storage-blob-go/azblob"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/azureblob"
 	"gocloud.dev/blob/gcsblob"
@@ -78,11 +78,12 @@ func setupAWS(ctx context.Context, bucket string) (*blob.Bucket, error) {
 // authorization. It assumes environment variables AZURE_STORAGE_ACCOUNT_NAME
 // and AZURE_STORAGE_ACCOUNT_KEY are present.
 func setupAzure(ctx context.Context, bucket string) (*blob.Bucket, error) {
-	accountName := os.Getenv("AZURE_STORAGE_ACCOUNT_NAME")
-	accountKey := os.Getenv("AZURE_STORAGE_ACCOUNT_KEY")
-	serviceURL, err := azureblob.ServiceURLFromAccountKey(accountName, accountKey)
+	accountName := azureblob.DefaultAccountName()
+	accountKey := azureblob.DefaultAccountKey()
+	credential, err := azureblob.NewCredential(accountName, accountKey)
 	if err != nil {
 		return nil, err
 	}
-	return azureblob.OpenBucket(ctx, serviceURL, bucket, nil)
+	p := azureblob.NewPipeline(credential, azblob.PipelineOptions{})
+	return azureblob.OpenBucket(ctx, p, accountName, bucket, nil)
 }

--- a/samples/tutorial/setup.go
+++ b/samples/tutorial/setup.go
@@ -78,8 +78,14 @@ func setupAWS(ctx context.Context, bucket string) (*blob.Bucket, error) {
 // authorization. It assumes environment variables AZURE_STORAGE_ACCOUNT_NAME
 // and AZURE_STORAGE_ACCOUNT_KEY are present.
 func setupAzure(ctx context.Context, bucket string) (*blob.Bucket, error) {
-	accountName := azureblob.DefaultAccountName()
-	accountKey := azureblob.DefaultAccountKey()
+	accountName, err := azureblob.DefaultAccountName()
+	if err != nil {
+		return nil, err
+	}
+	accountKey, err := azureblob.DefaultAccountKey()
+	if err != nil {
+		return nil, err
+	}
 	credential, err := azureblob.NewCredential(accountName, accountKey)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Most of the types involved are specific to Azure storage, so I didn't add an `azure` package similar to `gcp` or `aws`. I did add a bunch of types and providers to `azureblob` itself.

In addition to the new types and ProviderSets, the main changes include:

* Support for "default" credentials loaded from the environment.
* You now pass in a `pipeline.Pipeline` (used to make HTTP requests) instead of a `ServiceURL`; given a `pipeline.Pipeline` there are no decisions to make about how to create the `ServiceURL` (other than setting SASToken).
* I moved the `SASToken` to `Options` instead of trying to provide parallel construction paths.

Fixes #1060.
