### PR TITLE
pusbsub: add benchmark for aws

### DIFF
--- a/pubsub/drivertest/drivertest.go
+++ b/pubsub/drivertest/drivertest.go
@@ -472,7 +472,7 @@ func benchmarkReceive(b *testing.B, topic *pubsub.Topic, sub *pubsub.Subscriptio
 	attrs := map[string]string{"label": "value"}
 	body := []byte("hello, world")
 	const (
-		nMessages          = 10000
+		nMessages          = 1000
 		concurrencySend    = 100
 		concurrencyReceive = 1
 	)


### PR DESCRIPTION
Fixes #1235.

It runs at about 10 messages per second, most likely indicating a problem in our code.