### PR TITLE
proxy: add goveralls installation into makeproxy

### DIFF
--- a/internal/proxy/makeproxy.sh
+++ b/internal/proxy/makeproxy.sh
@@ -38,7 +38,7 @@ repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." >/dev/null 2>&1 && pwd
 for path in "." "internal/contributebot" "samples/appengine"; do
   cd "$repo_root/$path"
   go mod download
-  # We need to install goveralls because Travis uses it for tests and will look
+  # We need to get goveralls because Travis uses it for tests and will look
   # for it in the module proxy.
-  go install github.com/mattn/goveralls
+  go get github.com/mattn/goveralls
 done

--- a/internal/proxy/makeproxy.sh
+++ b/internal/proxy/makeproxy.sh
@@ -38,4 +38,7 @@ repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." >/dev/null 2>&1 && pwd
 for path in "." "internal/contributebot" "samples/appengine"; do
   cd "$repo_root/$path"
   go mod download
+  # We need to install goveralls because Travis uses it for tests and will look
+  # for it in the module proxy.
+  go install github.com/mattn/goveralls
 done


### PR DESCRIPTION
Our project doesn't depend on goveralls directly, but Travis uses it. Travis runs 

```
  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
      go install github.com/mattn/goveralls;
    fi
```

Which ends up in our proxy. The proxy should, therefore, have goveralls installed.
