### PR TITLE
internal/docstore: initial

### DIFF
--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -1,0 +1,216 @@
+// Copyright 2019 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package docstore provides a portable implementation of a document store.
+package docstore // import "gocloud.dev/internal/docstore"
+
+import (
+	"context"
+	"strings"
+	"unicode/utf8"
+
+	"gocloud.dev/internal/docstore/driver"
+	"gocloud.dev/internal/gcerr"
+)
+
+// A Document is a set of field-value pairs.
+// It can be represented as a map[string]int or a pointer to a struct.
+// For structs, the exported fields are the document fields.
+type Document = interface{}
+
+// A Collection is a set of documents.
+type Collection struct {
+	driver driver.Collection
+}
+
+// NewCollection is intended for use by provider implementations.
+var NewCollection = newCollection
+
+// newCollection makes a Collection.
+func newCollection(d driver.Collection) *Collection {
+	return &Collection{driver: d}
+}
+
+// Actions returns an ActionList that can be used to perform
+// actions on the collection's documents.
+func (c *Collection) Actions() *ActionList {
+	return &ActionList{coll: c}
+}
+
+// An ActionList is a sequence of actions that affect a single collection.
+type ActionList struct {
+	coll    *Collection
+	actions []*Action
+}
+
+// An Action is a read or write on a single document.
+// Use the methods of ActionList to create and execute Actions.
+type Action struct {
+	kind       driver.ActionKind
+	doc        Document
+	fieldpaths []string // paths to retrieve, for Get
+	mods       Mods     // modifications to make, for Update
+}
+
+func (l *ActionList) add(a *Action) *ActionList {
+	l.actions = append(l.actions, a)
+	return l
+}
+
+// Create adds an action that creates a new document.
+// The document must not already exist; an AlreadyExists error is returned if it
+// does. If the document doesn't have key fields, it will be given key fields with
+// unique values.
+// TODO(jba): treat zero values for struct fields as not present?
+func (l *ActionList) Create(doc Document) *ActionList {
+	return l.add(&Action{kind: driver.Create, doc: doc})
+}
+
+// Replace adds an action that replaces a document.
+// The document must already exist; a NotFound error is returned if it does not.
+func (l *ActionList) Replace(doc Document) *ActionList {
+	return l.add(&Action{kind: driver.Replace, doc: doc})
+}
+
+// Put adds an action that adds or replaces a document.
+// The document may or may not already exist.
+func (l *ActionList) Put(doc Document) *ActionList {
+	return l.add(&Action{kind: driver.Put, doc: doc})
+}
+
+// Delete adds an action that deletes a document.
+// Only the key fields and RevisionField of doc are used.
+// If the document doesn't exist, nothing happens and no error is returned.
+func (l *ActionList) Delete(doc Document) *ActionList {
+	// Rationale for not returning an error if the document does not exist:
+	// Returning an error might be informative and could be ignored, but if the
+	// semantics of an action list are to stop at first error, then we might abort a
+	// list of Deletes just because one of the docs was not present, and that seems
+	// wrong, or at least something you'd want to turn off.
+	return l.add(&Action{kind: driver.Delete, doc: doc})
+}
+
+// Get adds an action that retrieves a document.
+// Only the key fields of doc are used to create the request.
+// If fps is omitted, all the fields of doc are set to those of the
+// retrieved document. If fps is present, only the given field paths are
+// set. In both cases, other fields of doc are not touched.
+//
+// A field path is a dot-separated sequence of UTF-8 field names. A field path
+// can select top level fields or elements of sub-documents. There is no way to
+// select a single list element.
+func (l *ActionList) Get(doc Document, fps ...string) *ActionList {
+	return l.add(&Action{
+		kind:       driver.Get,
+		doc:        doc,
+		fieldpaths: fps,
+	})
+}
+
+// Update applies Mods to doc, which must exist.
+// Only the key and revision fields of doc are used.
+//
+// A modification will create a field if it doesn't exist.
+//
+// No field path in mods can be a prefix of another. (It makes no sense
+// to, say, set foo but increment foo.bar.)
+//
+// Update does not modify its doc argument. To obtain the new value of the document,
+// call Get after calling Update.
+func (l *ActionList) Update(doc Document, mods Mods) *ActionList {
+	return l.add(&Action{
+		kind: driver.Update,
+		doc:  doc,
+		mods: mods,
+	})
+}
+
+// Mods is a map from field paths to modifications.
+// A field path is a dot-separated sequence of UTF-8 field names.
+// See ActionList.Update.
+type Mods map[string]interface{}
+
+// Do executes the action list. If all the actions executed successfully, Do returns
+// (number of actions, nil). If any failed, Do returns the number of successful
+// actions and an error. In general there is no way to know which actions succeeded,
+// but the error will contain as much information as possible about the failures.
+func (l *ActionList) Do(ctx context.Context) (int, error) {
+	var das []*driver.Action
+	for _, a := range l.actions {
+		d, err := a.toDriverAction()
+		if err != nil {
+			return 0, wrapError(l.coll.driver, err)
+		}
+		das = append(das, d)
+	}
+	n, err := l.coll.driver.RunActions(ctx, das)
+	return n, wrapError(l.coll.driver, err)
+}
+
+func (a *Action) toDriverAction() (*driver.Action, error) {
+	ddoc, err := driver.NewDocument(a.doc)
+	if err != nil {
+		return nil, err
+	}
+	d := &driver.Action{Kind: a.kind, Doc: ddoc}
+	if a.fieldpaths != nil {
+		d.FieldPaths = make([][]string, len(a.fieldpaths))
+		for i, s := range a.fieldpaths {
+			fp, err := parseFieldPath(s)
+			if err != nil {
+				return nil, err
+			}
+			d.FieldPaths[i] = fp
+		}
+	}
+	if a.mods != nil {
+		// Convert mods from a map to a slice of (fieldPath, value) pairs.
+		// The map is easier for users to write, but the slice is easier
+		// to process.
+		// TODO(jba): check for prefix
+		for k, v := range a.mods {
+			fp, err := parseFieldPath(k)
+			if err != nil {
+				return nil, err
+			}
+			d.Mods = append(d.Mods, driver.Mod{fp, v})
+		}
+	}
+	return d, nil
+}
+
+func parseFieldPath(s string) ([]string, error) {
+	if !utf8.ValidString(s) {
+		return nil, gcerr.Newf(gcerr.InvalidArgument, nil, "invalid UTF-8 field path %q", s)
+	}
+	fp := strings.Split(s, ".")
+	for _, c := range fp {
+		if c == "" {
+			return nil, gcerr.Newf(gcerr.InvalidArgument, nil, "empty component in field path %q", s)
+		}
+	}
+	return fp, nil
+}
+
+func wrapError(c driver.Collection, err error) error {
+	if err == nil {
+		return nil
+	}
+	if gcerr.DoNotWrap(err) {
+		return err
+	}
+	return gcerr.New(c.ErrorCode(err), err, 2, "docstore")
+}
+
+// TODO(jba): ErrorAs

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Go Cloud Authors
+// Copyright 2019 The Go Cloud Development Kit Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 // Package docstore provides a portable implementation of a document store.
+// TODO(jba): link to an explanation of document stores (https://en.wikipedia.org/wiki/Document-oriented_database?)
+// TODO(jba): expand package doc to batch other Go CDK APIs.
 package docstore // import "gocloud.dev/internal/docstore"
 
 import (
@@ -24,12 +26,17 @@ import (
 	"gocloud.dev/internal/gcerr"
 )
 
-// A Document is a set of field-value pairs.
-// It can be represented as a map[string]int or a pointer to a struct.
-// For structs, the exported fields are the document fields.
+// A Document is a set of field-value pairs. One or more fields, called the key
+// fields, must uniquely identify the document in the collection. You specify the key
+// fields when you open a provider collection.
+// A field name must be a valid UTF-8 string that does not contain a '.'.
+//
+// A Document can be represented as a map[string]int or a pointer to a struct. For
+// structs, the exported fields are the document fields.
 type Document = interface{}
 
 // A Collection is a set of documents.
+// TODO(jba): make the docstring look more like blob.Bucket.
 type Collection struct {
 	driver driver.Collection
 }
@@ -42,13 +49,24 @@ func newCollection(d driver.Collection) *Collection {
 	return &Collection{driver: d}
 }
 
+// A FieldPath is a dot-separated sequence of UTF-8 field names. Examples:
+//   room
+//   room.size
+//   room.size.width
+//
+// A FieldPath can be used select top-level fields or elements of sub-documents.
+// There is no way to select a single list element.
+type FieldPath string
+
 // Actions returns an ActionList that can be used to perform
 // actions on the collection's documents.
 func (c *Collection) Actions() *ActionList {
 	return &ActionList{coll: c}
 }
 
-// An ActionList is a sequence of actions that affect a single collection.
+// An ActionList is a sequence of actions that affect a single collection. The
+// actions are performed in order. If an action fails, the ones following it are not
+// executed.
 type ActionList struct {
 	coll    *Collection
 	actions []*Action
@@ -59,8 +77,8 @@ type ActionList struct {
 type Action struct {
 	kind       driver.ActionKind
 	doc        Document
-	fieldpaths []string // paths to retrieve, for Get
-	mods       Mods     // modifications to make, for Update
+	fieldpaths []FieldPath // paths to retrieve, for Get
+	mods       Mods        // modifications to make, for Update
 }
 
 func (l *ActionList) add(a *Action) *ActionList {
@@ -69,21 +87,24 @@ func (l *ActionList) add(a *Action) *ActionList {
 }
 
 // Create adds an action that creates a new document.
-// The document must not already exist; an AlreadyExists error is returned if it
-// does. If the document doesn't have key fields, it will be given key fields with
-// unique values.
+// The document must not already exist; an error for which gcerrors.Code returns
+// AlreadyExists is returned if it does. If the document doesn't have key fields, it
+// will be given key fields with unique values.
 // TODO(jba): treat zero values for struct fields as not present?
 func (l *ActionList) Create(doc Document) *ActionList {
 	return l.add(&Action{kind: driver.Create, doc: doc})
 }
 
 // Replace adds an action that replaces a document.
-// The document must already exist; a NotFound error is returned if it does not.
+// The key fields must be set.
+// The document must already exist; an error for which gcerrors.Code returns NotFound
+// is returned if it does not.
 func (l *ActionList) Replace(doc Document) *ActionList {
 	return l.add(&Action{kind: driver.Replace, doc: doc})
 }
 
 // Put adds an action that adds or replaces a document.
+// The key fields must be set.
 // The document may or may not already exist.
 func (l *ActionList) Put(doc Document) *ActionList {
 	return l.add(&Action{kind: driver.Put, doc: doc})
@@ -102,15 +123,11 @@ func (l *ActionList) Delete(doc Document) *ActionList {
 }
 
 // Get adds an action that retrieves a document.
-// Only the key fields of doc are used to create the request.
+// Only the key fields of doc are used.
 // If fps is omitted, all the fields of doc are set to those of the
 // retrieved document. If fps is present, only the given field paths are
 // set. In both cases, other fields of doc are not touched.
-//
-// A field path is a dot-separated sequence of UTF-8 field names. A field path
-// can select top level fields or elements of sub-documents. There is no way to
-// select a single list element.
-func (l *ActionList) Get(doc Document, fps ...string) *ActionList {
+func (l *ActionList) Get(doc Document, fps ...FieldPath) *ActionList {
 	return l.add(&Action{
 		kind:       driver.Get,
 		doc:        doc,
@@ -137,9 +154,12 @@ func (l *ActionList) Update(doc Document, mods Mods) *ActionList {
 }
 
 // Mods is a map from field paths to modifications.
-// A field path is a dot-separated sequence of UTF-8 field names.
+// At present, a modification is one of:
+// - nil, to delete the field
+// - any other value, to set the field to that value
+// TODO(jba): add other kinds of modification
 // See ActionList.Update.
-type Mods map[string]interface{}
+type Mods map[FieldPath]interface{}
 
 // Do executes the action list. If all the actions executed successfully, Do returns
 // (number of actions, nil). If any failed, Do returns the number of successful
@@ -190,17 +210,59 @@ func (a *Action) toDriverAction() (*driver.Action, error) {
 	return d, nil
 }
 
-func parseFieldPath(s string) ([]string, error) {
-	if !utf8.ValidString(s) {
-		return nil, gcerr.Newf(gcerr.InvalidArgument, nil, "invalid UTF-8 field path %q", s)
+// Create is a convenience for building and running a single-element action list.
+// See ActionList.Create.
+func (c *Collection) Create(ctx context.Context, doc Document) error {
+	_, err := c.Actions().Create(doc).Do(ctx)
+	return err
+}
+
+// Replace is a convenience for building and running a single-element action list.
+// See ActionList.Replace.
+func (c *Collection) Replace(ctx context.Context, doc Document) error {
+	_, err := c.Actions().Replace(doc).Do(ctx)
+	return err
+}
+
+// Put is a convenience for building and running a single-element action list.
+// See ActionList.Put.
+func (c *Collection) Put(ctx context.Context, doc Document) error {
+	_, err := c.Actions().Put(doc).Do(ctx)
+	return err
+}
+
+// Delete is a convenience for building and running a single-element action list.
+// See ActionList.Delete.
+func (c *Collection) Delete(ctx context.Context, doc Document) error {
+	_, err := c.Actions().Delete(doc).Do(ctx)
+	return err
+}
+
+// Get is a convenience for building and running a single-element action list.
+// See ActionList.Get.
+func (c *Collection) Get(ctx context.Context, doc Document, fps ...FieldPath) error {
+	_, err := c.Actions().Get(doc, fps...).Do(ctx)
+	return err
+}
+
+// Update is a convenience for building and running a single-element action list.
+// See ActionList.Update.
+func (c *Collection) Update(ctx context.Context, doc Document, mods Mods) error {
+	_, err := c.Actions().Update(doc, mods).Do(ctx)
+	return err
+}
+
+func parseFieldPath(fp FieldPath) ([]string, error) {
+	if !utf8.ValidString(string(fp)) {
+		return nil, gcerr.Newf(gcerr.InvalidArgument, nil, "invalid UTF-8 field path %q", fp)
 	}
-	fp := strings.Split(s, ".")
-	for _, c := range fp {
-		if c == "" {
-			return nil, gcerr.Newf(gcerr.InvalidArgument, nil, "empty component in field path %q", s)
+	parts := strings.Split(string(fp), ".")
+	for _, p := range parts {
+		if p == "" {
+			return nil, gcerr.Newf(gcerr.InvalidArgument, nil, "empty component in field path %q", fp)
 		}
 	}
-	return fp, nil
+	return parts, nil
 }
 
 func wrapError(c driver.Collection, err error) error {

--- a/internal/docstore/driver/document.go
+++ b/internal/docstore/driver/document.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Go Cloud Authors
+// Copyright 2019 The Go Cloud Development Kit Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/docstore/driver/document.go
+++ b/internal/docstore/driver/document.go
@@ -1,0 +1,107 @@
+// Copyright 2019 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"gocloud.dev/gcerrors"
+	"gocloud.dev/internal/gcerr"
+)
+
+// A Document is a lightweight wrapper around either a map[string]interface{} or a
+// struct pointer. It provides operations to get and set fields and field paths.
+type Document struct {
+	m map[string]interface{} // nil if it's a *struct
+	//s      reflect.Value          // the struct reflected
+	//fields fields.List            // for structs
+}
+
+// Create a new document from doc, which must be a map[string]interface{} or a struct pointer.
+func NewDocument(doc interface{}) (Document, error) {
+	// TODO: handle a nil *struct?
+	if m, ok := doc.(map[string]interface{}); ok {
+		return Document{m: m}, nil
+	}
+	panic("unimplemented")
+}
+
+// TODO(jba): remove this method after memdocstore uses the codec framework.
+func (d Document) Map() map[string]interface{} {
+	return d.m
+}
+
+// GetField returns the value of the named document field.
+func (d Document) GetField(field string) (interface{}, error) {
+	if d.m != nil {
+		x, ok := d.m[field]
+		if !ok {
+			return nil, gcerr.Newf(gcerr.NotFound, nil, "field %q not found in map", field)
+		}
+		return x, nil
+	}
+	panic("unimplemented")
+}
+
+// getDocument gets the value of the given field path, which must be a document.
+// If create is true, it creates intermediate documents as needed.
+func (d Document) getDocument(fp []string, create bool) (Document, error) {
+	if len(fp) == 0 {
+		return d, nil
+	}
+	x, err := d.GetField(fp[0])
+	if err != nil {
+		if create && gcerrors.Code(err) == gcerrors.NotFound {
+			// TODO(jba): create the right type for the struct field.
+			x = map[string]interface{}{}
+			if err := d.SetField(fp[0], x); err != nil {
+				return Document{}, err
+			}
+		} else {
+			return Document{}, err
+		}
+	}
+	d2, err := NewDocument(x)
+	if err != nil {
+		return Document{}, err
+	}
+	return d2.getDocument(fp[1:], create)
+}
+
+// Get returns the value of the given field path in the document.
+func (d Document) Get(fp []string) (interface{}, error) {
+	d2, err := d.getDocument(fp[:len(fp)-1], false)
+	if err != nil {
+		return nil, err
+	}
+	return d2.GetField(fp[len(fp)-1])
+}
+
+// Set sets the value of the field path in the document.
+// This creates sub-maps as necessary, if possible.
+func (d Document) Set(fp []string, val interface{}) error {
+	d2, err := d.getDocument(fp[:len(fp)-1], true)
+	if err != nil {
+		return err
+	}
+	return d2.SetField(fp[len(fp)-1], val)
+}
+
+// SetField sets the field to value in the document.
+func (d Document) SetField(field string, value interface{}) error {
+	if d.m != nil {
+		d.m[field] = value
+		return nil
+	}
+	panic("unimplemented")
+}

--- a/internal/docstore/driver/driver.go
+++ b/internal/docstore/driver/driver.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Go Cloud Authors
+// Copyright 2019 The Go Cloud Development Kit Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/docstore/driver/driver.go
+++ b/internal/docstore/driver/driver.go
@@ -1,0 +1,73 @@
+// Copyright 2019 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package driver defines a set of interfaces that the docstore package uses to
+// interact with the underlying services.
+package driver // import "gocloud.dev/internal/docstore/driver"
+
+import (
+	"context"
+
+	"gocloud.dev/internal/gcerr"
+)
+
+// A Collection is a set of documents.
+type Collection interface {
+	// RunActions executes a sequence of actions.
+	// Implementations are free to execute the actions however they wish, but it must
+	// appear as if they were executed in order. The actions need not happen
+	// atomically.
+	//
+	// RunActions should return immediately after the first action that fails.
+	// The first return value is the number of actions successfully
+	// executed, and the second is the error that caused the action to fail.
+	//
+	// If all actions succeed, RunActions returns (number of actions, nil).
+	RunActions(context.Context, []*Action) (int, error)
+
+	// ErrorCode should return a code that describes the error, which was returned by
+	// one of the other methods in this interface.
+	ErrorCode(error) gcerr.ErrorCode
+
+	// TODO(jba): RunQuery
+}
+
+// ActionKind describes the type of an action.
+type ActionKind int
+
+const (
+	Create ActionKind = iota
+	Replace
+	Put
+	Get
+	Delete
+	Update
+)
+
+// An Action describes a single operation on a single document.
+type Action struct {
+	Kind       ActionKind // the kind of action
+	Doc        Document   // the document on which to perform the action
+	FieldPaths [][]string // field paths to retrieve, for Get only
+	Mods       []Mod      // modifications to make, for Update only
+}
+
+// A Mod is a modification to a field path in a document.
+// At present, the only modifications supported are:
+// - set the value at the field path, or create the field path if it doesn't exist
+// - delete the field path (when Value is nil)
+type Mod struct {
+	FieldPath []string
+	Value     interface{}
+}

--- a/internal/docstore/driver/util.go
+++ b/internal/docstore/driver/util.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Go Cloud Authors
+// Copyright 2019 The Go Cloud Development Kit Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/docstore/driver/util.go
+++ b/internal/docstore/driver/util.go
@@ -1,0 +1,21 @@
+// Copyright 2019 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import "github.com/google/uuid"
+
+// UniqueString generates a string that is unique with high probability.
+// Driver implementations can use it to generate keys for Create actions.
+func UniqueString() string { return uuid.New().String() }

--- a/internal/docstore/drivertest/drivertest.go
+++ b/internal/docstore/drivertest/drivertest.go
@@ -1,0 +1,181 @@
+// Copyright 2019 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package drivertest provides a conformance test for implementations of
+// driver.
+package drivertest // import "gocloud.dev/internal/docstore/drivertest"
+
+import (
+	"context"
+	//	"math"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	ds "gocloud.dev/internal/docstore"
+	"gocloud.dev/internal/docstore/driver"
+)
+
+// Harness descibes the functionality test harnesses must provide to run
+// conformance tests.
+type Harness interface {
+	// MakeCollection makes a driver.Collection for testing.
+	MakeCollection(context.Context) (driver.Collection, error)
+
+	// Close closes resources used by the harness.
+	Close()
+}
+
+// HarnessMaker describes functions that construct a harness for running tests.
+// It is called exactly once per test; Harness.Close() will be called when the test is complete.
+type HarnessMaker func(ctx context.Context, t *testing.T) (Harness, error)
+
+// RunConformanceTests runs conformance tests for provider implementations of docstore.
+func RunConformanceTests(t *testing.T, newHarness HarnessMaker) {
+	t.Run("Create", func(t *testing.T) { withCollection(t, newHarness, testCreate) })
+	t.Run("Put", func(t *testing.T) { withCollection(t, newHarness, testPut) })
+	t.Run("Replace", func(t *testing.T) { withCollection(t, newHarness, testReplace) })
+	t.Run("Get", func(t *testing.T) { withCollection(t, newHarness, testGet) })
+	t.Run("Delete", func(t *testing.T) { withCollection(t, newHarness, testDelete) })
+	t.Run("Update", func(t *testing.T) { withCollection(t, newHarness, testUpdate) })
+}
+
+const KeyField = "_id"
+
+func withCollection(t *testing.T, newHarness HarnessMaker, f func(*testing.T, *ds.Collection)) {
+	ctx := context.Background()
+	h, err := newHarness(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Close()
+
+	dc, err := h.MakeCollection(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coll := ds.NewCollection(dc)
+	f(t, coll)
+}
+
+type docmap = map[string]interface{}
+
+var nonexistentDoc = docmap{KeyField: "doesNotExist"}
+
+func testCreate(t *testing.T, coll *ds.Collection) {
+	named := docmap{KeyField: "testCreate1", "b": true}
+	unnamed := docmap{"b": false}
+	// Attempt to clean up
+	defer func() {
+		_, _ = coll.Actions().Delete(named).Delete(unnamed).Do(context.Background())
+	}()
+
+	mustRunAndCompare(t, coll, named, coll.Actions().Create(named))
+	mustRunAndCompare(t, coll, unnamed, coll.Actions().Create(unnamed))
+	// Can't create an existing doc.
+	shouldFail(t, coll.Actions().Create(named))
+}
+
+func testPut(t *testing.T, coll *ds.Collection) {
+	named := docmap{KeyField: "testPut1", "b": true}
+	mustRunAndCompare(t, coll, named, coll.Actions().Put(named)) // create new
+	named["b"] = false
+	mustRunAndCompare(t, coll, named, coll.Actions().Put(named)) // replace existing
+}
+
+func testReplace(t *testing.T, coll *ds.Collection) {
+	doc1 := docmap{KeyField: "testReplace", "s": "a"}
+	mustRun(t, coll.Actions().Put(doc1))
+
+	doc1["s"] = "b"
+	mustRunAndCompare(t, coll, doc1, coll.Actions().Replace(doc1))
+
+	// Can't replace a nonexistent doc.
+	shouldFail(t, coll.Actions().Replace(nonexistentDoc))
+}
+
+func testGet(t *testing.T, coll *ds.Collection) {
+	doc := docmap{
+		KeyField: "testGet1",
+		"s":      "a string",
+		"i":      int64(95),
+		"f":      32.3,
+	}
+	mustRun(t, coll.Actions().Put(doc))
+
+	checkGet := func(got, want docmap) {
+		t.Helper()
+		mustRun(t, coll.Actions().Get(got))
+		if diff := cmp.Diff(got, want); diff != "" {
+			t.Errorf("got=-, want=+: %s", diff)
+		}
+	}
+
+	// If only the key fields are present, the full document is populated.
+	checkGet(docmap{KeyField: doc[KeyField]}, doc)
+}
+
+func testDelete(t *testing.T, coll *ds.Collection) {
+	doc := docmap{KeyField: "testDelete"}
+	mustRun(t, coll.Actions().Put(doc).Delete(doc))
+	shouldFail(t, coll.Actions().Get(doc))
+	// Delete doesn't fail if the doc doesn't exist.
+	mustRun(t, coll.Actions().Delete(nonexistentDoc))
+}
+
+func testUpdate(t *testing.T, coll *ds.Collection) {
+	doc := docmap{KeyField: "testUpdate", "a": "A", "b": "B"}
+	mustRun(t, coll.Actions().Put(doc))
+
+	got := docmap{KeyField: doc[KeyField]}
+	mustRun(t, coll.Actions().Update(doc, ds.Mods{
+		"a": "X",
+		"b": nil,
+		"c": "C",
+	}).Get(got))
+	want := docmap{
+		KeyField: doc[KeyField],
+		"a":      "X",
+		"c":      "C",
+	}
+	if !cmp.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// Can't update a nonexistent doc
+	shouldFail(t, coll.Actions().Update(nonexistentDoc, ds.Mods{}))
+}
+
+func mustRun(t *testing.T, al *ds.ActionList) {
+	t.Helper()
+	if _, err := al.Do(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustRunAndCompare(t *testing.T, coll *ds.Collection, doc docmap, al *ds.ActionList) {
+	t.Helper()
+	mustRun(t, al)
+	got := docmap{KeyField: doc[KeyField]}
+	mustRun(t, coll.Actions().Get(got))
+	if diff := cmp.Diff(got, doc); diff != "" {
+		t.Fatalf(diff)
+	}
+}
+
+func shouldFail(t *testing.T, al *ds.ActionList) {
+	t.Helper()
+	if _, err := al.Do(context.Background()); err == nil {
+		t.Error("got nil, want error")
+	}
+}

--- a/internal/docstore/example_test.go
+++ b/internal/docstore/example_test.go
@@ -1,0 +1,39 @@
+// Copyright 2018 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docstore_test
+
+import (
+	"context"
+
+	"gocloud.dev/internal/docstore"
+)
+
+func ExampleActions() {
+	ctx := context.Background()
+
+	type Player struct {
+		Name  string // Name is the key
+		Score int
+	}
+
+	fred := &Player{Name: "Fred", Score: 18}
+	got := &Player{Name: "Fred"}
+	coll := docstore.NewCollection(nil)
+	_, err := coll.Actions().
+		Put(fred).
+		Get(got).
+		Do(ctx)
+	_ = err
+}

--- a/internal/docstore/example_test.go
+++ b/internal/docstore/example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Go Cloud Authors
+// Copyright 2019 The Go Cloud Development Kit Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/docstore/memdocstore/mem.go
+++ b/internal/docstore/memdocstore/mem.go
@@ -1,0 +1,177 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package memdocstore provides an in-memory implementation of the docstore
+// API. It is suitable for local development and testing.
+package memdocstore // import "gocloud.dev/internal/docstore/memdocstore"
+
+import (
+	"context"
+
+	"gocloud.dev/gcerrors"
+	"gocloud.dev/internal/docstore"
+	"gocloud.dev/internal/docstore/driver"
+	"gocloud.dev/internal/gcerr"
+)
+
+// Options sets options for constructing a *docstore.Collection backed by memory.
+type Options struct{}
+
+// OpenCollection creates a *docstore.Collection backed by memory.
+// memdocstore requires that a single field be designated the primary
+// key. Its values must be unique over all documents in the collection,
+// and the primary key must be provided to retrieve a document.
+// The values need not be strings; they may be any comparable Go value.
+// keyField is the name of the primary key field.
+func OpenCollection(keyField string, opts *Options) *docstore.Collection {
+	return docstore.NewCollection(newCollection(keyField))
+}
+
+func newCollection(keyField string) driver.Collection {
+	return &collection{
+		keyField: keyField,
+		docs:     map[interface{}]driver.Document{},
+	}
+}
+
+type collection struct {
+	keyField string
+	docs     map[interface{}]driver.Document
+}
+
+// RunActions implements driver.RunActions.
+func (c *collection) RunActions(ctx context.Context, actions []*driver.Action) (int, error) {
+	// Stop immediately if the context is done.
+	if ctx.Err() != nil {
+		return 0, ctx.Err()
+	}
+	// Run each action in order, stopping at the first error.
+	for i, a := range actions {
+		if err := c.runAction(a); err != nil {
+			return i, err
+		}
+	}
+	return len(actions), nil
+}
+
+// runAction executes a single action.
+func (c *collection) runAction(a *driver.Action) error {
+	// Get the key from the doc so we can look it up in the map.
+	key, err := a.Doc.GetField(c.keyField)
+	// The only acceptable error case is NotFound during a Create.
+	if err != nil && !(gcerrors.Code(err) == gcerr.NotFound && a.Kind == driver.Create) {
+		return err
+	}
+	// If there is a key, get the current document.
+	var (
+		current driver.Document
+		exists  bool
+	)
+	if err == nil {
+		current, exists = c.docs[key]
+	}
+	// Check for a NotFound error.
+	if !exists && (a.Kind == driver.Replace || a.Kind == driver.Update || a.Kind == driver.Get) {
+		return gcerr.Newf(gcerr.NotFound, nil, "document with key %v does not exist", key)
+	}
+	switch a.Kind {
+	case driver.Create:
+		// It is an error to attempt to create an existing document.
+		if exists {
+			return gcerr.Newf(gcerr.AlreadyExists, nil, "Create: document with key %v exists", key)
+		}
+		// If the user didn't supply a value for the key field, create a new one.
+		if key == nil {
+			key = driver.UniqueString()
+			// Set the new key in the document.
+			if err := a.Doc.SetField(c.keyField, key); err != nil {
+				return gcerr.Newf(gcerr.InvalidArgument, nil, "cannot set key field %q", c.keyField)
+			}
+		}
+		fallthrough
+
+	case driver.Replace, driver.Put:
+		c.docs[key] = a.Doc
+
+	case driver.Delete:
+		delete(c.docs, key)
+
+	case driver.Update:
+		if err := c.update(current, a.Mods); err != nil {
+			return err
+		}
+
+	case driver.Get:
+		// We've already retrieved the document into current, above.
+		// Now we copy its fields into the user-provided document.
+		if err := copyFields(a.Doc, current, a.FieldPaths); err != nil {
+			return err
+		}
+	default:
+		return gcerr.Newf(gcerr.Internal, nil, "unknown kind %v", a.Kind)
+	}
+	return nil
+}
+
+func (c *collection) update(doc driver.Document, mods []driver.Mod) error {
+	// Apply each modification in order. Fail on the first error.
+	// TODO(jba): this should be atomic.
+	for _, m := range mods {
+		if m.Value == nil {
+			deleteAtFieldPath(doc.Map(), m.FieldPath)
+		} else if err := doc.Set(m.FieldPath, m.Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Delete the value from m at the given field path.
+func deleteAtFieldPath(m map[string]interface{}, fp []string) {
+	if len(fp) == 1 {
+		delete(m, fp[0])
+	} else if m2, ok := m[fp[0]].(map[string]interface{}); ok {
+		deleteAtFieldPath(m2, fp[1:])
+	}
+	// Otherwise do nothing.
+}
+
+// Copy the fields of src to dest.
+func copyFields(dest, src driver.Document, fps [][]string) error {
+	if fps == nil {
+		// If no field paths were provided, copy all the fields.
+		for k, v := range src.Map() {
+			// TODO(jba): copy v to avoid as much structure-sharing as possible.
+			if err := dest.SetField(k, v); err != nil {
+				return err
+			}
+		}
+	} else {
+		for _, fp := range fps {
+			val, err := src.Get(fp)
+			if err != nil {
+				return err
+			}
+			if err := dest.Set(fp, val); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ErrorCode implements driver.ErrorCOde.
+func (c *collection) ErrorCode(err error) gcerr.ErrorCode {
+	return gcerrors.Code(err)
+}

--- a/internal/docstore/memdocstore/mem_test.go
+++ b/internal/docstore/memdocstore/mem_test.go
@@ -1,0 +1,39 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memdocstore
+
+import (
+	"context"
+	"testing"
+
+	"gocloud.dev/internal/docstore/driver"
+	"gocloud.dev/internal/docstore/drivertest"
+)
+
+type harness struct{}
+
+func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
+	return &harness{}, nil
+}
+
+func (h *harness) MakeCollection(context.Context) (driver.Collection, error) {
+	return newCollection(drivertest.KeyField), nil
+}
+
+func (h *harness) Close() {}
+
+func TestConformance(t *testing.T) {
+	drivertest.RunConformanceTests(t, newHarness)
+}


### PR DESCRIPTION
This commit includes:
- The concrete Collection and Document types
- The corresponding driver types
- An in-memory implementation
- Some conformance tests
- An example

These include support for the six actions on maps.

Later I will add:
- optimistic locking
- struct support
- queries
- a Firestore implementation