### PR TITLE
blob: split the openbucket example

### DIFF
--- a/blob/example_openbucket_test.go
+++ b/blob/example_openbucket_test.go
@@ -33,7 +33,7 @@ func ExampleOpenBucket() {
 	// memblob registers for the "mem" scheme.
 
 	ctx := context.Background()
-	b, err := blob.OpenBucket(ctx, "mem://mybucket")
+	b, err := blob.OpenBucket(ctx, "mem://")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/blob/example_openbucket_test.go
+++ b/blob/example_openbucket_test.go
@@ -18,41 +18,27 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/url"
-	"path/filepath"
-	"strings"
 
 	"gocloud.dev/blob"
-	_ "gocloud.dev/blob/fileblob"
+	_ "gocloud.dev/blob/memblob"
 )
 
 func ExampleOpenBucket() {
 
 	// Connect to a bucket using a URL.
-	// This example uses "fileblob", the file-based implementation.
-	// We need to add a blank import line to register the fileblob provider's
+	// This example uses "memblob", the in-memory implementation.
+	// We need to add a blank import line to register the memblob provider's
 	// URLOpener, which implements blob.BucketURLOpener:
-	// import _ "gocloud.dev/blob/fileblob"
-	// fileblob registers for the "file" scheme.
-	dir, cleanup := newTempDir()
-	defer cleanup()
+	// import _ "gocloud.dev/blob/memblob"
+	// memblob registers for the "mem" scheme.
 
-	// Ensure the path has a leading slash; fileblob ignores the URL's
-	// Host field, so URLs should always start with "file:///". On
-	// Windows, the leading "/" will be stripped, so "file:///c:/foo"
-	// will refer to c:/foo.
-	urlpath := url.PathEscape(filepath.ToSlash(dir))
-	if !strings.HasPrefix(urlpath, "/") {
-		urlpath = "/" + urlpath
-	}
 	ctx := context.Background()
-	b, err := blob.OpenBucket(ctx, "file://"+urlpath)
+	b, err := blob.OpenBucket(ctx, "mem://mybucket")
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println("Got a bucket for valid path")
 
-	// Now we can use b to read or write files to the container.
+	// Now we can use b to read or write blob to the container.
 	if err := b.WriteAll(ctx, "my-key", []byte("hello world"), nil); err != nil {
 		log.Fatal(err)
 	}
@@ -62,6 +48,5 @@ func ExampleOpenBucket() {
 	}
 	fmt.Println(string(data))
 	// Output:
-	// Got a bucket for valid path
 	// hello world
 }

--- a/blob/example_openbucket_test.go
+++ b/blob/example_openbucket_test.go
@@ -45,11 +45,23 @@ func ExampleOpenBucket() {
 	if !strings.HasPrefix(urlpath, "/") {
 		urlpath = "/" + urlpath
 	}
-	if _, err := blob.OpenBucket(context.Background(), "file://"+urlpath); err != nil {
+	ctx := context.Background()
+	b, err := blob.OpenBucket(ctx, "file://"+urlpath)
+	if err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println("Got a bucket for valid path")
 
+	// Now we can use b to read or write files to the container.
+	if err := b.WriteAll(ctx, "my-key", []byte("hello world"), nil); err != nil {
+		log.Fatal(err)
+	}
+	data, err := b.ReadAll(ctx, "my-key")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(data))
 	// Output:
 	// Got a bucket for valid path
+	// hello world
 }

