### PR TITLE
all: avoid wrapping certain errors

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -833,7 +833,7 @@ func wrapError(b driver.Bucket, err error) error {
 	if err == nil {
 		return nil
 	}
-	if err == io.EOF {
+	if gcerr.DoNotWrap(err) {
 		return err
 	}
 	return gcerr.New(b.ErrorCode(err), err, 2, "blob")

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -484,8 +484,7 @@ type errorCoder interface {
 }
 
 func wrapError(ec errorCoder, err error) error {
-	// Don't wrap context errors.
-	if _, ok := err.(*retry.ContextError); ok || err == context.Canceled || err == context.DeadlineExceeded {
+	if gcerr.DoNotWrap(err) {
 		return err
 	}
 	return gcerr.New(ec.ErrorCode(err), err, 2, "pubsub")

--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -167,6 +167,9 @@ func wrapError(w driver.Watcher, err error) error {
 	if err == nil {
 		return nil
 	}
+	if gcerr.DoNotWrap(err) {
+		return err
+	}
 	return gcerr.New(w.ErrorCode(err), err, 2, "runtimevar")
 }
 

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -80,5 +80,8 @@ func (k *Keeper) Decrypt(ctx context.Context, ciphertext []byte) (plaintext []by
 }
 
 func wrapError(k *Keeper, err error) error {
+	if gcerr.DoNotWrap(err) {
+		return err
+	}
 	return gcerr.New(k.k.ErrorCode(err), err, 2, "secrets")
 }


### PR DESCRIPTION
APIs shouldn't wrap errors like context.Canceled and io.EOF, so callers
can test for them directly.