### PR TITLE
blob/fileblob: ErrorAs supports os.PathError

### DIFF
--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -403,7 +403,15 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 func (b *bucket) As(i interface{}) bool { return false }
 
 // As implements driver.ErrorAs.
-func (b *bucket) ErrorAs(err error, i interface{}) bool { return false }
+func (b *bucket) ErrorAs(err error, i interface{}) bool {
+	if perr, ok := err.(*os.PathError); ok {
+		if p, ok := i.(**os.PathError); ok {
+			*p = perr
+			return true
+		}
+	}
+	return false
+}
 
 // Attributes implements driver.Attributes.
 func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes, error) {

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -45,9 +45,10 @@
 //  - file:///c:/foo/bar
 //    -> Passes "c:/foo/bar".
 //
-// As
+// As and ErrorAs
 //
 // fileblob does not support any types for As.
+// It supports *os.PathError for ErrorAs
 package fileblob // import "gocloud.dev/blob/fileblob"
 
 import (

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -45,10 +45,10 @@
 //  - file:///c:/foo/bar
 //    -> Passes "c:/foo/bar".
 //
-// As and ErrorAs
+// As
 //
-// fileblob does not support any types for As.
-// It supports *os.PathError for ErrorAs
+// fileblob exposes the following types for As:
+//  - Error: *os.PathError
 package fileblob // import "gocloud.dev/blob/fileblob"
 
 import (

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gocloud.dev/blob"
@@ -188,9 +189,9 @@ func (verifyPathError) ErrorCheck(b *blob.Bucket, err error) error {
 	if !b.ErrorAs(err, &perr) {
 		return errors.New("want ErrorAs to succeed for PathError")
 	}
-	const want = "/tmp/go-cloud-fileblob/key-does-not-exist"
-	if got := perr.Path; got != want {
-		return fmt.Errorf("got path %q, want %q", got, want)
+	const wantSuffix = "go-cloud-fileblob/key-does-not-exist"
+	if got := perr.Path; !strings.HasSuffix(got, wantSuffix) {
+		return fmt.Errorf("got path %q, want suffix %q", got, wantSuffix)
 	}
 	return nil
 }

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -16,6 +16,8 @@ package fileblob
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -23,6 +25,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"gocloud.dev/blob"
 	"gocloud.dev/blob/driver"
 	"gocloud.dev/blob/drivertest"
 )
@@ -56,7 +59,7 @@ func (h *harness) Close() {
 }
 
 func TestConformance(t *testing.T) {
-	drivertest.RunConformanceTests(t, newHarness, nil)
+	drivertest.RunConformanceTests(t, newHarness, []drivertest.AsTest{verifyPathError{}})
 }
 
 func BenchmarkFileblob(b *testing.B) {
@@ -167,4 +170,27 @@ func TestUnescape(t *testing.T) {
 			t.Errorf("%s: got unescaped %q want %q", tc.filename, got, tc.want)
 		}
 	}
+}
+
+type verifyPathError struct{}
+
+func (verifyPathError) Name() string { return "verify ErrorAs handles os.PathError" }
+
+func (verifyPathError) BucketCheck(b *blob.Bucket) error             { return nil }
+func (verifyPathError) BeforeWrite(as func(interface{}) bool) error  { return nil }
+func (verifyPathError) BeforeList(as func(interface{}) bool) error   { return nil }
+func (verifyPathError) AttributesCheck(attrs *blob.Attributes) error { return nil }
+func (verifyPathError) ReaderCheck(r *blob.Reader) error             { return nil }
+func (verifyPathError) ListObjectCheck(o *blob.ListObject) error     { return nil }
+
+func (verifyPathError) ErrorCheck(b *blob.Bucket, err error) error {
+	var perr *os.PathError
+	if !b.ErrorAs(err, &perr) {
+		return errors.New("want ErrorAs to succeed for PathError")
+	}
+	const want = "/tmp/go-cloud-fileblob/key-does-not-exist"
+	if got := perr.Path; got != want {
+		return fmt.Errorf("got path %q, want %q", got, want)
+	}
+	return nil
 }


### PR DESCRIPTION
Have ErrorAs recognize `os.PathError`s, since they are returned
from many filesystem operations.