### PR TITLE
all: remove "go get ... wire" from the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ talk at Next 2018:
 # First "cd" into your project directory if you have one to ensure "go get" uses
 # Go modules (or not) appropriately. See "go help modules" for more info.
 go get gocloud.dev
-go get github.com/google/wire/cmd/wire
 ```
 
 Go Cloud builds at the latest stable release of Go. Previous Go versions may


### PR DESCRIPTION
Removing the suggestion to install wire explicitly in the README. wire is a dependency of go-cloud already, and relevant samples (like the guestbook) further suggest to install it.