### PR TITLE
admin: add P2 priority to our repositories

### DIFF
--- a/internal/admin/repository/main.tf
+++ b/internal/admin/repository/main.tf
@@ -163,3 +163,9 @@ resource "github_issue_label" "P1" {
   name        = "P1"
   color       = "ff6666"
 }
+
+resource "github_issue_label" "P2" {
+  repository  = "${github_repository.repo.name}"
+  name        = "P1"
+  color       = "cc9900"
+}


### PR DESCRIPTION
Terraform will perform the following actions:
```
  + module.go_cloud_repo.github_issue_label.P2
      id:         <computed>
      color:      "cc9900"
      etag:       <computed>
      name:       "P1"
      repository: "go-cloud"
      url:        <computed>

  + module.wire_repo.github_issue_label.P2
      id:         <computed>
      color:      "cc9900"
      etag:       <computed>
      name:       "P1"
      repository: "wire"
      url:        <computed>
```