--- a/blob/example_openbucket_test.go
+++ b/blob/example_openbucket_test.go
@@ -27,23 +27,15 @@ import (
 )
 
 func ExampleOpenBucket() {
+
 	// Connect to a bucket using a URL.
-	// This example uses the file-based implementation, which registers for
-	// the "file" scheme.
+	// This example uses "fileblob", the file-based implementation.
+	// We need to add a blank import line to register the fileblob provider's
+	// URLOpener, which implements blob.BucketURLOpener:
+	// import _ "gocloud.dev/blob/fileblob"
+	// fileblob registers for the "file" scheme.
 	dir, cleanup := newTempDir()
 	defer cleanup()
-
-	ctx := context.Background()
-
-	// The blob package is designed for using with a specific provider package.
-	// Here blob.OpenBucket needs a provider that implements blob.BucketURLOpener
-	// to work. In this example, we use blob/fileblob, so we need to add a blank
-	// import line to register the fileblob provider:
-	// import _ "gocloud.dev/blob/fileblob"
-	if _, err := blob.OpenBucket(ctx, "file:///nonexistentpath"); err == nil {
-		log.Fatal("Expected an error opening nonexistent path")
-	}
-	fmt.Println("Got expected error opening a nonexistent path")
 
 	// Ensure the path has a leading slash; fileblob ignores the URL's
 	// Host field, so URLs should always start with "file:///". On
@@ -53,12 +45,11 @@ func ExampleOpenBucket() {
 	if !strings.HasPrefix(urlpath, "/") {
 		urlpath = "/" + urlpath
 	}
-	if _, err := blob.OpenBucket(ctx, "file://"+urlpath); err != nil {
+	if _, err := blob.OpenBucket(context.Background(), "file://"+urlpath); err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println("Got a bucket for valid path")
 
 	// Output:
-	// Got expected error opening a nonexistent path
 	// Got a bucket for valid path
 }

--- a/blob/example_openbucket_test.go
+++ b/blob/example_openbucket_test.go
@@ -1,0 +1,64 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blob_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/fileblob"
+)
+
+func ExampleOpenBucket() {
+	// Connect to a bucket using a URL.
+	// This example uses the file-based implementation, which registers for
+	// the "file" scheme.
+	dir, cleanup := newTempDir()
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// The blob package is designed for using with a specific provider package.
+	// Here blob.OpenBucket needs a provider that implements blob.BucketURLOpener
+	// to work. In this example, we use blob/fileblob, so we need to add a blank
+	// import line to register the fileblob provider:
+	// import _ "gocloud.dev/blob/fileblob"
+	if _, err := blob.OpenBucket(ctx, "file:///nonexistentpath"); err == nil {
+		log.Fatal("Expected an error opening nonexistent path")
+	}
+	fmt.Println("Got expected error opening a nonexistent path")
+
+	// Ensure the path has a leading slash; fileblob ignores the URL's
+	// Host field, so URLs should always start with "file:///". On
+	// Windows, the leading "/" will be stripped, so "file:///c:/foo"
+	// will refer to c:/foo.
+	urlpath := url.PathEscape(filepath.ToSlash(dir))
+	if !strings.HasPrefix(urlpath, "/") {
+		urlpath = "/" + urlpath
+	}
+	if _, err := blob.OpenBucket(ctx, "file://"+urlpath); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Got a bucket for valid path")
+
+	// Output:
+	// Got expected error opening a nonexistent path
+	// Got a bucket for valid path
+}

--- a/blob/example_test.go
+++ b/blob/example_test.go
@@ -20,10 +20,8 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/fileblob"
@@ -317,37 +315,6 @@ func ExampleBucket_As() {
 	// Output:
 	// fileblob does not support the `string` type for Bucket.As
 	// fileblob does not support the `*string` type for WriterOptions.BeforeWrite
-}
-
-func ExampleOpenBucket() {
-	// Connect to a bucket using a URL.
-	// This example uses the file-based implementation, which registers for
-	// the "file" scheme.
-	dir, cleanup := newTempDir()
-	defer cleanup()
-
-	ctx := context.Background()
-	if _, err := blob.OpenBucket(ctx, "file:///nonexistentpath"); err == nil {
-		log.Fatal("Expected an error opening nonexistent path")
-	}
-	fmt.Println("Got expected error opening a nonexistent path")
-
-	// Ensure the path has a leading slash; fileblob ignores the URL's
-	// Host field, so URLs should always start with "file:///". On
-	// Windows, the leading "/" will be stripped, so "file:///c:/foo"
-	// will refer to c:/foo.
-	urlpath := url.PathEscape(filepath.ToSlash(dir))
-	if !strings.HasPrefix(urlpath, "/") {
-		urlpath = "/" + urlpath
-	}
-	if _, err := blob.OpenBucket(ctx, "file://"+urlpath); err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println("Got a bucket for valid path")
-
-	// Output:
-	// Got expected error opening a nonexistent path
-	// Got a bucket for valid path
 }
 
 func newTempDir() (string, func()) {


### PR DESCRIPTION
This shows the necessary blank import line when using `OpenBucket` only. Also added some comments inside the example.

Fixes: #1302 