### PR TITLE
blob: create URLMux type for scheme registration

### DIFF
--- a/blob/anyblob/anyblob.go
+++ b/blob/anyblob/anyblob.go
@@ -1,0 +1,43 @@
+// Copyright 2019 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package anyblob provides an Open function that opens buckets backed
+// by GCS, S3, Azure Storage, filesystem, and memory.
+package anyblob
+
+import (
+	"context"
+
+	"gocloud.dev/blob"
+	"gocloud.dev/blob/azureblob"
+	"gocloud.dev/blob/fileblob"
+	"gocloud.dev/blob/gcsblob"
+	"gocloud.dev/blob/memblob"
+	"gocloud.dev/blob/s3blob"
+)
+
+// Open opens a bucket URL, allowing URL overrides for all openers that
+// support it. See the URLOpener types in various provider packages for
+// more details.
+func Open(ctx context.Context, urlstr string) (*blob.Bucket, error) {
+	return mux.Open(ctx, urlstr)
+}
+
+var mux = blob.NewURLMux(map[string]blob.BucketURLOpener{
+	azureblob.Scheme: &azureblob.URLOpener{AllowURLOverrides: true},
+	fileblob.Scheme:  &fileblob.URLOpener{},
+	gcsblob.Scheme:   &gcsblob.URLOpener{AllowURLOverrides: true},
+	memblob.Scheme:   &memblob.URLOpener{},
+	s3blob.Scheme:    &s3blob.URLOpener{AllowURLOverrides: true},
+})

