### PR TITLE
all: factor out common ErrorAs behavior

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -96,7 +96,6 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -498,15 +497,10 @@ func (b *Bucket) As(i interface{}) bool {
 
 // ErrorAs converts i to provider-specific types.
 // ErrorAs panics if i is nil or not a pointer.
+// ErrorAs returns false if err == nil.
 // See Bucket.As for more details.
 func (b *Bucket) ErrorAs(err error, i interface{}) bool {
-	if i == nil || reflect.TypeOf(i).Kind() != reflect.Ptr {
-		panic("blob: ErrorAs i must be a non-nil pointer")
-	}
-	if e, ok := err.(*gcerr.Error); ok {
-		return b.b.ErrorAs(e.Unwrap(), i)
-	}
-	return b.b.ErrorAs(err, i)
+	return gcerr.ErrorAs(err, i, b.b.ErrorAs)
 }
 
 // ReadAll is a shortcut for creating a Reader via NewReader with nil

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -211,24 +211,11 @@ func (t *Topic) As(i interface{}) bool {
 }
 
 // ErrorAs converts err to provider-specific types.
-// See Topic.As for more details.
 // ErrorAs panics if target is nil or not a pointer.
 // ErrorAs returns false if err == nil.
+// See Topic.As for more details.
 func (t *Topic) ErrorAs(err error, target interface{}) bool {
-	return errorAs(t.driver.ErrorAs, err, target)
-}
-
-func errorAs(erras func(error, interface{}) bool, err error, target interface{}) bool {
-	if target == nil || reflect.TypeOf(target).Kind() != reflect.Ptr {
-		panic("pubsub: ErrorAs target must be a non-nil pointer")
-	}
-	if err == nil {
-		return false
-	}
-	if e, ok := err.(*gcerr.Error); ok {
-		err = e.Unwrap()
-	}
-	return erras(err, target)
+	return gcerr.ErrorAs(err, target, t.driver.ErrorAs)
 }
 
 // NewTopic is for use by provider implementations.
@@ -481,6 +468,14 @@ func (s *Subscription) Shutdown(ctx context.Context) (err error) {
 // See Topic.As for more details.
 func (s *Subscription) As(i interface{}) bool {
 	return s.driver.As(i)
+}
+
+// ErrorAs converts err to provider-specific types.
+// ErrorAs panics if target is nil or not a pointer.
+// ErrorAs returns false if err == nil.
+// See Topic.As for more details.
+func (s *Subscription) ErrorAs(err error, target interface{}) bool {
+	return gcerr.ErrorAs(err, target, s.driver.ErrorAs)
 }
 
 // NewSubscription is for use by provider implementations.

--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -210,18 +210,10 @@ func wrapError(w driver.Watcher, err error) error {
 
 // ErrorAs converts i to provider-specific types.
 // ErrorAs panics if i is nil or not a pointer.
+// ErrorAs returns false if err == nil.
 // See Snapshot.As for more details.
 func (c *Variable) ErrorAs(err error, i interface{}) bool {
-	if err == nil {
-		return false
-	}
-	if i == nil || reflect.TypeOf(i).Kind() != reflect.Ptr {
-		panic("runtimevar: ErrorAs i must be a non-nil pointer")
-	}
-	if e, ok := err.(*gcerr.Error); ok {
-		return c.watcher.ErrorAs(e.Unwrap(), i)
-	}
-	return c.watcher.ErrorAs(err, i)
+	return gcerr.ErrorAs(err, i, c.watcher.ErrorAs)
 }
 
 // Decode is a function type for unmarshaling/decoding a slice of bytes into

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -57,7 +57,6 @@ package secrets // import "gocloud.dev/secrets"
 
 import (
 	"context"
-	"reflect"
 
 	"gocloud.dev/internal/gcerr"
 	"gocloud.dev/internal/oc"
@@ -129,14 +128,9 @@ func (k *Keeper) Decrypt(ctx context.Context, ciphertext []byte) (plaintext []by
 // which error type(s) are supported.
 //
 // ErrorAs panics if i is nil or not a pointer.
+// ErrorAs returns false if err == nil.
 func (k *Keeper) ErrorAs(err error, i interface{}) bool {
-	if i == nil || reflect.TypeOf(i).Kind() != reflect.Ptr {
-		panic("secrets: ErrorAs i must be a non-nil pointer")
-	}
-	if e, ok := err.(*gcerr.Error); ok {
-		return k.k.ErrorAs(e.Unwrap(), i)
-	}
-	return k.k.ErrorAs(err, i)
+	return gcerr.ErrorAs(err, i, k.k.ErrorAs)
 }
 
 func wrapError(k *Keeper, err error) error {


### PR DESCRIPTION
Define an ErrorAs helper in gcerr, and call it from all concrete
ErrorAs implementations.

This shortens the concrete implementations to a single line and removes
inconsistencies.

Also, add an addition check in ErrorAs for a nil-valued pointer.

Also, add pubsub.Subscriber.ErrorAs, inadvertently omitted.