### PR TITLE
blob: fix ErrorAs

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -420,6 +420,9 @@ func (b *Bucket) As(i interface{}) bool {
 // ErrorAs converts i to provider-specific types.
 // See Bucket.As for more details.
 func (b *Bucket) ErrorAs(err error, i interface{}) bool {
+	if e, ok := err.(*gcerr.Error); ok {
+		return b.b.ErrorAs(e.Unwrap(), i)
+	}
 	return b.b.ErrorAs(err, i)
 }
 

--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -1831,6 +1831,9 @@ func testAs(t *testing.T, newHarness HarnessMaker, st AsTest) {
 	if gotErr == nil {
 		t.Fatalf("got nil error from NewReader for nonexistent key, want an error")
 	}
+	if err := st.ErrorCheck(b, gotErr); err != nil {
+		t.Error(err)
+	}
 }
 
 func benchmarkRead(b *testing.B, bkt *blob.Bucket) {


### PR DESCRIPTION
We need to unwrap the error before passing to the driver ErrorAs.