### PR TITLE
docs: use "Go Cloud Development Kit" or GCDK instead of "Go Cloud"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
-# This is the official list of Go Cloud authors for copyright purposes.
+# This is the official list of Go Cloud Development Kit authors for copyright
+# purposes.
 # This file is distinct from the CONTRIBUTORS files.
 # See the latter for an explanation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ how you can help.
 
 ## Filing issues
 
-Filing issues is an important way you can contribute to the Go Cloud Project. We
-want your feedback on things like bugs, desired API changes, or just anything
-that isn't working for you.
+Filing issues is an important way you can contribute to the Go Cloud Development
+Kit. We want your feedback on things like bugs, desired API changes, or just
+anything that isn't working for you.
 
 ### Bugs
 
@@ -22,13 +22,13 @@ of the issue, like "blob/gcsblob: not blobby enough".
 ### Changes
 
 Unlike the core Go project, we do not have a formal proposal process for
-changes. If you have a change you would like to see in Go Cloud, please file an
-issue with the necessary details.
+changes. If you have a change you would like to see in the Go CDK, please file
+an issue with the necessary details.
 
 ### Triaging
 
-The Go Cloud team triages issues at least every two weeks, but usually within
-two business days. Bugs or feature requests are either placed into a **Sprint**
+The Go CDK team triages issues at least every two weeks, but usually within two
+business days. Bugs or feature requests are either placed into a **Sprint**
 milestone which means the issue is intended to be worked on. Issues that we
 would like to address but do not have time for are placed into the [Unplanned][]
 milestone.
@@ -77,10 +77,10 @@ Tests that interact with cloud providers are written using a replay method,
 where the test is run and actually performs the operations, and the
 requests/results of the operations are stored in a replay file. This replay file
 is then read back in unit tests on Travis, so the tests get to operate with real
-data. Unfortunately, while the Go Cloud team can generate these replay files
-against our test cloud infrastructure, it is not yet possible for external
-contributors to do the same. We want to improve this process in the future and
-are researching how we can do this. If you have any ideas, please file an issue!
+data. Unfortunately, while the GCDK team can generate these replay files against
+our test cloud infrastructure, it is not yet possible for external contributors
+to do the same. We want to improve this process in the future and are
+researching how we can do this. If you have any ideas, please file an issue!
 
 #### Writing and running tests against a cloud environment
 
