### PR TITLE
gcppubsub: remove context args

### DIFF
--- a/internal/contributebot/go.sum
+++ b/internal/contributebot/go.sum
@@ -162,6 +162,7 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/subcommands v0.0.0-20181012225330-46f0354f6315/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=

--- a/pubsub/gcppubsub/example_test.go
+++ b/pubsub/gcppubsub/example_test.go
@@ -53,7 +53,7 @@ func ExampleOpenTopic() {
 	defer pubClient.Close()
 
 	// Construct a *pubsub.Topic.
-	t := gcppubsub.OpenTopic(ctx, pubClient, projID, "example-topic", nil)
+	t := gcppubsub.OpenTopic(pubClient, projID, "example-topic", nil)
 	defer t.Shutdown(ctx)
 
 	// Now we can use t to send messages.
@@ -90,7 +90,7 @@ func ExampleOpenSubscription() {
 	defer subClient.Close()
 
 	// Construct a *pubsub.Subscription.
-	s := gcppubsub.OpenSubscription(ctx, subClient, projID, "example-subscription", nil)
+	s := gcppubsub.OpenSubscription(subClient, projID, "example-subscription", nil)
 	defer s.Shutdown(ctx)
 
 	// Now we can use s to receive messages.

--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -83,14 +83,14 @@ type TopicOptions struct{}
 // OpenTopic returns a *pubsub.Topic backed by an existing GCP PubSub topic
 // topicName in the given projectID. See the package documentation for an
 // example.
-func OpenTopic(ctx context.Context, client *raw.PublisherClient, proj gcp.ProjectID, topicName string, opts *TopicOptions) *pubsub.Topic {
-	dt := openTopic(ctx, client, proj, topicName)
+func OpenTopic(client *raw.PublisherClient, proj gcp.ProjectID, topicName string, opts *TopicOptions) *pubsub.Topic {
+	dt := openTopic(client, proj, topicName)
 	return pubsub.NewTopic(dt)
 }
 
 // openTopic returns the driver for OpenTopic. This function exists so the test
 // harness can get the driver interface implementation if it needs to.
-func openTopic(ctx context.Context, client *raw.PublisherClient, proj gcp.ProjectID, topicName string) driver.Topic {
+func openTopic(client *raw.PublisherClient, proj gcp.ProjectID, topicName string) driver.Topic {
 	path := fmt.Sprintf("projects/%s/topics/%s", proj, topicName)
 	return &topic{path, client}
 }
@@ -173,13 +173,13 @@ type SubscriptionOptions struct{}
 // OpenSubscription returns a *pubsub.Subscription backed by an existing GCP
 // PubSub subscription subscriptionName in the given projectID. See the package
 // documentation for an example.
-func OpenSubscription(ctx context.Context, client *raw.SubscriberClient, proj gcp.ProjectID, subscriptionName string, opts *SubscriptionOptions) *pubsub.Subscription {
-	ds := openSubscription(ctx, client, proj, subscriptionName)
+func OpenSubscription(client *raw.SubscriberClient, proj gcp.ProjectID, subscriptionName string, opts *SubscriptionOptions) *pubsub.Subscription {
+	ds := openSubscription(client, proj, subscriptionName)
 	return pubsub.NewSubscription(ds, nil)
 }
 
 // openSubscription returns a driver.Subscription.
-func openSubscription(ctx context.Context, client *raw.SubscriberClient, projectID gcp.ProjectID, subscriptionName string) driver.Subscription {
+func openSubscription(client *raw.SubscriberClient, projectID gcp.ProjectID, subscriptionName string) driver.Subscription {
 	path := fmt.Sprintf("projects/%s/subscriptions/%s", projectID, subscriptionName)
 	return &subscription{client, path}
 }

--- a/pubsub/gcppubsub/gcppubsub_test.go
+++ b/pubsub/gcppubsub/gcppubsub_test.go
@@ -68,7 +68,7 @@ func createTopic(ctx context.Context, pubClient *raw.PublisherClient, topicName,
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating topic: %v", err)
 	}
-	dt = openTopic(ctx, pubClient, projectID, topicName)
+	dt = openTopic(pubClient, projectID, topicName)
 	cleanup = func() {
 		pubClient.DeleteTopic(ctx, &pubsubpb.DeleteTopicRequest{Topic: topicPath})
 	}
@@ -76,7 +76,7 @@ func createTopic(ctx context.Context, pubClient *raw.PublisherClient, topicName,
 }
 
 func (h *harness) MakeNonexistentTopic(ctx context.Context) (driver.Topic, error) {
-	dt := openTopic(ctx, h.pubClient, projectID, "nonexistent-topic")
+	dt := openTopic(h.pubClient, projectID, "nonexistent-topic")
 	return dt, nil
 }
 
@@ -95,7 +95,7 @@ func createSubscription(ctx context.Context, subClient *raw.SubscriberClient, dt
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating subscription: %v", err)
 	}
-	ds = openSubscription(ctx, subClient, projectID, subName)
+	ds = openSubscription(subClient, projectID, subName)
 	cleanup = func() {
 		subClient.DeleteSubscription(ctx, &pubsubpb.DeleteSubscriptionRequest{Subscription: subPath})
 	}
@@ -103,7 +103,7 @@ func createSubscription(ctx context.Context, subClient *raw.SubscriberClient, dt
 }
 
 func (h *harness) MakeNonexistentSubscription(ctx context.Context) (driver.Subscription, error) {
-	ds := openSubscription(ctx, h.subClient, projectID, "nonexistent-subscription")
+	ds := openSubscription(h.subClient, projectID, "nonexistent-subscription")
 	return ds, nil
 
 }
@@ -253,7 +253,7 @@ func TestOpenTopic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	topic := OpenTopic(ctx, pc, projID, "my-topic", nil)
+	topic := OpenTopic(pc, projID, "my-topic", nil)
 	err = topic.Send(ctx, &pubsub.Message{Body: []byte("hello world")})
 	if err == nil {
 		t.Error("got nil, want error")
@@ -279,7 +279,7 @@ func TestOpenSubscription(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sub := OpenSubscription(ctx, sc, projID, "my-subscription", nil)
+	sub := OpenSubscription(sc, projID, "my-subscription", nil)
 	_, err = sub.Receive(ctx)
 	if err == nil {
 		t.Error("got nil, want error")

--- a/samples/gcmsg/gcp.go
+++ b/samples/gcmsg/gcp.go
@@ -35,7 +35,7 @@ func openGCPSubscription(ctx context.Context, proj, subID string) (*pubsub.Subsc
 	if err != nil {
 		return nil, nil, err
 	}
-	sub := gcppubsub.OpenSubscription(ctx, subClient, gcp.ProjectID(proj), subID, nil)
+	sub := gcppubsub.OpenSubscription(subClient, gcp.ProjectID(proj), subID, nil)
 	cleanup2 := func() {
 		sub.Shutdown(ctx)
 		cleanup()
@@ -79,7 +79,7 @@ func openGCPTopic(ctx context.Context, proj, topicID string) (*pubsub.Topic, fun
 	if err != nil {
 		return nil, nil, err
 	}
-	topic := gcppubsub.OpenTopic(ctx, pubClient, gcp.ProjectID(proj), topicID, nil)
+	topic := gcppubsub.OpenTopic(pubClient, gcp.ProjectID(proj), topicID, nil)
 	cleanup2 := func() {
 		topic.Shutdown(ctx)
 		cleanup()


### PR DESCRIPTION
Remove the context.Context argument from OpenTopic and OpenSubscription.

By design, all external work (e.g. establishing client connections)
has already happened by this point, so there is need for a context.