### PR TITLE
pubsub: convert switch statements to maps in awspubsub ErrorCode methods

### DIFF
--- a/pubsub/awspubsub/awspubsub.go
+++ b/pubsub/awspubsub/awspubsub.go
@@ -104,65 +104,31 @@ func (t *topic) ErrorCode(err error) gcerrors.ErrorCode {
 	if !ok {
 		return gcerr.Unknown
 	}
-	switch ae.Code() {
-
-	case sns.ErrCodeAuthorizationErrorException:
-		return gcerr.AuthorizationError
-
-	case sns.ErrCodeEndpointDisabledException:
-		return gcerr.Unknown
-
-	case sns.ErrCodeFilterPolicyLimitExceededException:
-		return gcerr.ResourceExhausted
-
-	case sns.ErrCodeInternalErrorException:
-		return gcerr.Internal
-
-	case sns.ErrCodeInvalidParameterException:
-		return gcerr.InvalidArgument
-
-	case sns.ErrCodeInvalidParameterValueException:
-		return gcerr.InvalidArgument
-
-	case sns.ErrCodeInvalidSecurityException:
-		return gcerr.InvalidCredentials
-
-	case sns.ErrCodeKMSAccessDeniedException:
-		return gcerr.AuthorizationError
-
-	case sns.ErrCodeKMSDisabledException:
-		return gcerr.FailedPrecondition
-
-	case sns.ErrCodeKMSInvalidStateException:
-		return gcerr.FailedPrecondition
-
-	case sns.ErrCodeKMSNotFoundException:
-		return gcerr.NotFound
-
-	case sns.ErrCodeKMSOptInRequired:
-		return gcerr.FailedPrecondition
-
-	case sns.ErrCodeKMSThrottlingException:
-		return gcerr.Throttled
-
-	case sns.ErrCodeNotFoundException:
-		return gcerr.NotFound
-
-	case sns.ErrCodePlatformApplicationDisabledException:
-		return gcerr.Unknown
-
-	case sns.ErrCodeSubscriptionLimitExceededException:
-		return gcerr.ResourceExhausted
-
-	case sns.ErrCodeThrottledException:
-		return gcerr.Throttled
-
-	case sns.ErrCodeTopicLimitExceededException:
-		return gcerr.ResourceExhausted
-
-	default:
+	m := map[string]gcerrors.ErrorCode{
+		sns.ErrCodeAuthorizationErrorException:          gcerr.AuthorizationError,
+		sns.ErrCodeEndpointDisabledException:            gcerr.Unknown,
+		sns.ErrCodeFilterPolicyLimitExceededException:   gcerr.ResourceExhausted,
+		sns.ErrCodeInternalErrorException:               gcerr.Internal,
+		sns.ErrCodeInvalidParameterException:            gcerr.InvalidArgument,
+		sns.ErrCodeInvalidParameterValueException:       gcerr.InvalidArgument,
+		sns.ErrCodeInvalidSecurityException:             gcerr.InvalidCredentials,
+		sns.ErrCodeKMSAccessDeniedException:             gcerr.AuthorizationError,
+		sns.ErrCodeKMSDisabledException:                 gcerr.FailedPrecondition,
+		sns.ErrCodeKMSInvalidStateException:             gcerr.FailedPrecondition,
+		sns.ErrCodeKMSNotFoundException:                 gcerr.NotFound,
+		sns.ErrCodeKMSOptInRequired:                     gcerr.FailedPrecondition,
+		sns.ErrCodeKMSThrottlingException:               gcerr.Throttled,
+		sns.ErrCodeNotFoundException:                    gcerr.NotFound,
+		sns.ErrCodePlatformApplicationDisabledException: gcerr.Unknown,
+		sns.ErrCodeSubscriptionLimitExceededException:   gcerr.ResourceExhausted,
+		sns.ErrCodeThrottledException:                   gcerr.Throttled,
+		sns.ErrCodeTopicLimitExceededException:          gcerr.ResourceExhausted,
+	}
+	ec, ok := m[ae.Code()]
+	if !ok {
 		return gcerr.Unknown
 	}
+	return ec
 }
 
 type subscription struct {
@@ -266,58 +232,29 @@ func (t *subscription) ErrorCode(err error) gcerrors.ErrorCode {
 	if !ok {
 		return gcerr.Unknown
 	}
-	switch ae.Code() {
-	case sqs.ErrCodeBatchEntryIdsNotDistinct:
-		return gcerr.InvalidArgument
-
-	case sqs.ErrCodeBatchRequestTooLong:
-		return gcerr.InvalidArgument
-
-	case sqs.ErrCodeEmptyBatchRequest:
-		return gcerr.InvalidArgument
-
-	case sqs.ErrCodeInvalidAttributeName:
-		return gcerr.InvalidArgument
-
-	case sqs.ErrCodeInvalidBatchEntryId:
-		return gcerr.InvalidArgument
-
-	case sqs.ErrCodeInvalidIdFormat:
-		return gcerr.InvalidArgument
-
-	case sqs.ErrCodeInvalidMessageContents:
-		return gcerr.InvalidArgument
-
-	case sqs.ErrCodeMessageNotInflight:
-		return gcerr.FailedPrecondition
-
-	case sqs.ErrCodeOverLimit:
-		return gcerr.ResourceExhausted
-
-	case sqs.ErrCodePurgeQueueInProgress:
-		return gcerr.FailedPrecondition
-
-	case sqs.ErrCodeQueueDeletedRecently:
-		return gcerr.FailedPrecondition
-
-	case sqs.ErrCodeQueueDoesNotExist:
-		return gcerr.FailedPrecondition
-
-	case sqs.ErrCodeQueueNameExists:
-		return gcerr.FailedPrecondition
-
-	case sqs.ErrCodeReceiptHandleIsInvalid:
-		return gcerr.InvalidArgument
-
-	case sqs.ErrCodeTooManyEntriesInBatchRequest:
-		return gcerr.InvalidArgument
-
-	case sqs.ErrCodeUnsupportedOperation:
-		return gcerr.InvalidArgument
-
-	default:
+	m := map[string]gcerrors.ErrorCode{
+		sqs.ErrCodeBatchEntryIdsNotDistinct:     gcerr.InvalidArgument,
+		sqs.ErrCodeBatchRequestTooLong:          gcerr.InvalidArgument,
+		sqs.ErrCodeEmptyBatchRequest:            gcerr.InvalidArgument,
+		sqs.ErrCodeInvalidAttributeName:         gcerr.InvalidArgument,
+		sqs.ErrCodeInvalidBatchEntryId:          gcerr.InvalidArgument,
+		sqs.ErrCodeInvalidIdFormat:              gcerr.InvalidArgument,
+		sqs.ErrCodeInvalidMessageContents:       gcerr.InvalidArgument,
+		sqs.ErrCodeMessageNotInflight:           gcerr.FailedPrecondition,
+		sqs.ErrCodeOverLimit:                    gcerr.ResourceExhausted,
+		sqs.ErrCodePurgeQueueInProgress:         gcerr.FailedPrecondition,
+		sqs.ErrCodeQueueDeletedRecently:         gcerr.FailedPrecondition,
+		sqs.ErrCodeQueueDoesNotExist:            gcerr.FailedPrecondition,
+		sqs.ErrCodeQueueNameExists:              gcerr.FailedPrecondition,
+		sqs.ErrCodeReceiptHandleIsInvalid:       gcerr.InvalidArgument,
+		sqs.ErrCodeTooManyEntriesInBatchRequest: gcerr.InvalidArgument,
+		sqs.ErrCodeUnsupportedOperation:         gcerr.InvalidArgument,
+	}
+	ec, ok := m[ae.Code()]
+	if !ok {
 		return gcerr.Unknown
 	}
+	return ec
 }
 
 func errorAs(err error, target interface{}) bool {

--- a/pubsub/awspubsub/awspubsub.go
+++ b/pubsub/awspubsub/awspubsub.go
@@ -104,31 +104,32 @@ func (t *topic) ErrorCode(err error) gcerrors.ErrorCode {
 	if !ok {
 		return gcerr.Unknown
 	}
-	m := map[string]gcerrors.ErrorCode{
-		sns.ErrCodeAuthorizationErrorException:          gcerr.AuthorizationError,
-		sns.ErrCodeEndpointDisabledException:            gcerr.Unknown,
-		sns.ErrCodeFilterPolicyLimitExceededException:   gcerr.ResourceExhausted,
-		sns.ErrCodeInternalErrorException:               gcerr.Internal,
-		sns.ErrCodeInvalidParameterException:            gcerr.InvalidArgument,
-		sns.ErrCodeInvalidParameterValueException:       gcerr.InvalidArgument,
-		sns.ErrCodeInvalidSecurityException:             gcerr.InvalidCredentials,
-		sns.ErrCodeKMSAccessDeniedException:             gcerr.AuthorizationError,
-		sns.ErrCodeKMSDisabledException:                 gcerr.FailedPrecondition,
-		sns.ErrCodeKMSInvalidStateException:             gcerr.FailedPrecondition,
-		sns.ErrCodeKMSNotFoundException:                 gcerr.NotFound,
-		sns.ErrCodeKMSOptInRequired:                     gcerr.FailedPrecondition,
-		sns.ErrCodeKMSThrottlingException:               gcerr.Throttled,
-		sns.ErrCodeNotFoundException:                    gcerr.NotFound,
-		sns.ErrCodePlatformApplicationDisabledException: gcerr.Unknown,
-		sns.ErrCodeSubscriptionLimitExceededException:   gcerr.ResourceExhausted,
-		sns.ErrCodeThrottledException:                   gcerr.Throttled,
-		sns.ErrCodeTopicLimitExceededException:          gcerr.ResourceExhausted,
-	}
-	ec, ok := m[ae.Code()]
+	ec, ok := topicErrorCodeMap[ae.Code()]
 	if !ok {
 		return gcerr.Unknown
 	}
 	return ec
+}
+
+var topicErrorCodeMap = map[string]gcerrors.ErrorCode{
+	sns.ErrCodeAuthorizationErrorException:          gcerr.AuthorizationError,
+	sns.ErrCodeEndpointDisabledException:            gcerr.Unknown,
+	sns.ErrCodeFilterPolicyLimitExceededException:   gcerr.ResourceExhausted,
+	sns.ErrCodeInternalErrorException:               gcerr.Internal,
+	sns.ErrCodeInvalidParameterException:            gcerr.InvalidArgument,
+	sns.ErrCodeInvalidParameterValueException:       gcerr.InvalidArgument,
+	sns.ErrCodeInvalidSecurityException:             gcerr.InvalidCredentials,
+	sns.ErrCodeKMSAccessDeniedException:             gcerr.AuthorizationError,
+	sns.ErrCodeKMSDisabledException:                 gcerr.FailedPrecondition,
+	sns.ErrCodeKMSInvalidStateException:             gcerr.FailedPrecondition,
+	sns.ErrCodeKMSNotFoundException:                 gcerr.NotFound,
+	sns.ErrCodeKMSOptInRequired:                     gcerr.FailedPrecondition,
+	sns.ErrCodeKMSThrottlingException:               gcerr.Throttled,
+	sns.ErrCodeNotFoundException:                    gcerr.NotFound,
+	sns.ErrCodePlatformApplicationDisabledException: gcerr.Unknown,
+	sns.ErrCodeSubscriptionLimitExceededException:   gcerr.ResourceExhausted,
+	sns.ErrCodeThrottledException:                   gcerr.Throttled,
+	sns.ErrCodeTopicLimitExceededException:          gcerr.ResourceExhausted,
 }
 
 type subscription struct {
@@ -232,29 +233,30 @@ func (t *subscription) ErrorCode(err error) gcerrors.ErrorCode {
 	if !ok {
 		return gcerr.Unknown
 	}
-	m := map[string]gcerrors.ErrorCode{
-		sqs.ErrCodeBatchEntryIdsNotDistinct:     gcerr.InvalidArgument,
-		sqs.ErrCodeBatchRequestTooLong:          gcerr.InvalidArgument,
-		sqs.ErrCodeEmptyBatchRequest:            gcerr.InvalidArgument,
-		sqs.ErrCodeInvalidAttributeName:         gcerr.InvalidArgument,
-		sqs.ErrCodeInvalidBatchEntryId:          gcerr.InvalidArgument,
-		sqs.ErrCodeInvalidIdFormat:              gcerr.InvalidArgument,
-		sqs.ErrCodeInvalidMessageContents:       gcerr.InvalidArgument,
-		sqs.ErrCodeMessageNotInflight:           gcerr.FailedPrecondition,
-		sqs.ErrCodeOverLimit:                    gcerr.ResourceExhausted,
-		sqs.ErrCodePurgeQueueInProgress:         gcerr.FailedPrecondition,
-		sqs.ErrCodeQueueDeletedRecently:         gcerr.FailedPrecondition,
-		sqs.ErrCodeQueueDoesNotExist:            gcerr.FailedPrecondition,
-		sqs.ErrCodeQueueNameExists:              gcerr.FailedPrecondition,
-		sqs.ErrCodeReceiptHandleIsInvalid:       gcerr.InvalidArgument,
-		sqs.ErrCodeTooManyEntriesInBatchRequest: gcerr.InvalidArgument,
-		sqs.ErrCodeUnsupportedOperation:         gcerr.InvalidArgument,
-	}
-	ec, ok := m[ae.Code()]
+	ec, ok := subscriptionErrorCodeMap[ae.Code()]
 	if !ok {
 		return gcerr.Unknown
 	}
 	return ec
+}
+
+var subscriptionErrorCodeMap = map[string]gcerrors.ErrorCode{
+	sqs.ErrCodeBatchEntryIdsNotDistinct:     gcerr.InvalidArgument,
+	sqs.ErrCodeBatchRequestTooLong:          gcerr.InvalidArgument,
+	sqs.ErrCodeEmptyBatchRequest:            gcerr.InvalidArgument,
+	sqs.ErrCodeInvalidAttributeName:         gcerr.InvalidArgument,
+	sqs.ErrCodeInvalidBatchEntryId:          gcerr.InvalidArgument,
+	sqs.ErrCodeInvalidIdFormat:              gcerr.InvalidArgument,
+	sqs.ErrCodeInvalidMessageContents:       gcerr.InvalidArgument,
+	sqs.ErrCodeMessageNotInflight:           gcerr.FailedPrecondition,
+	sqs.ErrCodeOverLimit:                    gcerr.ResourceExhausted,
+	sqs.ErrCodePurgeQueueInProgress:         gcerr.FailedPrecondition,
+	sqs.ErrCodeQueueDeletedRecently:         gcerr.FailedPrecondition,
+	sqs.ErrCodeQueueDoesNotExist:            gcerr.FailedPrecondition,
+	sqs.ErrCodeQueueNameExists:              gcerr.FailedPrecondition,
+	sqs.ErrCodeReceiptHandleIsInvalid:       gcerr.InvalidArgument,
+	sqs.ErrCodeTooManyEntriesInBatchRequest: gcerr.InvalidArgument,
+	sqs.ErrCodeUnsupportedOperation:         gcerr.InvalidArgument,
 }
 
 func errorAs(err error, target interface{}) bool {

--- a/pubsub/awspubsub/awspubsub.go
+++ b/pubsub/awspubsub/awspubsub.go
@@ -113,23 +113,23 @@ func (t *topic) ErrorCode(err error) gcerrors.ErrorCode {
 
 var topicErrorCodeMap = map[string]gcerrors.ErrorCode{
 	sns.ErrCodeAuthorizationErrorException:          gcerr.AuthorizationError,
-	sns.ErrCodeEndpointDisabledException:            gcerr.Unknown,
-	sns.ErrCodeFilterPolicyLimitExceededException:   gcerr.ResourceExhausted,
+	sns.ErrCodeKMSAccessDeniedException:             gcerr.AuthorizationError,
+	sns.ErrCodeKMSDisabledException:                 gcerr.FailedPrecondition,
+	sns.ErrCodeKMSInvalidStateException:             gcerr.FailedPrecondition,
+	sns.ErrCodeKMSOptInRequired:                     gcerr.FailedPrecondition,
 	sns.ErrCodeInternalErrorException:               gcerr.Internal,
 	sns.ErrCodeInvalidParameterException:            gcerr.InvalidArgument,
 	sns.ErrCodeInvalidParameterValueException:       gcerr.InvalidArgument,
 	sns.ErrCodeInvalidSecurityException:             gcerr.InvalidCredentials,
-	sns.ErrCodeKMSAccessDeniedException:             gcerr.AuthorizationError,
-	sns.ErrCodeKMSDisabledException:                 gcerr.FailedPrecondition,
-	sns.ErrCodeKMSInvalidStateException:             gcerr.FailedPrecondition,
 	sns.ErrCodeKMSNotFoundException:                 gcerr.NotFound,
-	sns.ErrCodeKMSOptInRequired:                     gcerr.FailedPrecondition,
-	sns.ErrCodeKMSThrottlingException:               gcerr.Throttled,
 	sns.ErrCodeNotFoundException:                    gcerr.NotFound,
-	sns.ErrCodePlatformApplicationDisabledException: gcerr.Unknown,
 	sns.ErrCodeSubscriptionLimitExceededException:   gcerr.ResourceExhausted,
-	sns.ErrCodeThrottledException:                   gcerr.Throttled,
+	sns.ErrCodeFilterPolicyLimitExceededException:   gcerr.ResourceExhausted,
 	sns.ErrCodeTopicLimitExceededException:          gcerr.ResourceExhausted,
+	sns.ErrCodeKMSThrottlingException:               gcerr.Throttled,
+	sns.ErrCodeThrottledException:                   gcerr.Throttled,
+	sns.ErrCodePlatformApplicationDisabledException: gcerr.Unknown,
+	sns.ErrCodeEndpointDisabledException:            gcerr.Unknown,
 }
 
 type subscription struct {
@@ -248,15 +248,15 @@ var subscriptionErrorCodeMap = map[string]gcerrors.ErrorCode{
 	sqs.ErrCodeInvalidBatchEntryId:          gcerr.InvalidArgument,
 	sqs.ErrCodeInvalidIdFormat:              gcerr.InvalidArgument,
 	sqs.ErrCodeInvalidMessageContents:       gcerr.InvalidArgument,
-	sqs.ErrCodeMessageNotInflight:           gcerr.FailedPrecondition,
+	sqs.ErrCodeReceiptHandleIsInvalid:       gcerr.InvalidArgument,
+	sqs.ErrCodeTooManyEntriesInBatchRequest: gcerr.InvalidArgument,
+	sqs.ErrCodeUnsupportedOperation:         gcerr.InvalidArgument,
 	sqs.ErrCodeOverLimit:                    gcerr.ResourceExhausted,
+	sqs.ErrCodeMessageNotInflight:           gcerr.FailedPrecondition,
 	sqs.ErrCodePurgeQueueInProgress:         gcerr.FailedPrecondition,
 	sqs.ErrCodeQueueDeletedRecently:         gcerr.FailedPrecondition,
 	sqs.ErrCodeQueueDoesNotExist:            gcerr.FailedPrecondition,
 	sqs.ErrCodeQueueNameExists:              gcerr.FailedPrecondition,
-	sqs.ErrCodeReceiptHandleIsInvalid:       gcerr.InvalidArgument,
-	sqs.ErrCodeTooManyEntriesInBatchRequest: gcerr.InvalidArgument,
-	sqs.ErrCodeUnsupportedOperation:         gcerr.InvalidArgument,
 }
 
 func errorAs(err error, target interface{}) bool {

--- a/pubsub/awspubsub/awspubsub.go
+++ b/pubsub/awspubsub/awspubsub.go
@@ -24,6 +24,7 @@ package awspubsub
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sns"
@@ -100,36 +101,56 @@ func (t *topic) ErrorAs(err error, target interface{}) bool {
 
 // ErrorCode implements driver.Topic.ErrorCode.
 func (t *topic) ErrorCode(err error) gcerrors.ErrorCode {
+	return errorCode(err)
+}
+
+func errorCode(err error) gcerrors.ErrorCode {
 	ae, ok := err.(awserr.Error)
 	if !ok {
 		return gcerr.Unknown
 	}
-	ec, ok := topicErrorCodeMap[ae.Code()]
+	ec, ok := errorCodeMap[ae.Code()]
 	if !ok {
 		return gcerr.Unknown
 	}
 	return ec
 }
 
-var topicErrorCodeMap = map[string]gcerrors.ErrorCode{
+var errorCodeMap = map[string]gcerrors.ErrorCode{
 	sns.ErrCodeAuthorizationErrorException:          gcerr.AuthorizationError,
 	sns.ErrCodeKMSAccessDeniedException:             gcerr.AuthorizationError,
 	sns.ErrCodeKMSDisabledException:                 gcerr.FailedPrecondition,
 	sns.ErrCodeKMSInvalidStateException:             gcerr.FailedPrecondition,
 	sns.ErrCodeKMSOptInRequired:                     gcerr.FailedPrecondition,
+	sqs.ErrCodeMessageNotInflight:                   gcerr.FailedPrecondition,
+	sqs.ErrCodePurgeQueueInProgress:                 gcerr.FailedPrecondition,
+	sqs.ErrCodeQueueDeletedRecently:                 gcerr.FailedPrecondition,
+	sqs.ErrCodeQueueDoesNotExist:                    gcerr.FailedPrecondition,
+	sqs.ErrCodeQueueNameExists:                      gcerr.FailedPrecondition,
 	sns.ErrCodeInternalErrorException:               gcerr.Internal,
 	sns.ErrCodeInvalidParameterException:            gcerr.InvalidArgument,
 	sns.ErrCodeInvalidParameterValueException:       gcerr.InvalidArgument,
+	sqs.ErrCodeBatchEntryIdsNotDistinct:             gcerr.InvalidArgument,
+	sqs.ErrCodeBatchRequestTooLong:                  gcerr.InvalidArgument,
+	sqs.ErrCodeEmptyBatchRequest:                    gcerr.InvalidArgument,
+	sqs.ErrCodeInvalidAttributeName:                 gcerr.InvalidArgument,
+	sqs.ErrCodeInvalidBatchEntryId:                  gcerr.InvalidArgument,
+	sqs.ErrCodeInvalidIdFormat:                      gcerr.InvalidArgument,
+	sqs.ErrCodeInvalidMessageContents:               gcerr.InvalidArgument,
+	sqs.ErrCodeReceiptHandleIsInvalid:               gcerr.InvalidArgument,
+	sqs.ErrCodeTooManyEntriesInBatchRequest:         gcerr.InvalidArgument,
+	sqs.ErrCodeUnsupportedOperation:                 gcerr.InvalidArgument,
 	sns.ErrCodeInvalidSecurityException:             gcerr.InvalidCredentials,
 	sns.ErrCodeKMSNotFoundException:                 gcerr.NotFound,
 	sns.ErrCodeNotFoundException:                    gcerr.NotFound,
-	sns.ErrCodeSubscriptionLimitExceededException:   gcerr.ResourceExhausted,
 	sns.ErrCodeFilterPolicyLimitExceededException:   gcerr.ResourceExhausted,
+	sns.ErrCodeSubscriptionLimitExceededException:   gcerr.ResourceExhausted,
 	sns.ErrCodeTopicLimitExceededException:          gcerr.ResourceExhausted,
+	sqs.ErrCodeOverLimit:                            gcerr.ResourceExhausted,
 	sns.ErrCodeKMSThrottlingException:               gcerr.Throttled,
 	sns.ErrCodeThrottledException:                   gcerr.Throttled,
-	sns.ErrCodePlatformApplicationDisabledException: gcerr.Unknown,
 	sns.ErrCodeEndpointDisabledException:            gcerr.Unknown,
+	sns.ErrCodePlatformApplicationDisabledException: gcerr.Unknown,
 }
 
 type subscription struct {
@@ -229,34 +250,7 @@ func (s *subscription) ErrorAs(err error, target interface{}) bool {
 
 // ErrorCode implements driver.Subscription.ErrorCode.
 func (t *subscription) ErrorCode(err error) gcerrors.ErrorCode {
-	ae, ok := err.(awserr.Error)
-	if !ok {
-		return gcerr.Unknown
-	}
-	ec, ok := subscriptionErrorCodeMap[ae.Code()]
-	if !ok {
-		return gcerr.Unknown
-	}
-	return ec
-}
-
-var subscriptionErrorCodeMap = map[string]gcerrors.ErrorCode{
-	sqs.ErrCodeBatchEntryIdsNotDistinct:     gcerr.InvalidArgument,
-	sqs.ErrCodeBatchRequestTooLong:          gcerr.InvalidArgument,
-	sqs.ErrCodeEmptyBatchRequest:            gcerr.InvalidArgument,
-	sqs.ErrCodeInvalidAttributeName:         gcerr.InvalidArgument,
-	sqs.ErrCodeInvalidBatchEntryId:          gcerr.InvalidArgument,
-	sqs.ErrCodeInvalidIdFormat:              gcerr.InvalidArgument,
-	sqs.ErrCodeInvalidMessageContents:       gcerr.InvalidArgument,
-	sqs.ErrCodeReceiptHandleIsInvalid:       gcerr.InvalidArgument,
-	sqs.ErrCodeTooManyEntriesInBatchRequest: gcerr.InvalidArgument,
-	sqs.ErrCodeUnsupportedOperation:         gcerr.InvalidArgument,
-	sqs.ErrCodeOverLimit:                    gcerr.ResourceExhausted,
-	sqs.ErrCodeMessageNotInflight:           gcerr.FailedPrecondition,
-	sqs.ErrCodePurgeQueueInProgress:         gcerr.FailedPrecondition,
-	sqs.ErrCodeQueueDeletedRecently:         gcerr.FailedPrecondition,
-	sqs.ErrCodeQueueDoesNotExist:            gcerr.FailedPrecondition,
-	sqs.ErrCodeQueueNameExists:              gcerr.FailedPrecondition,
+	return errorCode(err)
 }
 
 func errorAs(err error, target interface{}) bool {


### PR DESCRIPTION
This reduces the verbosity and the amount of branching in in these methods.