### PR TITLE
internal/trace: support for tracing

### DIFF
--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -1,0 +1,45 @@
+// Copyright 2019 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package trace provides support for OpenCensus tracing.
+package trace
+
+import (
+	"context"
+
+	"go.opencensus.io/trace"
+	// "gocloud.dev/errors"
+)
+
+// StartSpan adds a span to the trace with the given name.
+func StartSpan(ctx context.Context, name string) context.Context {
+	ctx, _ = trace.StartSpan(ctx, name)
+	return ctx
+}
+
+// EndSpan ends a span with the given error.
+func EndSpan(ctx context.Context, err error) {
+	span := trace.FromContext(ctx)
+	if err != nil {
+		span.SetStatus(toStatus(err))
+	}
+	span.End()
+}
+
+// toStatus interrogates an error and converts it to an appropriate
+// OpenCensus status.
+func toStatus(err error) trace.Status {
+	// TODO(jba): see if err is a *gocloud.dev/errors.Error, and use its code.
+	return trace.Status{Code: -1, Message: err.Error()}
+}

--- a/internal/trace/trace_test.go
+++ b/internal/trace/trace_test.go
@@ -1,0 +1,40 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	octrace "go.opencensus.io/trace"
+)
+
+func TestToStatus(t *testing.T) {
+	for _, testcase := range []struct {
+		input error
+		want  octrace.Status
+	}{
+		{
+			errors.New("some random error"),
+			octrace.Status{Code: -1, Message: "some random error"},
+		},
+	} {
+		got := toStatus(testcase.input)
+		if r := cmp.Diff(got, testcase.want); r != "" {
+			t.Errorf("got -, want +:\n%s", r)
+		}
+	}
+}


### PR DESCRIPTION
A small package that helps add tracing to our APIs.