### PR TITLE
internal/gcerr: remove some error codes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -654,6 +654,7 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 h1:z99zHgr7hKfrUcX/KsoJk5FJfjTceCKIp96+biqP4To=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 h1:+DCIGbF/swA92ohVg0//6X2IVY3KZs6p9mix0ziNYJM=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c h1:fqgJT0MGcGpPgpWU7VRdRjuArfcOvC4AoJmILihzhDg=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/internal/gcerr/gcerr.go
+++ b/internal/gcerr/gcerr.go
@@ -68,15 +68,6 @@ const (
 
 	// The operation timed out.
 	DeadlineExceeded ErrorCode = 11
-
-	// This user does not have access to the resource.
-	AuthorizationError = 12
-
-	// The credentials are not valid.
-	InvalidCredentials = 13
-
-	// The request was denied due to throttling.
-	Throttled = 14
 )
 
 // When adding a new error code, try to use the names defined in google.golang.org/grpc/codes.

--- a/pubsub/awspubsub/awspubsub.go
+++ b/pubsub/awspubsub/awspubsub.go
@@ -117,8 +117,8 @@ func errorCode(err error) gcerrors.ErrorCode {
 }
 
 var errorCodeMap = map[string]gcerrors.ErrorCode{
-	sns.ErrCodeAuthorizationErrorException:          gcerr.AuthorizationError,
-	sns.ErrCodeKMSAccessDeniedException:             gcerr.AuthorizationError,
+	sns.ErrCodeAuthorizationErrorException:          gcerr.PermissionDenied,
+	sns.ErrCodeKMSAccessDeniedException:             gcerr.PermissionDenied,
 	sns.ErrCodeKMSDisabledException:                 gcerr.FailedPrecondition,
 	sns.ErrCodeKMSInvalidStateException:             gcerr.FailedPrecondition,
 	sns.ErrCodeKMSOptInRequired:                     gcerr.FailedPrecondition,
@@ -140,15 +140,15 @@ var errorCodeMap = map[string]gcerrors.ErrorCode{
 	sqs.ErrCodeReceiptHandleIsInvalid:               gcerr.InvalidArgument,
 	sqs.ErrCodeTooManyEntriesInBatchRequest:         gcerr.InvalidArgument,
 	sqs.ErrCodeUnsupportedOperation:                 gcerr.InvalidArgument,
-	sns.ErrCodeInvalidSecurityException:             gcerr.InvalidCredentials,
+	sns.ErrCodeInvalidSecurityException:             gcerr.PermissionDenied,
 	sns.ErrCodeKMSNotFoundException:                 gcerr.NotFound,
 	sns.ErrCodeNotFoundException:                    gcerr.NotFound,
 	sns.ErrCodeFilterPolicyLimitExceededException:   gcerr.ResourceExhausted,
 	sns.ErrCodeSubscriptionLimitExceededException:   gcerr.ResourceExhausted,
 	sns.ErrCodeTopicLimitExceededException:          gcerr.ResourceExhausted,
 	sqs.ErrCodeOverLimit:                            gcerr.ResourceExhausted,
-	sns.ErrCodeKMSThrottlingException:               gcerr.Throttled,
-	sns.ErrCodeThrottledException:                   gcerr.Throttled,
+	sns.ErrCodeKMSThrottlingException:               gcerr.ResourceExhausted,
+	sns.ErrCodeThrottledException:                   gcerr.ResourceExhausted,
 	sns.ErrCodeEndpointDisabledException:            gcerr.Unknown,
 	sns.ErrCodePlatformApplicationDisabledException: gcerr.Unknown,
 }


### PR DESCRIPTION
In an attempt to keep to a minimal set of error codes, remove two codes
that map to PermissionDenied and one that maps to ResourceExhausted.