### PR TITLE
internal/admin: allow stale branches to be merged in

### DIFF
--- a/internal/admin/repository/main.tf
+++ b/internal/admin/repository/main.tf
@@ -35,7 +35,7 @@ resource "github_branch_protection" "default_branch" {
   enforce_admins = true
 
   required_status_checks {
-    strict = true
+    strict = false
 
     contexts = [
       "Travis CI - Pull Request",


### PR DESCRIPTION
Output from `terraform plan`:

```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ module.go_cloud_repo.github_branch_protection.default_branch
      required_status_checks.0.strict: "true" => "false"

  ~ module.wire_repo.github_branch_protection.default_branch
      required_status_checks.0.strict: "true" => "false"


Plan: 0 to add, 2 to change, 0 to destroy.

------------------------------------------------------------------------
```