### PR TITLE
admin: fix wrong label name

### DIFF
--- a/internal/admin/repository/main.tf
+++ b/internal/admin/repository/main.tf
@@ -166,6 +166,6 @@ resource "github_issue_label" "P1" {
 
 resource "github_issue_label" "P2" {
   repository  = "${github_repository.repo.name}"
-  name        = "P1"
+  name        = "P2"
   color       = "cc9900"
 }


### PR DESCRIPTION
Fixes an unfortunate typo from #1321

```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ module.go_cloud_repo.github_issue_label.P1
      color: "cc9900" => "ff6666"

  ~ module.go_cloud_repo.github_issue_label.P2
      name:  "P1" => "P2"

  ~ module.wire_repo.github_issue_label.P1
      color: "cc9900" => "ff6666"

  ~ module.wire_repo.github_issue_label.P2
      name:  "P1" => "P2"


Plan: 0 to add, 4 to change, 0 to destroy.

------------------------------------------------------------------------
```

