### PR TITLE
pubsub: add metrics

### DIFF
--- a/blob/oc_test.go
+++ b/blob/oc_test.go
@@ -16,17 +16,11 @@ package blob_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"go.opencensus.io/stats/view"
-	"go.opencensus.io/tag"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/memblob"
 	"gocloud.dev/gcerrors"
-	"gocloud.dev/internal/oc"
 	"gocloud.dev/internal/testing/octest"
 )
 
@@ -52,60 +46,14 @@ func TestOpenCensus(t *testing.T) {
 		t.Fatal("got nil, want error")
 	}
 
-	diff := octest.DiffSpans(te.Spans, []octest.Span{
-		{"gocloud.dev/blob.NewWriter", gcerrors.OK},
-		{"gocloud.dev/blob.NewRangeReader", gcerrors.OK},
-		{"gocloud.dev/blob.Attributes", gcerrors.OK},
-		{"gocloud.dev/blob.Delete", gcerrors.OK},
-		{"gocloud.dev/blob.NewRangeReader", gcerrors.NotFound},
+	diff := octest.Diff(te.Spans, te.Counts(), "gocloud.dev/blob", "gocloud.dev/blob/memblob", []octest.Call{
+		{"NewWriter", gcerrors.OK},
+		{"NewRangeReader", gcerrors.OK},
+		{"Attributes", gcerrors.OK},
+		{"Delete", gcerrors.OK},
+		{"NewRangeReader", gcerrors.NotFound},
 	})
 	if diff != "" {
-		t.Errorf("trace: %s", diff)
+		t.Error(diff)
 	}
-
-	// Wait for counts. Expect all counts to arrive in the same view.Data.
-	for {
-		data := <-te.Stats
-		if _, ok := data.Rows[0].Data.(*view.CountData); !ok {
-			continue
-		}
-		// There should be a count of 1 for each of these sets of tags.
-		// Rows may appear in any order, but tags within a row will be sorted
-		// by key name (see https://godoc.org/go.opencensus.io/stats/view#Row.Equal).
-		var want []*view.Row
-		for _, m := range []string{"Attributes", "Delete", "NewRangeReader", "NewWriter"} {
-			want = append(want, &view.Row{
-				Tags: []tag.Tag{
-					{Key: oc.MethodKey, Value: "gocloud.dev/blob." + m},
-					{Key: oc.ProviderKey, Value: "gocloud.dev/blob/memblob"},
-					{Key: oc.StatusKey, Value: "OK"},
-				},
-				Data: &view.CountData{Value: 1},
-			})
-		}
-		want = append(want, &view.Row{
-			Tags: []tag.Tag{
-				{Key: oc.MethodKey, Value: "gocloud.dev/blob.NewRangeReader"},
-				{Key: oc.ProviderKey, Value: "gocloud.dev/blob/memblob"},
-				{Key: oc.StatusKey, Value: "NotFound"},
-			},
-			Data: &view.CountData{Value: 1},
-		})
-		diff := cmp.Diff(data.Rows, want, cmpopts.SortSlices(lessRow))
-		if diff != "" {
-			t.Errorf("metrics: %s", diff)
-		}
-		break
-	}
-}
-
-// The order doesn't matter; we just need a deterministic ordering of rows.
-func lessRow(r1, r2 *view.Row) bool { return rowKey(r1) < rowKey(r2) }
-
-func rowKey(r *view.Row) string {
-	var vals []string
-	for _, t := range r.Tags {
-		vals = append(vals, t.Value)
-	}
-	return strings.Join(vals, "|")
 }

--- a/internal/testing/octest/diff.go
+++ b/internal/testing/octest/diff.go
@@ -18,14 +18,20 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
 	"gocloud.dev/gcerrors"
+	"gocloud.dev/internal/oc"
 )
 
