### PR TITLE
secrets: delete unused code in wrapError

### DIFF
--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -86,9 +86,6 @@ type wrappedError struct {
 }
 
 func wrapError(k driver.Keeper, err error) error {
-	if err == nil {
-		return nil
-	}
 	return &wrappedError{k: k, err: err}
 }
 


### PR DESCRIPTION
`wrapError` is only called with non-nil errors.