--- a/blob/fileblob/example_test.go
+++ b/blob/fileblob/example_test.go
@@ -19,14 +19,14 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
+	"strings"
 
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/fileblob"
 )
 
 func Example() {
-
 	// For this example, create a temporary directory.
 	dir, err := ioutil.TempDir("", "go-cloud-fileblob-example")
 	if err != nil {
@@ -35,15 +35,14 @@ func Example() {
 	defer os.RemoveAll(dir)
 
 	// Create a file-based bucket.
-	_, err = fileblob.OpenBucket(dir, nil)
+	bucket, err := fileblob.OpenBucket(dir, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// Output:
+	_ = bucket
 }
 
-func Example_open() {
+func ExampleURLOpener() {
 	// For this example, create a temporary directory.
 	dir, err := ioutil.TempDir("", "go-cloud-fileblob-example")
 	if err != nil {
@@ -51,10 +50,16 @@ func Example_open() {
 	}
 	defer os.RemoveAll(dir)
 
-	_, err = blob.Open(context.Background(), path.Join("file://", dir))
+	// Create a URL mux with the fileblob.URLOpener.
+	// This would typically happen once in your application.
+	mux := blob.NewURLMux(map[string]blob.BucketURLOpener{
+		fileblob.Scheme: &fileblob.URLOpener{},
+	})
+
+	// Open a bucket from a URL.
+	bucket, err := mux.Open(context.Background(), "file:///"+strings.Replace(dir, string(filepath.Separator), "/", -1))
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// Output:
+	_ = bucket
 }

--- a/blob/gcsblob/example_test.go
+++ b/blob/gcsblob/example_test.go
@@ -70,8 +70,33 @@ func Example() {
 	// ReadAll failed due to invalid credentials
 }
 
-func Example_open() {
-	_, _ = blob.Open(context.Background(), "gs://my-bucket")
+func ExampleURLOpener() {
+	ctx := context.Background()
 
-	// Output:
+	// Get GCP credentials.
+	creds, err := gcp.DefaultCredentials(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create an HTTP client.
+	// This example uses the default HTTP transport and the credentials created
+	// above.
+	client, err := gcp.NewHTTPClient(gcp.DefaultTransport(), gcp.CredentialsTokenSource(creds))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a URL mux with the gcsblob.URLOpener.
+	// This would typically happen once in your application.
+	mux := blob.NewURLMux(map[string]blob.BucketURLOpener{
+		gcsblob.Scheme: &gcsblob.URLOpener{Client: client},
+	})
+
+	// Open a bucket using the mux.
+	bucket, err := mux.Open(ctx, "gs://my-bucket")
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = bucket
 }

--- a/blob/memblob/example_test.go
+++ b/blob/memblob/example_test.go
@@ -30,8 +30,11 @@ func Example() {
 	// Output:
 }
 
-func Example_open() {
-	_, err := blob.Open(context.Background(), "mem://")
+func ExampleURLOpener() {
+	mux := blob.NewURLMux(map[string]blob.BucketURLOpener{
+		memblob.Scheme: &memblob.URLOpener{},
+	})
+	_, err := mux.Open(context.Background(), "mem://")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/blob/memblob/memblob.go
+++ b/blob/memblob/memblob.go
@@ -15,15 +15,6 @@
 // Package memblob provides an in-memory blob implementation.
 // Use OpenBucket to construct a *blob.Bucket.
 //
-// Open URLs
-//
-// For blob.Open URLs, memblob registers for the scheme "mem"; URLs start
-// with "mem://".
-//
-// The URL's Path and Host are ignored, and no query options are supported.
-// Example:
-//  - mem://
-//
 // As
 //
 // memblob does not support any types for As.
@@ -53,10 +44,15 @@ var (
 	errNotImplemented = errors.New("not implemented")
 )
 
-func init() {
-	blob.Register("mem", func(_ context.Context, u *url.URL) (driver.Bucket, error) {
-		return openBucket(nil), nil
-	})
+// Scheme is the URL scheme conventionally used for in-memory buckets in a URLMux.
+const Scheme = "mem"
+
+// URLOpener opens URLs like "mem://".
+type URLOpener struct{}
+
+// OpenBucketURL returns a new in-memory bucket.
+func (*URLOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.Bucket, error) {
+	return OpenBucket(nil), nil
 }
 
 // Options sets options for constructing a *blob.Bucket backed by memory.

--- a/blob/s3blob/example_test.go
+++ b/blob/s3blob/example_test.go
@@ -62,8 +62,55 @@ func Example() {
 	// ReadAll failed due to invalid credentials
 }
 
-func Example_open() {
-	_, _ = blob.Open(context.Background(), "s3://my-bucket")
+func ExampleURLOpener() {
+	ctx := context.Background()
 
-	// Output:
+	// Establish an AWS session.
+	session, err := session.NewSession(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a URL mux with the s3blob.URLOpener.
+	// This would typically happen once in your application.
+	mux := blob.NewURLMux(map[string]blob.BucketURLOpener{
+		s3blob.Scheme: &s3blob.URLOpener{
+			ConfigProvider: session,
+		},
+	})
+
+	// Open creates a *Bucket from a URL.
+	// This URL will open the bucket "my-bucket".
+	bucket, err := mux.Open(ctx, "s3://my-bucket")
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = bucket
+}
+
+func ExampleURLOpener_optionsInURL() {
+	ctx := context.Background()
+
+	// Establish an AWS session.
+	session, err := session.NewSession(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a URL mux with the s3blob.URLOpener.
+	// This would typically happen once in your application.
+	mux := blob.NewURLMux(map[string]blob.BucketURLOpener{
+		s3blob.Scheme: &s3blob.URLOpener{
+			ConfigProvider:    session,
+			AllowURLOverrides: true,
+		},
+	})
+
+	// Open creates a *Bucket from a URL.
+	// This URL will open the bucket "my-bucket" in us-west-1.
+	bucket, err := mux.Open(ctx, "s3://my-bucket?region=us-west-1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = bucket
 }


### PR DESCRIPTION
Added URLOpener types to all of the provider packages.

I have not added the convenience functions, since this PR was already long enough and it seemed like this was the smallest change to get URLs away from globals. I'll file an issue to track adding the convenience functions.

Fixes #931