-// Span holds the expected contents of a span obtained from tracing.
-type Span struct {
-	Name string
-	Code gcerrors.ErrorCode
+// Call holds the expected contents of a measured call.
+// It is used for both metric and trace comparison.
+type Call struct {
+	Method string
+	Code   gcerrors.ErrorCode
 }
 
 func formatSpanData(s *trace.SpanData) string {
@@ -35,21 +41,33 @@ func formatSpanData(s *trace.SpanData) string {
 	return fmt.Sprintf("<Name: %q, Code: %d>", s.Name, s.Code)
 }
 
-func formatSpan(s *Span) string {
-	if s == nil {
+func formatCall(c *Call) string {
+	if c == nil {
 		return "nothing"
 	}
-	return fmt.Sprintf("<Name: %q, Code: %d>", s.Name, s.Code)
+	return fmt.Sprintf("<Name: %q, Code: %d>", c.Method, c.Code)
 }
 
-// DiffSpans compares the list of spans obtained from OpenCensus tracing
+// Diff compares the list of spans and metric counts obtained from OpenCensus instrumentation
 // (using the TestExporter in this package, or similar) with an expected
-// list of spans. Only the name and code of the spans are compared.
-// Order matters.
-func DiffSpans(got []*trace.SpanData, want []Span) string {
+// list of call. Only the name and code are compared.
+// Order matters for traces (though not for metrics).
+func Diff(gotSpans []*trace.SpanData, gotRows []*view.Row, namePrefix, provider string, want []Call) string {
+	ds := diffSpans(gotSpans, namePrefix, want)
+	dc := diffCounts(gotRows, namePrefix, provider, want)
+	if len(ds) > 0 {
+		ds = "trace: " + ds + "\n"
+	}
+	if len(dc) > 0 {
+		dc = "metrics: " + dc
+	}
+	return ds + dc
+}
+
+func diffSpans(got []*trace.SpanData, prefix string, want []Call) string {
 	var diffs []string
-	add := func(i int, g *trace.SpanData, w *Span) {
-		diffs = append(diffs, fmt.Sprintf("#%d: got %s, want %s", i, formatSpanData(g), formatSpan(w)))
+	add := func(i int, g *trace.SpanData, w *Call) {
+		diffs = append(diffs, fmt.Sprintf("#%d: got %s, want %s", i, formatSpanData(g), formatCall(w)))
 	}
 
 	for i := 0; i < len(got) || i < len(want); i++ {
@@ -58,12 +76,37 @@ func DiffSpans(got []*trace.SpanData, want []Span) string {
 			add(i, nil, &want[i])
 		case i >= len(want):
 			add(i, got[i], nil)
-		case got[i].Name != want[i].Name || got[i].Code != int32(want[i].Code):
-			add(i, got[i], &want[i])
+		case got[i].Name != prefix+"."+want[i].Method || got[i].Code != int32(want[i].Code):
+			w := want[i]
+			w.Method = prefix + "." + w.Method
+			add(i, got[i], &w)
 		}
 	}
-	if len(diffs) == 0 {
-		return ""
+	return strings.Join(diffs, "\n")
+}
+
+func diffCounts(got []*view.Row, prefix, provider string, wantCalls []Call) string {
+	var want []*view.Row
+	for _, wc := range wantCalls {
+		want = append(want, &view.Row{
+			Tags: []tag.Tag{
+				{Key: oc.MethodKey, Value: prefix + "." + wc.Method},
+				{Key: oc.ProviderKey, Value: provider},
+				{Key: oc.StatusKey, Value: fmt.Sprint(wc.Code)},
+			},
+			Data: &view.CountData{Value: 1},
+		})
 	}
-	return "\n" + strings.Join(diffs, "\n")
+	return cmp.Diff(got, want, cmpopts.SortSlices(lessRow))
+}
+
+// The order doesn't matter; we just need a deterministic ordering of rows.
+func lessRow(r1, r2 *view.Row) bool { return rowKey(r1) < rowKey(r2) }
+
+func rowKey(r *view.Row) string {
+	var vals []string
+	for _, t := range r.Tags {
+		vals = append(vals, t.Value)
+	}
+	return strings.Join(vals, "|")
 }

--- a/internal/testing/octest/exporter.go
+++ b/internal/testing/octest/exporter.go
@@ -65,6 +65,18 @@ func (te *TestExporter) ExportView(vd *view.Data) {
 	}
 }
 
+// Counts returns the first exported data that includes aggregated counts.
+func (te *TestExporter) Counts() []*view.Row {
+	// Wait for counts. Expect all counts to arrive in the same view.Data.
+	for {
+		data := <-te.Stats
+		if _, ok := data.Rows[0].Data.(*view.CountData); !ok {
+			continue
+		}
+		return data.Rows
+	}
+}
+
 // Unregister unregisters the exporter from OpenCensus.
 func (te *TestExporter) Unregister() {
 	view.UnregisterExporter(te)

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -24,8 +24,10 @@ import (
 
 	"gocloud.dev/gcerrors"
 	"gocloud.dev/internal/gcerr"
+	"gocloud.dev/internal/testing/octest"
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/driver"
+	"gocloud.dev/pubsub/mempubsub"
 )
 
 type driverTopic struct {
@@ -380,4 +382,42 @@ func TestErrorsAreWrapped(t *testing.T) {
 	verify(top.Send(ctx, &pubsub.Message{}))
 	_, err := sub.Receive(ctx)
 	verify(err)
+}
+
+func TestOpenCensus(t *testing.T) {
+	ctx := context.Background()
+	te := octest.NewTestExporter(pubsub.OpenCensusViews)
+	defer te.Unregister()
+
+	top := mempubsub.NewTopic()
+	sub := mempubsub.NewSubscription(top, time.Second)
+	if err := top.Send(ctx, &pubsub.Message{Body: []byte("x")}); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := sub.Receive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg.Ack()
+	if err := top.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := sub.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = sub.Receive(ctx)
+
+	diff := octest.Diff(te.Spans, te.Counts(), "gocloud.dev/pubsub", "gocloud.dev/pubsub/mempubsub", []octest.Call{
+		{"driver.Topic.SendBatch", gcerrors.OK},
+		{"Topic.Send", gcerrors.OK},
+		{"driver.Subscription.ReceiveBatch", gcerrors.OK},
+		{"Subscription.Receive", gcerrors.OK},
+		{"Topic.Shutdown", gcerrors.OK},
+		{"driver.Subscription.SendAcks", gcerrors.OK},
+		{"Subscription.Shutdown", gcerrors.OK},
+		{"Subscription.Receive", gcerrors.FailedPrecondition},
+	})
+	if diff != "" {
+		t.Error(diff)
+	}
 }


### PR DESCRIPTION
- Adapt pubsub concrete type to use the new oc.Tracer type.
- Add instrumentation for ReceiveBatch.
- Fix bug in which a Context variable was changed instead of using a fresh one.
- Factor out common testing code to the octest package.
- Combine comparison of traces and metric counts.
- Use new testing code in blob.