@@ -97,7 +97,7 @@ generate new ones to be used by others.
 
 *   Follow the normal
     [pull request flow](https://help.github.com/articles/creating-a-pull-request/)
-*   Build your changes using Go 1.11 with Go modules enabled. Go Cloud's
+*   Build your changes using Go 1.11 with Go modules enabled. The GCDK's
     continuous integration uses Go modules in order to ensure
     [reproducible builds](https://research.swtch.com/vgo-repro).
 *   Test your changes using `go test ./...`. Please add tests that show the
@@ -130,8 +130,7 @@ request. GitHub notifications can be noisy, and it is unfortunately easy for
 things to be lost in the shuffle.
 
 Once your PR is approved (hooray!) the reviewer will squash your commits into a
-single commit, and then merge the commit onto the Go Cloud master branch. Thank
-you!
+single commit, and then merge the commit onto the GCDK master branch. Thank you!
 
 ## Github code review workflow conventions
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,5 @@
 # This is the official list of people who can contribute
-# (and typically have contributed) code to the Go Cloud repository.
+# (and typically have contributed) code to the Go CDK repository.
 # The AUTHORS file lists the copyright holders; this file
 # lists people.  For example, Google employees are listed here
 # but not in AUTHORS, because Google holds the copyright.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="logo-gopherblue.png" alt="" width="448" height="221">
 
-# The Go Cloud Project
+# The Go Cloud Development Kit (Go CDK)
 
 _Write once, run on any cloud ☁️_
 
@@ -8,10 +8,10 @@ _Write once, run on any cloud ☁️_
 [![godoc](https://godoc.org/github.com/google/go-cloud?status.svg)][godoc]
 [![Coverage Status](https://coveralls.io/repos/github/google/go-cloud/badge.svg?branch=master)](https://coveralls.io/github/google/go-cloud?branch=master)
 
-The Go Cloud Project is an initiative that will allow application developers to
-seamlessly deploy cloud applications on any combination of cloud providers. It
-does this by providing stable, idiomatic interfaces for common uses like storage
-and databases. Think `database/sql` for cloud products.
+The Go Cloud Development Kit will allow application developers to seamlessly
+deploy cloud applications on any combination of cloud providers. It does this by
+providing stable, idiomatic interfaces for common uses like storage and
+databases. Think `database/sql` for cloud products.
 
 Imagine writing this to read from blob storage (like Google Cloud Storage or
 S3):
@@ -25,11 +25,11 @@ of cloud-specific authorization, tracing, SDKs and all the other code required
 to make an application portable across cloud platforms.
 
 The project works well with a code generator called
-[Wire](https://github.com/google/wire/blob/master/README.md). It
-creates human-readable code that only imports the cloud SDKs for providers you
-use. This allows Go Cloud to grow to support any number of cloud providers,
-without increasing compile times or binary sizes, and avoiding any side effects
-from `init()` functions.
+[Wire](https://github.com/google/wire/blob/master/README.md). It creates
+human-readable code that only imports the cloud SDKs for providers you use. This
+allows the Go CDK to grow to support any number of cloud providers, without
+increasing compile times or binary sizes, and avoiding any side effects from
+`init()` functions.
 
 You can learn more about the project from our [announcement blog post][], or our
 talk at Next 2018:
@@ -50,7 +50,7 @@ go get gocloud.dev
 go get github.com/google/wire/cmd/wire
 ```
 
-Go Cloud builds at the latest stable release of Go. Previous Go versions may
+The Go CDK builds at the latest stable release of Go. Previous Go versions may
 compile but are not supported.
 
 ## Samples
@@ -77,7 +77,7 @@ While in alpha, the API is subject to breaking changes.
 
 ## Current features
 
-Go Cloud provides generic APIs for:
+The Go CDK provides generic APIs for:
 
 *   Unstructured binary (blob) storage
 *   Publish/Subscribe (pubsub)
@@ -88,24 +88,25 @@ Go Cloud provides generic APIs for:
 
 ## Contributing
 
-Thank you for your interest in contributing to Go Cloud! :heart:
+Thank you for your interest in contributing to the Go Cloud Development
+Kit! :heart:
 
-Everyone is welcome to contribute to Go Cloud, whether it's in the form of code,
+Everyone is welcome to contribute, whether it's in the form of code,
 documentation, bug reports, feature requests, or anything else. We encourage you
-to experiment with Go Cloud and make contributions to help evolve it to meet
+to experiment with the Go CDK and make contributions to help evolve it to meet
 your needs!
 
 The GitHub repository at [google/go-cloud][go-cloud] contains some provider
-implementations for each portable API. We intend to include [Google Cloud
-Platform][gcp], [Amazon Web Services][aws], and
-[Azure][azure] implementations, as well as prominent open
-source providers and at least one implementation suitable for use in local
-testing. Unfortunately, we cannot support every cloud provider directly from the
-project; however, we encourage contributions in separate repositories.
+implementations for each portable API. We intend to include
+[Google Cloud Platform][gcp], [Amazon Web Services][aws], and [Azure][azure]
+implementations, as well as prominent open source providers and at least one
+implementation suitable for use in local testing. Unfortunately, we cannot
+support every cloud provider directly from the project; however, we encourage
+contributions in separate repositories.
 
-If you create a repository that implements the Go Cloud interfaces for other
-providers, let us know! We would be happy to link to it here and give you
-a heads-up before making any breaking changes.
+If you create a repository that implements the Go CDK interfaces for other
+providers, let us know! We would be happy to link to it here and give you a
+heads-up before making any breaking changes.
 
 See [the contributing guide](./CONTRIBUTING.md) for more details.
 


### PR DESCRIPTION
This PR affects top-level files in the repo. I'll send subsequent PRs for other changes.

Updates #1186.