### PR TITLE
blob/all: add benchmarks for read and write/read/delete

### DIFF
--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -106,6 +106,24 @@ func TestConformance(t *testing.T) {
 	drivertest.RunConformanceTests(t, newHarness, []drivertest.AsTest{verifyContentLanguage{}})
 }
 
+func BenchmarkAzureblob(b *testing.B) {
+	name, err := DefaultAccountName()
+	if err != nil {
+		b.Fatal(err)
+	}
+	key, err := DefaultAccountKey()
+	if err != nil {
+		b.Fatal(err)
+	}
+	credential, err := NewCredential(name, key)
+	if err != nil {
+		b.Fatal(err)
+	}
+	p := NewPipeline(credential, azblob.PipelineOptions{})
+	bkt, err := OpenBucket(context.Background(), p, name, bucketName, nil)
+	drivertest.RunBenchmarks(b, bkt)
+}
+
 const language = "nl"
 
 // verifyContentLanguage uses As to access the underlying Azure types and

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -59,6 +59,18 @@ func TestConformance(t *testing.T) {
 	drivertest.RunConformanceTests(t, newHarness, nil)
 }
 
+func BenchmarkFileblob(b *testing.B) {
+	dir := path.Join(os.TempDir(), "go-cloud-fileblob")
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		b.Fatal(err)
+	}
+	bkt, err := OpenBucket(dir, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	drivertest.RunBenchmarks(b, bkt)
+}
+
 // File-specific unit tests.
 func TestNewBucket(t *testing.T) {
 	t.Run("BucketDirMissing", func(t *testing.T) {

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -98,6 +98,20 @@ func TestConformance(t *testing.T) {
 	drivertest.RunConformanceTests(t, newHarness, []drivertest.AsTest{verifyContentLanguage{}})
 }
 
+func BenchmarkGcsblob(b *testing.B) {
+	ctx := context.Background()
+	creds, err := gcp.DefaultCredentials(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+	client, err := gcp.NewHTTPClient(gcp.DefaultTransport(), gcp.CredentialsTokenSource(creds))
+	if err != nil {
+		b.Fatal(err)
+	}
+	bkt, err := OpenBucket(context.Background(), client, bucketName, nil)
+	drivertest.RunBenchmarks(b, bkt)
+}
+
 const language = "nl"
 
 // verifyContentLanguage uses As to access the underlying GCS types and

--- a/blob/memblob/memblob_test.go
+++ b/blob/memblob/memblob_test.go
@@ -42,3 +42,7 @@ func (h *harness) Close() {}
 func TestConformance(t *testing.T) {
 	drivertest.RunConformanceTests(t, newHarness, nil)
 }
+
+func BenchmarkMemblob(b *testing.B) {
+	drivertest.RunBenchmarks(b, OpenBucket(nil))
+}

--- a/blob/s3blob/example_test.go
+++ b/blob/s3blob/example_test.go
@@ -28,9 +28,17 @@ import (
 func Example() {
 	// Set the environment variables AWS uses to load the session.
 	// https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
+	prevAccessKey := os.Getenv("AWS_ACCESS_KEY")
+	prevSecretKey := os.Getenv("AWS_SECRET_KEY")
+	prevRegion := os.Getenv("AWS_REGION")
 	os.Setenv("AWS_ACCESS_KEY", "myaccesskey")
 	os.Setenv("AWS_SECRET_KEY", "mysecretkey")
 	os.Setenv("AWS_REGION", "us-east-1")
+	defer func() {
+		os.Setenv("AWS_ACCESS_KEY", prevAccessKey)
+		os.Setenv("AWS_SECRET_KEY", prevSecretKey)
+		os.Setenv("AWS_REGION", prevRegion)
+	}()
 
 	// Establish an AWS session.
 	session, err := session.NewSession(nil)

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -73,6 +73,20 @@ func TestConformance(t *testing.T) {
 	drivertest.RunConformanceTests(t, newHarness, []drivertest.AsTest{verifyContentLanguage{}})
 }
 
+func BenchmarkS3blob(b *testing.B) {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(region),
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	bkt, err := OpenBucket(context.Background(), sess, bucketName, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	drivertest.RunBenchmarks(b, bkt)
+}
+
 const language = "nl"
 
 // verifyContentLanguage uses As to access the underlying GCS types and


### PR DESCRIPTION
The benchmarks are implemented similar to conformance tests, so the provider implementation just has to create a `blob.Bucket`.

Sample output:

```
$ go test ./... -bench . | grep Bench
BenchmarkAzureblob/BenchmarkRead-12         	200	   5394847 ns/op
BenchmarkAzureblob/BenchmarkWriteReadDelete-12  100	  17338338 ns/op
BenchmarkFileblob/BenchmarkRead-12         	    50000    23963 ns/op
BenchmarkFileblob/BenchmarkWriteReadDelete-12   20000    76245 ns/op
BenchmarkGcsblob/BenchmarkRead-12         	    500	   2371446 ns/op
BenchmarkGcsblob/BenchmarkWriteReadDelete-12    100	 228282634 ns/op
BenchmarkMemblob/BenchmarkRead-12         	    50000    28073 ns/op
BenchmarkMemblob/BenchmarkWriteReadDelete-12    30000    52072 ns/op
BenchmarkS3blob/BenchmarkRead-12         	    100	  11489126 ns/op
BenchmarkS3blob/BenchmarkWriteReadDelete-12     20	  60829931 ns/op
```

Fixes #627.