### PR TITLE
gcerrors: add Canceled and DeadlineExceeded

### DIFF
--- a/gcerrors/errors.go
+++ b/gcerrors/errors.go
@@ -17,6 +17,8 @@
 package gcerrors
 
 import (
+	"context"
+
 	"gocloud.dev/internal/gcerr"
 	"golang.org/x/xerrors"
 )
@@ -58,11 +60,19 @@ const (
 	// Some resource has been exhausted, typically because a service resource limit
 	// has been reached.
 	ResourceExhausted ErrorCode = gcerr.ResourceExhausted
+
+	// The operation was canceled.
+	Canceled ErrorCode = gcerr.Canceled
+
+	// The operation timed out.
+	DeadlineExceeded ErrorCode = gcerr.DeadlineExceeded
 )
 
-// Code returns the ErrorCode of err if it is an *Error.
-// It returns Unknown if err is a non-nil error of a different type.
+// Code returns the ErrorCode of err if it, or some error it wraps, is an *Error.
+// If err is context.Canceled or context.DeadlineExceeded, or wraps one of those errors,
+// it returns the Canceled or DeadlineExceeded codes, respectively.
 // If err is nil, it returns the special code OK.
+// Otherwise, it returns Unknown.
 func Code(err error) ErrorCode {
 	if err == nil {
 		return OK
@@ -70,6 +80,12 @@ func Code(err error) ErrorCode {
 	var e *gcerr.Error
 	if xerrors.As(err, &e) {
 		return e.Code
+	}
+	if xerrors.Is(err, context.Canceled) {
+		return Canceled
+	}
+	if xerrors.Is(err, context.DeadlineExceeded) {
+		return DeadlineExceeded
 	}
 	return Unknown
 }

--- a/internal/gcerr/errorcode_string.go
+++ b/internal/gcerr/errorcode_string.go
@@ -4,9 +4,9 @@ package gcerr
 
 import "strconv"
 
-const _ErrorCode_name = "OKUnknownNotFoundAlreadyExistsInvalidArgumentInternalUnimplementedFailedPreconditionPermissionDeniedResourceExhausted"
+const _ErrorCode_name = "OKUnknownNotFoundAlreadyExistsInvalidArgumentInternalUnimplementedFailedPreconditionPermissionDeniedResourceExhaustedCanceledDeadlineExceeded"
 
-var _ErrorCode_index = [...]uint8{0, 2, 9, 17, 30, 45, 53, 66, 84, 100, 117}
+var _ErrorCode_index = [...]uint8{0, 2, 9, 17, 30, 45, 53, 66, 84, 100, 117, 125, 141}
 
 func (i ErrorCode) String() string {
 	if i < 0 || i >= ErrorCode(len(_ErrorCode_index)-1) {

--- a/internal/gcerr/gcerr.go
+++ b/internal/gcerr/gcerr.go
@@ -59,6 +59,12 @@ const (
 	// Some resource has been exhausted, typically because a service resource limit
 	// has been reached.
 	ResourceExhausted ErrorCode = 9
+
+	// The operation was canceled.
+	Canceled ErrorCode = 10
+
+	// The operation timed out.
+	DeadlineExceeded ErrorCode = 11
 )
 
 // When adding a new error code, try to use the names defined in google.golang.org/grpc/codes.
@@ -138,6 +144,10 @@ func GRPCCode(err error) ErrorCode {
 		return PermissionDenied
 	case codes.ResourceExhausted:
 		return ResourceExhausted
+	case codes.Canceled:
+		return Canceled
+	case codes.DeadlineExceeded:
+		return DeadlineExceeded
 	default:
 		return Unknown
 	}


### PR DESCRIPTION
- Add codes that match the two context errors.
- Change gcerrors.Code to recognize the context errors and return the appropriate code.

This is sufficient to ensure that callers of `internal/oc.Tracer.End` will
record helpful codes in traces and metrics.