### PR TITLE
rabbitpubsub: increase code coverage

### DIFF
--- a/pubsub/rabbitpubsub/fake_test.go
+++ b/pubsub/rabbitpubsub/fake_test.go
@@ -334,7 +334,11 @@ func (ch *fakeChannel) Close() error {
 	closeChan(ch.closed)
 	ch.closeMu.Unlock()
 	for _, c := range closeChans {
-		c <- amqp.ErrClosed
+		// Don't block on notifying.
+		select {
+		case c <- amqp.ErrClosed:
+		default:
+		}
 	}
 	return nil
 }

--- a/pubsub/rabbitpubsub/fake_test.go
+++ b/pubsub/rabbitpubsub/fake_test.go
@@ -30,7 +30,7 @@ import (
 // It also doubles as the state of the fake server.
 type fakeConnection struct {
 	mu        sync.Mutex
-	closed    bool
+	closed    chan struct{}
 	exchanges map[string]*exchange // exchange names are server-scoped
 	queues    map[string]*queue    // queue names are server-scoped
 }
@@ -39,12 +39,14 @@ type fakeConnection struct {
 type fakeChannel struct {
 	conn *fakeConnection
 	// The following fields are protected by conn.mu.
-	closed          bool
 	deliveryTag     uint64 // counter; used to distinguish published messages
 	pubChans        []chan<- amqp.Confirmation
 	returnChans     []chan<- amqp.Return
 	closeChans      []chan<- *amqp.Error
 	consumerCancels map[string]func() // from consumer name to cancel func for the context
+
+	closeMu sync.Mutex
+	closed  chan struct{}
 }
 
 // An exchange is a collection of queues.
@@ -64,27 +66,26 @@ func newFakeConnection() *fakeConnection {
 	return &fakeConnection{
 		exchanges: map[string]*exchange{},
 		queues:    map[string]*queue{},
+		closed:    make(chan struct{}),
 	}
 }
 
 // Channel creates a new AMQP fake channel.
 func (c *fakeConnection) Channel() (amqpChannel, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.closed {
+	if chanIsClosed(c.closed) {
 		return nil, amqp.ErrClosed
 	}
 	return &fakeChannel{
 		conn:            c,
 		consumerCancels: map[string]func(){},
+		closed:          make(chan struct{}),
 	}, nil
 }
 
 func (c *fakeConnection) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.closed = true
+	closeChan(c.closed)
 	return nil
 }
 
@@ -102,19 +103,25 @@ func (ch *fakeChannel) getExchange(name string) (*exchange, error) {
 // closes the channel and makes it unusable.)
 // It must be called with ch.conn.mu held.
 func (ch *fakeChannel) errorf(code int, reasonFormat string, args ...interface{}) error {
-	ch.closeLocked()
+	_ = ch.Close()
 	return &amqp.Error{Code: code, Reason: fmt.Sprintf(reasonFormat, args...)}
+}
+
+// Report whether the channel or its connection is closed. Does not require the lock.
+func (ch *fakeChannel) isClosed() bool {
+	return chanIsClosed(ch.closed) || chanIsClosed(ch.conn.closed)
 }
 
 // ExchangeDeclare creates a new exchange with the given name if one doesn't already
 // exist.
 func (ch *fakeChannel) ExchangeDeclare(name string) error {
+	if ch.isClosed() {
+		return amqp.ErrClosed
+	}
+
 	ch.conn.mu.Lock()
 	defer ch.conn.mu.Unlock()
 
-	if ch.closed || ch.conn.closed {
-		return amqp.ErrClosed
-	}
 	if _, ok := ch.conn.exchanges[name]; !ok {
 		ch.conn.exchanges[name] = &exchange{}
 	}
@@ -125,12 +132,12 @@ func (ch *fakeChannel) ExchangeDeclare(name string) error {
 // The exchange must exist.
 // If the queue doesn't exist, it's created.
 func (ch *fakeChannel) QueueDeclareAndBind(queueName, exchangeName string) error {
+	if ch.isClosed() {
+		return amqp.ErrClosed
+	}
 	ch.conn.mu.Lock()
 	defer ch.conn.mu.Unlock()
 
-	if ch.closed || ch.conn.closed {
-		return amqp.ErrClosed
-	}
 	ex, err := ch.getExchange(exchangeName)
 	if err != nil {
 		return err
@@ -145,12 +152,13 @@ func (ch *fakeChannel) QueueDeclareAndBind(queueName, exchangeName string) error
 }
 
 func (ch *fakeChannel) Publish(exchangeName string, pub amqp.Publishing) error {
+	if ch.isClosed() {
+		return amqp.ErrClosed
+	}
+
 	ch.conn.mu.Lock()
 	defer ch.conn.mu.Unlock()
 
-	if ch.closed || ch.conn.closed {
-		return amqp.ErrClosed
-	}
 	ex, err := ch.getExchange(exchangeName)
 	if err != nil {
 		return err
@@ -164,7 +172,13 @@ func (ch *fakeChannel) Publish(exchangeName string, pub amqp.Publishing) error {
 			ReplyText: "NO_ROUTE: no queues bound to exchange",
 		}
 		for _, c := range ch.returnChans {
-			c <- ret
+			select {
+			case c <- ret:
+			case <-ch.closed:
+				return amqp.ErrClosed
+			case <-ch.conn.closed:
+				return amqp.ErrClosed
+			}
 		}
 	} else {
 		// Each published message in the channel gets a new delivery tag, starting at 1.
@@ -184,7 +198,13 @@ func (ch *fakeChannel) Publish(exchangeName string, pub amqp.Publishing) error {
 	// Every Go channel registered with NotifyPublish gets a confirmation message.
 	// Ack is true even if the message was unroutable.
 	for _, c := range ch.pubChans {
-		c <- amqp.Confirmation{DeliveryTag: ch.deliveryTag, Ack: true}
+		select {
+		case c <- amqp.Confirmation{DeliveryTag: ch.deliveryTag, Ack: true}:
+		case <-ch.closed:
+			return amqp.ErrClosed
+		case <-ch.conn.closed:
+			return amqp.ErrClosed
+		}
 	}
 	return nil
 }
@@ -192,12 +212,12 @@ func (ch *fakeChannel) Publish(exchangeName string, pub amqp.Publishing) error {
 // Consume starts a consumer that reads from the given queue.
 // The consumerName can be used in a Cancel call to stop the consumer.
 func (ch *fakeChannel) Consume(queueName, consumerName string) (<-chan amqp.Delivery, error) {
+	if ch.isClosed() {
+		return nil, amqp.ErrClosed
+	}
 	ch.conn.mu.Lock()
 	defer ch.conn.mu.Unlock()
 
-	if ch.closed || ch.conn.closed {
-		return nil, amqp.ErrClosed
-	}
 	q, ok := ch.conn.queues[queueName]
 	if !ok {
 		return nil, ch.errorf(amqp.NotFound, "queue %q not found", queueName)
@@ -217,7 +237,11 @@ func (ch *fakeChannel) Consume(queueName, consumerName string) (<-chan amqp.Deli
 				select {
 				case delc <- m:
 				case <-ctx.Done():
-					// ignore error
+					// ignore errors here and below
+					return
+				case <-ch.closed:
+					return
+				case <-ch.conn.closed:
 					return
 				}
 			}
@@ -249,10 +273,7 @@ func (ch *fakeChannel) takeOneMessage(q *queue) (amqp.Delivery, bool) {
 
 // Ack is a no-op. (We don't test ack behavior.)
 func (ch *fakeChannel) Ack(tag uint64) error {
-	ch.conn.mu.Lock()
-	defer ch.conn.mu.Unlock()
-
-	if ch.closed || ch.conn.closed {
+	if ch.isClosed() {
 		return amqp.ErrClosed
 	}
 	return nil
@@ -260,12 +281,12 @@ func (ch *fakeChannel) Ack(tag uint64) error {
 
 // Cancel stops the consumer's goroutine.
 func (ch *fakeChannel) Cancel(consumerName string) error {
+	if ch.isClosed() {
+		return amqp.ErrClosed
+	}
 	ch.conn.mu.Lock()
 	defer ch.conn.mu.Unlock()
 
-	if ch.closed || ch.conn.closed {
-		return amqp.ErrClosed
-	}
 	cancel, ok := ch.consumerCancels[consumerName]
 	if !ok {
 		return ch.errorf(amqp.NotFound, "consumer %q not found", consumerName)
@@ -305,21 +326,17 @@ func (ch *fakeChannel) NotifyClose(c chan *amqp.Error) chan *amqp.Error {
 // Close marks the fakeChannel as closed and sends an error to all channels
 // registered with NotifyClose.
 func (ch *fakeChannel) Close() error {
-	ch.conn.mu.Lock()
-	defer ch.conn.mu.Unlock()
-
-	if ch.conn.closed {
+	if chanIsClosed(ch.conn.closed) {
 		return amqp.ErrClosed
 	}
-	ch.closeLocked()
-	return nil
-}
-
-func (ch *fakeChannel) closeLocked() {
-	ch.closed = true
-	for _, c := range ch.closeChans {
+	ch.closeMu.Lock()
+	closeChans := ch.closeChans
+	closeChan(ch.closed)
+	ch.closeMu.Unlock()
+	for _, c := range closeChans {
 		c <- amqp.ErrClosed
 	}
+	return nil
 }
 
 func (ch *fakeChannel) ExchangeDelete(name string) error {
@@ -330,4 +347,24 @@ func (ch *fakeChannel) ExchangeDelete(name string) error {
 func (ch *fakeChannel) QueueDelete(name string) error {
 	delete(ch.conn.queues, name)
 	return nil
+}
+
+// Assumes nothing is ever written to the channel.
+func chanIsClosed(ch chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+// Avoid panic when closing a closed channel.
+// Must be called with the lock held.
+func closeChan(ch chan struct{}) {
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
 }

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -38,6 +38,8 @@ type topic struct {
 	pubc   <-chan amqp.Confirmation // Go channel for server acks of publishes
 	retc   <-chan amqp.Return       // Go channel for "returned" undeliverable messages
 	closec <-chan *amqp.Error       // Go channel for AMQP channel close notifications
+
+	sendBatchHook func() // for testing
 }
 
 // TopicOptions sets options for constructing a *pubsub.Topic backed by
@@ -68,8 +70,9 @@ func OpenTopic(conn *amqp.Connection, name string, opts *TopicOptions) *pubsub.T
 
 func newTopic(conn amqpConnection, name string) *topic {
 	return &topic{
-		conn:     conn,
-		exchange: name,
+		conn:          conn,
+		exchange:      name,
+		sendBatchHook: func() {},
 	}
 }
 
@@ -135,7 +138,7 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 	if err := t.establishChannel(ctx); err != nil {
 		return err
 	}
-
+	t.sendBatchHook()
 	// Receive from Go channels concurrently or we will deadlock with the Publish
 	// RPC. (The amqp package docs recommend setting the capacity of the Go channel
 	// to the number of messages to be published, but we can't do that because we
@@ -281,31 +284,26 @@ func (*topic) ErrorCode(err error) gcerrors.ErrorCode {
 	return errorCode(err)
 }
 
+var errorCodes = map[int]gcerrors.ErrorCode{
+	amqp.NotFound:           gcerrors.NotFound,
+	amqp.PreconditionFailed: gcerrors.FailedPrecondition,
+	// These next indicate  a bug in our driver, not the user's code.
+	amqp.SyntaxError:    gcerrors.Internal,
+	amqp.CommandInvalid: gcerrors.Internal,
+	amqp.InternalError:  gcerrors.Internal,
+	amqp.NotImplemented: gcerrors.Unimplemented,
+	amqp.ChannelError:   gcerrors.FailedPrecondition, // typically channel closed
+}
+
 func errorCode(err error) gcerrors.ErrorCode {
 	aerr, ok := err.(*amqp.Error)
 	if !ok {
 		return gcerrors.Unknown
 	}
-	switch aerr.Code {
-	case amqp.NotFound:
-		return gcerrors.NotFound
-
-	case amqp.PreconditionFailed:
-		return gcerrors.FailedPrecondition
-
-	case amqp.SyntaxError, amqp.CommandInvalid:
-		// These indicate a bug in our driver, not the user's code.
-		return gcerrors.Internal
-
-	case amqp.InternalError:
-		return gcerrors.Internal
-
-	case amqp.NotImplemented:
-		return gcerrors.Unimplemented
-
-	default:
-		return gcerrors.Unknown
+	if ec, ok := errorCodes[aerr.Code]; ok {
+		return ec
 	}
+	return gcerrors.Unknown
 }
 
 func isRetryable(err error) bool {
@@ -401,15 +399,18 @@ type subscription struct {
 	ch     amqpChannel // AMQP channel used for all communication.
 	delc   <-chan amqp.Delivery
 	closec <-chan *amqp.Error
+
+	receiveBatchHook func() // for testing
 }
 
 var nextConsumer int64 // atomic
 
 func newSubscription(conn amqpConnection, name string) *subscription {
 	return &subscription{
-		conn:     conn,
-		queue:    name,
-		consumer: fmt.Sprintf("c%d", atomic.AddInt64(&nextConsumer, 1)),
+		conn:             conn,
+		queue:            name,
+		consumer:         fmt.Sprintf("c%d", atomic.AddInt64(&nextConsumer, 1)),
+		receiveBatchHook: func() {},
 	}
 }
 
@@ -455,6 +456,8 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 	if err := s.establishChannel(ctx); err != nil {
 		return nil, err
 	}
+
+	s.receiveBatchHook()
 
 	// Get up to maxMessages waiting messages, but don't take too long.
 	var ms []*driver.Message

--- a/pubsub/rabbitpubsub/rabbit_test.go
+++ b/pubsub/rabbitpubsub/rabbit_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -32,6 +33,7 @@ import (
 	"time"
 
 	"github.com/streadway/amqp"
+	"gocloud.dev/gcerrors"
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/driver"
 	"gocloud.dev/pubsub/drivertest"
@@ -64,9 +66,18 @@ func TestConformance(t *testing.T) {
 		return &harness{conn: mustDialRabbit(t)}, nil
 	}
 	_, isFake := mustDialRabbit(t).(*fakeConnection)
-	asTests := []drivertest.AsTest{
-		rabbitAsTest{isFake},
+	asTests := []drivertest.AsTest{rabbitAsTest{isFake}}
+	drivertest.RunConformanceTests(t, harnessMaker, asTests)
+
+	// Run the conformance tests with the fake if we haven't.
+	if isFake {
+		return
 	}
+	t.Logf("now running tests with the fake")
+	harnessMaker = func(_ context.Context, t *testing.T) (drivertest.Harness, error) {
+		return &harness{conn: newFakeConnection()}, nil
+	}
+	asTests = []drivertest.AsTest{rabbitAsTest{true}}
 	drivertest.RunConformanceTests(t, harnessMaker, asTests)
 }
 
@@ -200,10 +211,97 @@ func TestUnroutable(t *testing.T) {
 	if got, want := len(merr), len(msgs); got != want {
 		t.Fatalf("got %d errors, want %d", got, want)
 	}
+	// Test MultiError.Error.
+	if got, want := strings.Count(merr.Error(), ";")+1, len(merr); got != want {
+		t.Errorf("got %d semicolon-separated messages, want %d", got, want)
+	}
+	// Test each individual error.
 	for i, err := range merr {
 		if !strings.Contains(err.Error(), "NO_ROUTE") {
 			t.Errorf("%d: got %v, want an error with 'NO_ROUTE'", i, err)
 		}
+	}
+}
+
+func TestErrorCode(t *testing.T) {
+	for _, test := range []struct {
+		in   error
+		want gcerrors.ErrorCode
+	}{
+		{nil, gcerrors.Unknown},
+		{&os.PathError{}, gcerrors.Unknown},
+		{&amqp.Error{Code: amqp.SyntaxError}, gcerrors.Internal},
+		{&amqp.Error{Code: amqp.NotImplemented}, gcerrors.Unimplemented},
+		{&amqp.Error{Code: amqp.ContentTooLarge}, gcerrors.Unknown},
+	} {
+		if got := errorCode(test.in); got != test.want {
+			t.Errorf("%v: got %s, want %s", test.in, got, test.want)
+		}
+	}
+}
+
+func TestOpens(t *testing.T) {
+	if got := OpenTopic(nil, "t", nil); got == nil {
+		t.Error("got nil, want non-nil")
+	}
+	if got := OpenSubscription(nil, "s", nil); got == nil {
+		t.Error("got nil, want non-nil")
+	}
+}
+
+func TestCancelSendAndReceive(t *testing.T) {
+	conn := mustDialRabbit(t)
+	defer conn.Close()
+
+	if err := declareExchange(conn, "t"); err != nil {
+		t.Fatal(err)
+	}
+	// The queue is needed, or RabbitMQ says the message is unroutable.
+	if err := bindQueue(conn, "s", "t"); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	top := newTopic(conn, "t")
+	top.sendBatchHook = cancel
+	msgs := []*driver.Message{
+		{Body: []byte("")},
+	}
+	var err error
+	for err == nil {
+		err = top.SendBatch(ctx, msgs)
+	}
+	ec := errorCodeForTest(err)
+	// Error might either be from context being canceled, or channel subsequently being closed.
+	if ec != gcerrors.Canceled && ec != gcerrors.FailedPrecondition {
+		t.Errorf("got %v, want context.Canceled or FailedPrecondition", err)
+	}
+
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+	if err := top.SendBatch(ctx, msgs); err != nil {
+		t.Fatal(err)
+	}
+	sub := newSubscription(conn, "s")
+	sub.receiveBatchHook = cancel
+	_, err = sub.ReceiveBatch(ctx, 4)
+	if err != context.Canceled {
+		t.Errorf("got %v, want context.Canceled", err)
+	}
+}
+
+// Includes some cases that are handled elsewhere in production code.
+func errorCodeForTest(err error) gcerrors.ErrorCode {
+	switch err {
+	case nil:
+		return gcerrors.OK
+	case context.Canceled:
+		return gcerrors.Canceled
+
+	case context.DeadlineExceeded:
+		return gcerrors.DeadlineExceeded
+	default:
+		return errorCode(err)
 	}
 }
 
@@ -312,6 +410,10 @@ func (rabbitAsTest) TopicErrorCheck(t *pubsub.Topic, err error) error {
 	if !t.ErrorAs(err, &merr) {
 		return fmt.Errorf("failed to convert %v (%T) to a MultiError", err, err)
 	}
+	var perr *os.PathError
+	if t.ErrorAs(err, &perr) {
+		return errors.New("got true for PathError, want false")
+	}
 	return nil
 }
 
@@ -328,6 +430,10 @@ func (rabbitAsTest) SubscriptionErrorCheck(s *pubsub.Subscription, err error) er
 	var merr MultiError
 	if !s.ErrorAs(err, &merr) {
 		return fmt.Errorf("failed to convert %v (%T) to a MultiError", err, err)
+	}
+	var perr *os.PathError
+	if s.ErrorAs(err, &perr) {
+		return errors.New("got true for PathError, want false")
 	}
 	return nil
 }


### PR DESCRIPTION
With a live rabbitMQ server, code coverage is over 87%.

It is lower with a fake, for the simple reason that the shims
for the live server in amqp.go are not touched. So the number
reported by our CI system is low.

Also, rework closing in the fake to remove a deadlock.