### PR TITLE
internal: simplify workerpool.Run to return funcs from nextTask, not interface{}

### DIFF
--- a/internal/workerpool/pool.go
+++ b/internal/workerpool/pool.go
@@ -22,12 +22,15 @@ import (
 	"context"
 )
 
-// Run runs a worker pool with no more than limit goroutines. It gets tasks
-// from the nextTask func. If nextTask returns nil, Run will no longer ask for
-// more tasks, and will return after waiting for the running goroutines to
-// finish. Each func returned from nextTask is a unit of work to be performed.
-// The provided context can be used to cancel everything and exit the loop.
-func Run(ctx context.Context, limit int, nextTask func(context.Context) func(context.Context)) {
+type Task func(context.Context)
+
+// Run runs a worker pool with no more than limit goroutines. It repeatedly
+// calls nextTask to get tasks to perform. These tasks are in the form of funcs
+// that do some work via side effects. If nextTask returns nil, Run will no
+// longer ask for more tasks, and will return after waiting for the running
+// goroutines to finish. The provided context can be used to cancel everything
+// and exit the loop.
+func Run(ctx context.Context, limit int, nextTask func(context.Context) Task) {
 	type token struct{}
 	sem := make(chan token, limit)
 Loop:

--- a/internal/workerpool/pool.go
+++ b/internal/workerpool/pool.go
@@ -25,24 +25,24 @@ import (
 // Run runs a worker pool with no more than limit goroutines. It gets tasks
 // from the nextTask func. If nextTask returns nil, Run will no longer ask for
 // more tasks, and will return after waiting for the running goroutines to
-// finish. The doWork func processes a single task. The provided context can
-// be used to cancel everything and exit the loop.
-func Run(ctx context.Context, limit int, nextTask func(context.Context) interface{}, doWork func(ctx context.Context, task interface{})) {
+// finish. Each func returned from nextTask is a unit of work to be performed.
+// The provided context can be used to cancel everything and exit the loop.
+func Run(ctx context.Context, limit int, nextTask func(context.Context) func(context.Context)) {
 	type token struct{}
 	sem := make(chan token, limit)
 Loop:
 	for {
-		task := nextTask(ctx)
-		if task == nil {
+		doTask := nextTask(ctx)
+		if doTask == nil {
 			break
 		}
 		select {
 		case <-ctx.Done():
 			break Loop
-		case sem <-token{}:
+		case sem <- token{}:
 		}
 		go func() {
-			doWork(ctx, task)
+			doTask(ctx)
 			<-sem
 		}()
 	}

--- a/internal/workerpool/pool_test.go
+++ b/internal/workerpool/pool_test.go
@@ -28,16 +28,15 @@ func TestRun(t *testing.T) {
 	t.Run("can be canceled", func(t *testing.T) {
 		ng0 := runtime.NumGoroutine()
 		ctx, cancel := context.WithCancel(context.Background())
-		type Task struct{}
-		nextTask := func(context.Context) interface{} {
-			return Task{}
+		nextTask := func(context.Context) func(context.Context) {
+			return func(context.Context) {
+				<-ctx.Done()
+			}
 		}
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
-			workerpool.Run(ctx, 1, nextTask, func(ctx context.Context, _ interface{}) {
-				<-ctx.Done()
-			})
+			workerpool.Run(ctx, 1, nextTask)
 			wg.Done()
 		}()
 		cancel()
@@ -52,32 +51,28 @@ func TestRun(t *testing.T) {
 		ng0 := runtime.NumGoroutine()
 		i := 0
 		n := 100
-		type Task struct{ i int }
-		nextTask := func(context.Context) interface{} {
+		// m keeps track of which tasks have been completed.
+		var mu sync.Mutex
+		m := make(map[int]bool)
+		nextTask := func(context.Context) func(context.Context) {
 			i++
 			if i > n {
 				return nil
 			}
-			return Task{i}
+			return func(i int) func(context.Context) {
+				return func(context.Context) {
+					mu.Lock()
+					m[i] = true
+					mu.Unlock()
+				}
+			}(i)
 		}
 
-		// m keeps track of which tasks have yet to be completed.
-		var mu sync.Mutex
-		m := make(map[int]bool)
-		for i := 1; i <= n; i++ {
-			m[i] = true
-		}
-
-		workerpool.Run(context.Background(), 10, nextTask, func(ctx context.Context, ti interface{}) {
-			t := ti.(Task)
-			mu.Lock()
-			defer mu.Unlock()
-			delete(m, t.i)
-		})
+		workerpool.Run(context.Background(), 10, nextTask)
 		t.Log("waiting for tasks to finish")
 		for {
 			mu.Lock()
-			if len(m) == 0 {
+			if len(m) == n {
 				break
 			}
 			mu.Unlock()

--- a/internal/workerpool/pool_test.go
+++ b/internal/workerpool/pool_test.go
@@ -28,7 +28,7 @@ func TestRun(t *testing.T) {
 	t.Run("can be canceled", func(t *testing.T) {
 		ng0 := runtime.NumGoroutine()
 		ctx, cancel := context.WithCancel(context.Background())
-		nextTask := func(context.Context) func(context.Context) {
+		nextTask := func(context.Context) workerpool.Task {
 			return func(context.Context) {
 				<-ctx.Done()
 			}
@@ -54,12 +54,12 @@ func TestRun(t *testing.T) {
 		// m keeps track of which tasks have been completed.
 		var mu sync.Mutex
 		m := make(map[int]bool)
-		nextTask := func(context.Context) func(context.Context) {
+		nextTask := func(context.Context) workerpool.Task {
 			i++
 			if i > n {
 				return nil
 			}
-			return func(i int) func(context.Context) {
+			return func(i int) workerpool.Task {
 				return func(context.Context) {
 					mu.Lock()
 					m[i] = true


### PR DESCRIPTION
With this change, there is no more lack of type safety in `workerpool.Run`.

This is based on an idea from @jba.
