### PR TITLE
internal/docstore: structs

### DIFF
--- a/internal/docstore/driver/codec.go
+++ b/internal/docstore/driver/codec.go
@@ -1,0 +1,701 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(jba): support struct tags.
+// TODO(jba): for efficiency, enable encoding of only a subset of field paths.
+
+package driver
+
+import (
+	"encoding"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/golang/protobuf/proto"
+	"gocloud.dev/internal/docstore/internal/fields"
+	"gocloud.dev/internal/gcerr"
+)
+
+var (
+	binaryMarshalerType   = reflect.TypeOf((*encoding.BinaryMarshaler)(nil)).Elem()
+	binaryUnmarshalerType = reflect.TypeOf((*encoding.BinaryUnmarshaler)(nil)).Elem()
+	textMarshalerType     = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+	textUnmarshalerType   = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+	protoMessageType      = reflect.TypeOf((*proto.Message)(nil)).Elem()
+)
+
+// An Encoder encodes Go values in some other form (e.g. JSON, protocol buffers).
+// The encoding protocol is designed to avoid losing type information by passing
+// values using interface{}. An Encoder is responsible for storing the value
+// it is encoding.
+//
+// Because all providers must support the same set of values, the encoding methods
+// (with the exception of EncodeStruct) do not return errors. EncodeStruct is special
+// because it is an escape hatch for arbitrary structs, not all of which may be
+// encodable.
+type Encoder interface {
+	// These methods all encode and store a single Go value.
+	EncodeNull()
+	EncodeBool(bool)
+	EncodeString(string)
+	EncodeInt(int64)
+	EncodeUint(uint64)
+	EncodeFloat(float64)
+	EncodeComplex(complex128)
+	EncodeBytes([]byte)
+
+	// EncodeList is called when a slice or array is encountered (except for a
+	// []byte, which is handled by EncodeBytes). Its argument is the length of the
+	// slice or array. The encoding algorithm will call the returned Encoder that
+	// many times to encode the successive values of the list. After each such call,
+	// ListIndex will be called with the index of the element just encoded.
+	//
+	// For example, []string{"a", "b"} will result in these calls:
+	//     enc2 := enc.EncodeList(2)
+	//     enc2.EncodeString("a")
+	//     enc2.ListIndex(0)
+	//     enc2.EncodeString("b")
+	//     enc2.ListIndex(1)
+	EncodeList(n int) Encoder
+	ListIndex(i int)
+
+	// EncodeMap is called when a map or struct is encountered. Its argument is the
+	// number of fields in the map or struct. The encoding algorithm will call the
+	// returned Encoder that many times to encode the successive values of the map or
+	// struct. After each such call, MapKey will be called with the key of the
+	// element just encoded.
+	//
+	// For example, map[string}int{"A": 1, "B": 2} will result in these calls:
+	//     enc2 := enc.EncodeMap(2)
+	//     enc2.EncodeInt(1)
+	//     enc2.MapKey("A")
+	//     enc2.EncodeInt(2)
+	//     enc2.MapKey("B")
+	// For struct{A, B int}{1, 2}, if EncodeStruct (see below) returns false, the same
+	// sequence of calls will occur.
+	EncodeMap(n int) Encoder
+	MapKey(string)
+
+	// If the encoder wants to encode a struct in a special way (other than as a map
+	// from its exported fields to values), it should do so here and return true along
+	// with any error from the encoding.
+	// Otherwise, it should return false.
+	// s is the reflection of a struct.
+	EncodeStruct(s reflect.Value) (bool, error)
+}
+
+// Encode encodes the value using the given Encoder. It traverses the value,
+// iterating over arrays, slices, maps and the exported fields of structs. If it
+// encounters a non-nil pointer, it encodes the value that it points to.
+// Encode treats a few interfaces specially:
+//
+// If the value implements encoding.BinaryMarshaler, Encode invokes MarshalBinary
+// on it and encodes the resulting byte slice.
+//
+// If the value implements encoding.TextMarshaler, Encode invokes MarshalText on it
+// and encodes the resulting string.
+//
+// If the value implements proto.Message, Encode invokes proto.Marshal on it and encodes
+// the resulting byte slice. Here proto is the package "github.com/golang/protobuf/proto".
+//
+// Not every map key type can be encoded. Only strings, integers (signed or
+// unsigned), and types that implement encoding.TextMarshaler are permitted as map
+// keys. These restrictions match exactly those of the encoding/json package.
+func Encode(v reflect.Value, e Encoder) error {
+	return wrap(encode(v, e), gcerr.InvalidArgument)
+}
+
+func encode(v reflect.Value, enc Encoder) error {
+	if !v.IsValid() {
+		enc.EncodeNull()
+		return nil
+	}
+	if v.Type().Implements(binaryMarshalerType) {
+		bytes, err := v.Interface().(encoding.BinaryMarshaler).MarshalBinary()
+		if err != nil {
+			return err
+		}
+		enc.EncodeBytes(bytes)
+		return nil
+	}
+	if v.Type().Implements(protoMessageType) {
+		if v.IsNil() {
+			enc.EncodeNull()
+		} else {
+			bytes, err := proto.Marshal(v.Interface().(proto.Message))
+			if err != nil {
+				return err
+			}
+			enc.EncodeBytes(bytes)
+		}
+		return nil
+	}
+	if v.Type().Implements(textMarshalerType) {
+		bytes, err := v.Interface().(encoding.TextMarshaler).MarshalText()
+		if err != nil {
+			return err
+		}
+		enc.EncodeString(string(bytes))
+		return nil
+	}
+	switch v.Kind() {
+	case reflect.Bool:
+		enc.EncodeBool(v.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		enc.EncodeInt(v.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		enc.EncodeUint(v.Uint())
+	case reflect.Float32, reflect.Float64:
+		enc.EncodeFloat(v.Float())
+	case reflect.Complex64, reflect.Complex128:
+		enc.EncodeComplex(v.Complex())
+	case reflect.String:
+		enc.EncodeString(v.String())
+	case reflect.Slice:
+		if v.IsNil() {
+			enc.EncodeNull()
+			return nil
+		}
+		fallthrough
+	case reflect.Array:
+		return encodeList(v, enc)
+	case reflect.Map:
+		return encodeMap(v, enc)
+	case reflect.Ptr:
+		if v.IsNil() {
+			enc.EncodeNull()
+			return nil
+		}
+		return encode(v.Elem(), enc)
+	case reflect.Interface:
+		if v.IsNil() {
+			enc.EncodeNull()
+			return nil
+		}
+		return encode(v.Elem(), enc)
+
+	case reflect.Struct:
+		return encodeStruct(v, enc)
+
+	default:
+		return gcerr.Newf(gcerr.InvalidArgument, nil, "cannot encode type %s", v.Type())
+	}
+	return nil
+}
+
+// Encode an array or non-nil slice.
+func encodeList(v reflect.Value, enc Encoder) error {
+	// Byte slices or byte arrays encode specially.
+	if v.Type().Elem().Kind() == reflect.Uint8 {
+		enc.EncodeBytes(v.Bytes())
+		return nil
+	}
+	n := v.Len()
+	enc2 := enc.EncodeList(n)
+	for i := 0; i < n; i++ {
+		if err := encode(v.Index(i), enc2); err != nil {
+			return err
+		}
+		enc2.ListIndex(i)
+	}
+	return nil
+}
+
+// Encode a map.
+func encodeMap(v reflect.Value, enc Encoder) error {
+	if v.IsNil() {
+		enc.EncodeNull()
+		return nil
+	}
+	keys := v.MapKeys()
+	enc2 := enc.EncodeMap(len(keys))
+	for _, k := range keys {
+		sk, err := stringifyMapKey(k)
+		if err != nil {
+			return err
+		}
+		if err := encode(v.MapIndex(k), enc2); err != nil {
+			return err
+		}
+		enc2.MapKey(sk)
+	}
+	return nil
+}
+
+// k is the key of a map. Encode it as a string.
+// Only strings, integers (signed or unsigned), and types that implement
+// encoding.TextMarshaler are supported.
+func stringifyMapKey(k reflect.Value) (string, error) {
+	// This is basically reflectWithString.resolve, from encoding/json/encode.go.
+	if k.Kind() == reflect.String {
+		return k.String(), nil
+	}
+	if tm, ok := k.Interface().(encoding.TextMarshaler); ok {
+		b, err := tm.MarshalText()
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+	switch k.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(k.Int(), 10), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return strconv.FormatUint(k.Uint(), 10), nil
+	default:
+		return "", gcerr.Newf(gcerr.InvalidArgument, nil, "cannot encode key %s of type %s", k, k.Type())
+	}
+}
+
+func encodeStruct(v reflect.Value, e Encoder) error {
+	didIt, err := e.EncodeStruct(v)
+	if didIt {
+		return err
+	}
+	fields, err := fieldCache.Fields(v.Type())
+	if err != nil {
+		return err
+	}
+	return encodeStructWithFields(v, fields, e)
+}
+
+func encodeStructWithFields(v reflect.Value, fields fields.List, e Encoder) error {
+	e2 := e.EncodeMap(len(fields))
+	for _, f := range fields {
+		fv, ok := fieldByIndex(v, f.Index)
+		if ok {
+			if err := encode(fv, e2); err != nil {
+				return err
+			}
+			e2.MapKey(f.Name)
+		}
+	}
+	return nil
+}
+
+// fieldByIndex retrieves the the field of v at the given index if present.
+// v must be a struct. index must refer to a valid field of v's type.
+// The second return value is false if there is a nil embedded pointer
+// along the path denoted by index.
+//
+// From encoding/json/encode.go.
+func fieldByIndex(v reflect.Value, index []int) (reflect.Value, bool) {
+	for _, i := range index {
+		if v.Kind() == reflect.Ptr {
+			if v.IsNil() {
+				return reflect.Value{}, false
+			}
+			v = v.Elem()
+		}
+		v = v.Field(i)
+	}
+	return v, true
+}
+
+////////////////////////////////////////////////////////////////
+
+// TODO(jba): consider a fast path: if we are decoding into a struct, assume the same struct
+// was used to encode. Then we can build a map from field names to functions, where each
+// function avoids all the tests of Decode and contains just the code for setting the field.
+
+// TODO(jba): provide a way to override the check on missing fields.
+
+// A Decoder decodes data that was produced by Encode back into Go values.
+// Each Decoder instance is responsible for decoding one value.
+type Decoder interface {
+	// The AsXXX methods each report whether the value being decoded can be represented as
+	// a particular Go type. If so, the method should return the value as that type, and true;
+	// otherwise it should return the zero value and false.
+	AsString() (string, bool)
+	AsInt() (int64, bool)
+	AsUint() (uint64, bool)
+	AsFloat() (float64, bool)
+	AsComplex() (complex128, bool)
+	AsBytes() ([]byte, bool)
+	AsBool() (bool, bool)
+	AsNull() bool
+
+	// ListLen should return the length of the value being decoded and true, if the
+	// value can be decoded into a slice or array. Otherwise, ListLen should return
+	// (0, false).
+	ListLen() (int, bool)
+
+	// If ListLen returned true, then DecodeList will be called. It should iterate
+	// over the value being decoded in sequence from index 0, invoking the callback
+	// for each element with the element's index and a Decoder for the element.
+	// If the callback returns false, DecodeList should return immediately.
+	DecodeList(func(int, Decoder) bool)
+
+	// MapLen should return the number of fields of the value being decoded and true,
+	// if the value can be decoded into a map or struct. Otherwise, it should return
+	// (0, false).
+	MapLen() (int, bool)
+
+	// If MapLen returned true, the DecodeMap will be called. It should iterate over
+	// the fields of the value being decoded, invoking the callback on each with the
+	// field name and a Decoder for the field value. If the callback returns false,
+	// DecodeMap should return immediately.
+	DecodeMap(func(string, Decoder) bool)
+
+	// AsInterface should decode the value into the Go value that best represents it.
+	AsInterface() (interface{}, error)
+
+	// String should return a human-readable representation of the Decoder, for error messages.
+	String() string
+}
+
+// Decode decodes the value held in the Decoder d into v.
+// Decode creates slices, maps and pointer elements as needed.
+// It treats values that implement encoding.BinaryUnmarshaler, encoding.TextUnmarshaler
+// and proto.Message specially; see Encode.
+func Decode(v reflect.Value, d Decoder) error {
+	return wrap(decode(v, d), gcerr.InvalidArgument)
+}
+
+func decode(v reflect.Value, d Decoder) error {
+	// A Null value sets anything nullable to nil.
+	// If the value isn't nullable, we keep going.
+	// TODO(jba): should we treat decoding a null into a non-nullable as an error, or
+	// ignore it like encoding/json does?
+	if d.AsNull() {
+		switch v.Kind() {
+		case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice:
+			v.Set(reflect.Zero(v.Type()))
+			return nil
+		}
+	}
+
+	// Handle implemented interfaces first.
+	if reflect.PtrTo(v.Type()).Implements(binaryUnmarshalerType) {
+		if b, ok := d.AsBytes(); ok {
+			return v.Addr().Interface().(encoding.BinaryUnmarshaler).UnmarshalBinary(b)
+		}
+		return decodingError(v, d)
+	}
+	if reflect.PtrTo(v.Type()).Implements(protoMessageType) {
+		if b, ok := d.AsBytes(); ok {
+			return proto.Unmarshal(b, v.Addr().Interface().(proto.Message))
+		}
+		return decodingError(v, d)
+	}
+	if reflect.PtrTo(v.Type()).Implements(textUnmarshalerType) {
+		if s, ok := d.AsString(); ok {
+			return v.Addr().Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(s))
+		}
+		return decodingError(v, d)
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		if b, ok := d.AsBool(); ok {
+			v.SetBool(b)
+			return nil
+		}
+
+	case reflect.String:
+		if s, ok := d.AsString(); ok {
+			v.SetString(s)
+			return nil
+		}
+
+	case reflect.Float32, reflect.Float64:
+		if f, ok := d.AsFloat(); ok {
+			v.SetFloat(f)
+			return nil
+		}
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i, ok := d.AsInt()
+		if !ok {
+			// Accept a floating-point number with integral value.
+			if f, ok := d.AsFloat(); ok {
+				i = int64(f)
+				if float64(i) != f {
+					return fmt.Errorf("docstore: float %f does not fit into %s", f, v.Type())
+				}
+			}
+		}
+		if v.OverflowInt(i) {
+			return overflowError(i, v.Type())
+		}
+		v.SetInt(i)
+		return nil
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		u, ok := d.AsUint()
+		if !ok {
+			// Accept a floating-point number with integral value.
+			if f, ok := d.AsFloat(); ok {
+				u = uint64(f)
+				if float64(u) != f {
+					return fmt.Errorf("docstore: float %f does not fit into %s", f, v.Type())
+				}
+			}
+		}
+		if v.OverflowUint(u) {
+			return overflowError(u, v.Type())
+		}
+		v.SetUint(u)
+		return nil
+
+	case reflect.Complex64, reflect.Complex128:
+		if c, ok := d.AsComplex(); ok {
+			v.SetComplex(c)
+			return nil
+		}
+
+	case reflect.Slice, reflect.Array:
+		return decodeList(v, d)
+
+	case reflect.Map:
+		return decodeMap(v, d)
+
+	case reflect.Ptr:
+		// If the pointer is nil, set it to a zero value.
+		if v.IsNil() {
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+		return decode(v.Elem(), d)
+
+	case reflect.Struct:
+		return decodeStruct(v, d)
+
+	case reflect.Interface:
+		if v.NumMethod() == 0 { // empty interface
+			// If v holds a pointer, set the pointer.
+			if !v.IsNil() && v.Elem().Kind() == reflect.Ptr {
+				return decode(v.Elem(), d)
+			}
+			// Otherwise, create a fresh value.
+			x, err := d.AsInterface()
+			if err != nil {
+				return err
+			}
+			v.Set(reflect.ValueOf(x))
+			return nil
+		}
+		// Any other kind of interface is an error???
+	}
+
+	return decodingError(v, d)
+}
+
+func decodeList(v reflect.Value, d Decoder) error {
+	// If we're decoding into a byte slice or array, and the decoded value
+	// supports that, then do the decoding.
+	if v.Type().Elem().Kind() == reflect.Uint8 {
+		if b, ok := d.AsBytes(); ok {
+			v.SetBytes(b)
+			return nil
+		}
+		// Fall through to decode the []byte as an ordinary slice.
+	}
+	dlen, ok := d.ListLen()
+	if !ok {
+		return decodingError(v, d)
+	}
+	err := prepareLength(v, dlen)
+	if err != nil {
+		return err
+	}
+	d.DecodeList(func(i int, vd Decoder) bool {
+		if err != nil || i >= dlen {
+			return false
+		}
+		err = decode(v.Index(i), vd)
+		return err == nil
+	})
+	return err
+}
+
+// v must be a slice or array. We want it to be of length wantLen. Prepare it as
+// necessary (details described in the code below), and return its resulting length.
+// If an array is too short, return an error. This behavior differs from
+// encoding/json, which just populates a short array with whatever it can and drops
+// the rest. That can lose data.
+func prepareLength(v reflect.Value, wantLen int) error {
+	vLen := v.Len()
+	if v.Kind() == reflect.Slice {
+		// Construct a slice of the right size, avoiding allocation if possible.
+		switch {
+		case vLen < wantLen: // v too short
+			if v.Cap() >= wantLen { // extend its length if there's room
+				v.SetLen(wantLen)
+			} else { // else make a new one
+				v.Set(reflect.MakeSlice(v.Type(), wantLen, wantLen))
+			}
+		case vLen > wantLen: // v too long; truncate it
+			v.SetLen(wantLen)
+		}
+	} else { // array
+		switch {
+		case vLen < wantLen: // v too short
+			return gcerr.Newf(gcerr.InvalidArgument, nil, "array length %d is too short for incoming list of length %d",
+				vLen, wantLen)
+		case vLen > wantLen: // v too long; set extra elements to zero
+			z := reflect.Zero(v.Type().Elem())
+			for i := wantLen; i < vLen; i++ {
+				v.Index(i).Set(z)
+			}
+		}
+	}
+	return nil
+}
+
+// Since a map value is not settable via reflection, this function always creates a
+// new element for each corresponding map key. Existing values of v are overwritten.
+// This happens even if the map value is something like a pointer to a struct, where
+// we could in theory populate the existing struct value instead of discarding it.
+// This behavior matches encoding/json.
+func decodeMap(v reflect.Value, d Decoder) error {
+	mapLen, ok := d.MapLen()
+	if !ok {
+		return decodingError(v, d)
+	}
+	t := v.Type()
+	if v.IsNil() {
+		v.Set(reflect.MakeMapWithSize(t, mapLen))
+	}
+	et := t.Elem()
+	var err error
+	kt := v.Type().Key()
+	d.DecodeMap(func(key string, vd Decoder) bool {
+		if err != nil {
+			return false
+		}
+		el := reflect.New(et).Elem()
+		err = decode(el, vd)
+		if err != nil {
+			return false
+		}
+		vk, e := unstringifyMapKey(key, kt)
+		if e != nil {
+			err = e
+			return false
+		}
+		v.SetMapIndex(vk, el)
+		return err == nil
+	})
+	return err
+}
+
+// Given a map key encoded as a string, and the type of the map key, convert the key
+// into the type.
+// For example, if we are decoding the key "3" for a map[int]interface{}, then key is "3"
+// and keyType is reflect.Int.
+func unstringifyMapKey(key string, keyType reflect.Type) (reflect.Value, error) {
+	// This code is mostly from the middle of decodeState.object in encoding/json/decode.go.
+	// Except for literalStore, which I don't understand.
+	// TODO(jba): understand literalStore.
+	switch {
+	case keyType.Kind() == reflect.String:
+		return reflect.ValueOf(key).Convert(keyType), nil
+	case reflect.PtrTo(keyType).Implements(textUnmarshalerType):
+		tu := reflect.New(keyType)
+		if err := tu.Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(key)); err != nil {
+			return reflect.Value{}, err
+		}
+		return tu.Elem(), nil
+	case keyType.Kind() == reflect.Interface && keyType.NumMethod() == 0:
+		// TODO: remove this case? encoding/json doesn't support it.
+		return reflect.ValueOf(key), nil
+	default:
+		switch keyType.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			n, err := strconv.ParseInt(key, 10, 64)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			if reflect.Zero(keyType).OverflowInt(n) {
+				return reflect.Value{}, overflowError(n, keyType)
+			}
+			return reflect.ValueOf(n).Convert(keyType), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			n, err := strconv.ParseUint(key, 10, 64)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			if reflect.Zero(keyType).OverflowUint(n) {
+				return reflect.Value{}, overflowError(n, keyType)
+			}
+			return reflect.ValueOf(n).Convert(keyType), nil
+		default:
+			return reflect.Value{}, gcerr.Newf(gcerr.InvalidArgument, nil, "invalid key type %s", keyType)
+		}
+	}
+}
+
+func decodeStruct(v reflect.Value, d Decoder) error {
+	fields, err := fieldCache.Fields(v.Type())
+	if err != nil {
+		return err
+	}
+	d.DecodeMap(func(key string, d2 Decoder) bool {
+		if err != nil {
+			return false
+		}
+		f := fields.Match(key)
+		if f == nil {
+			err = gcerr.Newf(gcerr.InvalidArgument, nil, "no field matching %q in %s", key, v.Type())
+			return false
+		}
+		fv, ok := fieldByIndexCreate(v, f.Index)
+		if !ok {
+			err = gcerr.Newf(gcerr.InvalidArgument, nil,
+				"setting field %q in %s: cannot create embedded pointer field of unexported type",
+				key, v.Type())
+			return false
+		}
+		err = decode(fv, d2)
+		return err == nil
+	})
+	return err
+}
+
+// fieldByIndexCreate retrieves the the field of v at the given index if present,
+// creating embedded struct pointers where necessary.
+// v must be a struct. index must refer to a valid field of v's type.
+// The second return value is false If there is a nil embedded pointer of unexported
+// type along the path denoted by index. (We cannot create such pointers.)
+func fieldByIndexCreate(v reflect.Value, index []int) (reflect.Value, bool) {
+	for _, i := range index {
+		if v.Kind() == reflect.Ptr {
+			if v.IsNil() {
+				if !v.CanSet() {
+					return reflect.Value{}, false
+				}
+				v.Set(reflect.New(v.Type().Elem()))
+			}
+			v = v.Elem()
+		}
+		v = v.Field(i)
+	}
+	return v, true
+}
+
+func decodingError(v reflect.Value, d Decoder) error {
+	return gcerr.Newf(gcerr.InvalidArgument, nil, "cannot set type %s to %s", v.Type(), d)
+}
+
+func overflowError(x interface{}, t reflect.Type) error {
+	return gcerr.Newf(gcerr.InvalidArgument, nil, "value %v overflows type %s", x, t)
+}
+
+func wrap(err error, code gcerr.ErrorCode) error {
+	if _, ok := err.(*gcerr.Error); !ok && err != nil {
+		err = gcerr.New(code, err, 2, err.Error())
+	}
+	return err
+}

--- a/internal/docstore/driver/codec_test.go
+++ b/internal/docstore/driver/codec_test.go
@@ -182,7 +182,7 @@ type testEncoder struct {
 	val interface{}
 }
 
-func (e *testEncoder) EncodeNull()                { e.val = nil }
+func (e *testEncoder) EncodeNil()                 { e.val = nil }
 func (e *testEncoder) EncodeBool(x bool)          { e.val = x }
 func (e *testEncoder) EncodeString(x string)      { e.val = x }
 func (e *testEncoder) EncodeInt(x int64)          { e.val = x }

--- a/internal/docstore/driver/codec_test.go
+++ b/internal/docstore/driver/codec_test.go
@@ -1,0 +1,436 @@
+// Copyright 2019 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	tspb "github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/google/go-cmp/cmp"
+	"gocloud.dev/internal/gcerr"
+)
+
+type myString string
+
+type te struct{ X byte }
+
+func (e te) MarshalText() ([]byte, error) {
+	return []byte{e.X}, nil
+}
+
+func (e *te) UnmarshalText(b []byte) error {
+	if len(b) != 1 {
+		return errors.New("te.UnmarshalText: need exactly 1 byte")
+	}
+	e.X = b[0]
+	return nil
+}
+
+type Embed1 struct {
+	E1 string
+}
+type Embed2 struct {
+	E2 string
+}
+
+type embed3 struct {
+	E3 string
+}
+
+type embed4 struct {
+	E4 string
+}
+
+type MyStruct struct {
+	A int
+	B *bool
+	C []*te
+	D []time.Time
+	T *tspb.Timestamp
+	Embed1
+	*Embed2
+	embed3
+	*embed4
+}
+
+func TestEncode(t *testing.T) {
+	var seven int32 = 7
+	var nullptr *int
+	tm := time.Now()
+	tmb, err := tm.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tru := true
+	ts := &tspb.Timestamp{Seconds: 25, Nanos: 300}
+	tsb, err := proto.Marshal(ts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		in, want interface{}
+	}{
+		{nil, nil},
+		{0, int64(0)},
+		{uint64(999), uint64(999)},
+		{float32(3.5), float64(3.5)},
+		{"", ""},
+		{"x", "x"},
+		{true, true},
+		{nullptr, nil},
+		{seven, int64(seven)},
+		{&seven, int64(seven)},
+		{3 + 4i, 3 + 4i},
+		{[]int(nil), nil},
+		{[]int{}, []interface{}{}},
+		{[]int{1, 2}, []interface{}{int64(1), int64(2)}},
+		{
+			[][]string{{"a", "b"}, {"c", "d"}},
+			[]interface{}{
+				[]interface{}{"a", "b"},
+				[]interface{}{"c", "d"},
+			},
+		},
+		{[...]int{1, 2}, []interface{}{int64(1), int64(2)}},
+		{[]interface{}{nil, false}, []interface{}{nil, false}},
+		{map[string]int(nil), nil},
+		{map[string]int{}, map[string]interface{}{}},
+		{
+			map[string]int{"a": 1, "b": 2},
+			map[string]interface{}{"a": int64(1), "b": int64(2)},
+		},
+		{tm, tmb},
+		{ts, tsb},
+		{te{'A'}, "A"},
+		{myString("x"), "x"},
+		{[]myString{"x"}, []interface{}{"x"}},
+		{map[myString]myString{"a": "x"}, map[string]interface{}{"a": "x"}},
+		{
+			map[int]bool{17: true},
+			map[string]interface{}{"17": true},
+		},
+		{
+			map[te]bool{te{'B'}: true},
+			map[string]interface{}{"B": true},
+		},
+		{
+			MyStruct{
+				A:      1,
+				B:      &tru,
+				C:      []*te{&te{'T'}},
+				D:      []time.Time{tm},
+				T:      ts,
+				Embed1: Embed1{E1: "E1"},
+				Embed2: &Embed2{E2: "E2"},
+				embed3: embed3{E3: "E3"},
+				embed4: &embed4{E4: "E4"},
+			},
+			map[string]interface{}{
+				"A":  int64(1),
+				"B":  true,
+				"C":  []interface{}{"T"},
+				"D":  []interface{}{tmb},
+				"T":  tsb,
+				"E1": "E1",
+				"E2": "E2",
+				"E3": "E3",
+				"E4": "E4",
+			},
+		},
+		{
+			MyStruct{},
+			map[string]interface{}{
+				"A":  int64(0),
+				"B":  nil,
+				"C":  nil,
+				"D":  nil,
+				"T":  nil,
+				"E1": "",
+				"E3": "",
+			},
+		},
+	} {
+		enc := &testEncoder{}
+		if err := Encode(reflect.ValueOf(test.in), enc); err != nil {
+			t.Fatal(err)
+		}
+		got := enc.val
+		if diff := cmp.Diff(got, test.want); diff != "" {
+			t.Errorf("%#v: %s", test.in, diff)
+		}
+	}
+}
+
+type testEncoder struct {
+	val interface{}
+}
+
+func (e *testEncoder) EncodeNull()                { e.val = nil }
+func (e *testEncoder) EncodeBool(x bool)          { e.val = x }
+func (e *testEncoder) EncodeString(x string)      { e.val = x }
+func (e *testEncoder) EncodeInt(x int64)          { e.val = x }
+func (e *testEncoder) EncodeUint(x uint64)        { e.val = x }
+func (e *testEncoder) EncodeFloat(x float64)      { e.val = x }
+func (e *testEncoder) EncodeComplex(x complex128) { e.val = x }
+func (e *testEncoder) EncodeBytes(x []byte)       { e.val = x }
+
+func (e *testEncoder) EncodeStruct(reflect.Value) (bool, error) {
+	return false, nil
+}
+
+func (e *testEncoder) ListIndex(int) { panic("impossible") }
+func (e *testEncoder) MapKey(string) { panic("impossible") }
+
+func (e *testEncoder) EncodeList(n int) Encoder {
+	s := make([]interface{}, n)
+	e.val = s
+	return &listEncoder{s: s}
+}
+
+func (e *testEncoder) EncodeMap(n int) Encoder {
+	m := make(map[string]interface{}, n)
+	e.val = m
+	return &mapEncoder{m: m}
+}
+
+type listEncoder struct {
+	s []interface{}
+	testEncoder
+}
+
+func (e *listEncoder) ListIndex(i int) { e.s[i] = e.val }
+
+type mapEncoder struct {
+	m map[string]interface{}
+	testEncoder
+}
+
+func (e *mapEncoder) MapKey(k string) { e.m[k] = e.val }
+
+func TestDecode(t *testing.T) {
+	two := 2
+	tru := true
+	fa := false
+	ptru := &tru
+	pfa := &fa
+	tm := time.Now()
+	tmb, err := tm.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := &tspb.Timestamp{Seconds: 25, Nanos: 300}
+	tsb, err := proto.Marshal(ts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		in   interface{} // pointer that will be set
+		val  interface{} // value to set it to
+		want interface{}
+	}{
+		{new(interface{}), nil, nil},
+		{new(int), int64(7), int(7)},
+		{new(uint8), uint64(250), uint8(250)},
+		{new(bool), true, true},
+		{new(string), "x", "x"},
+		{new(float32), 4.25, float32(4.25)},
+		{new(complex64), 3 + 5i, complex64(3 + 5i)},
+		{new(*int), int64(2), &two},
+		{new(*int), nil, (*int)(nil)},
+		{new([]byte), []byte("foo"), []byte("foo")},
+		{new([]string), []interface{}{"a", "b"}, []string{"a", "b"}},
+		{new([]**bool), []interface{}{true, false}, []**bool{&ptru, &pfa}},
+		{
+			new(map[string]string),
+			map[string]interface{}{"a": "b"},
+			map[string]string{"a": "b"},
+		},
+		{
+			new(map[int]bool),
+			map[string]interface{}{"17": true},
+			map[int]bool{17: true},
+		},
+		{
+			new(map[te]bool),
+			map[string]interface{}{"B": true},
+			map[te]bool{te{'B'}: true},
+		},
+		{
+			new(map[interface{}]bool),
+			map[string]interface{}{"B": true},
+			map[interface{}]bool{"B": true},
+		},
+		{
+			new(map[string][]bool),
+			map[string]interface{}{
+				"a": []interface{}{true, false},
+				"b": []interface{}{false, true},
+			},
+			map[string][]bool{
+				"a": []bool{true, false},
+				"b": []bool{false, true},
+			},
+		},
+		{new(myString), "x", myString("x")},
+		{new([]myString), []interface{}{"x"}, []myString{"x"}},
+		{new(time.Time), tmb, tm},
+		{new(*time.Time), tmb, &tm},
+		{new(*tspb.Timestamp), tsb, ts},
+		{new([]time.Time), []interface{}{tmb}, []time.Time{tm}},
+		{new([]*time.Time), []interface{}{tmb}, []*time.Time{&tm}},
+		{
+			new(map[myString]myString),
+			map[string]interface{}{"a": "x"},
+			map[myString]myString{"a": "x"},
+		},
+		{
+			new(map[string]time.Time),
+			map[string]interface{}{"t": tmb},
+			map[string]time.Time{"t": tm},
+		},
+		{
+			new(map[string]*time.Time),
+			map[string]interface{}{"t": tmb},
+			map[string]*time.Time{"t": &tm},
+		},
+		{new(te), "A", te{'A'}},
+		{new(**te), "B", func() **te { x := &te{'B'}; return &x }()},
+
+		{
+			&MyStruct{embed4: &embed4{}},
+			map[string]interface{}{
+				"a":  int64(1),
+				"b":  true,
+				"C":  []interface{}{"T"},
+				"D":  []interface{}{tmb},
+				"T":  tsb,
+				"E1": "E1",
+				"E2": "E2",
+				"E3": "E3",
+				"E4": "E4",
+			},
+			MyStruct{A: 1, B: &tru, C: []*te{&te{'T'}}, D: []time.Time{tm}, T: ts,
+				Embed1: Embed1{E1: "E1"},
+				Embed2: &Embed2{E2: "E2"},
+				embed3: embed3{E3: "E3"},
+				embed4: &embed4{E4: "E4"},
+			},
+		},
+	} {
+		dec := &testDecoder{test.val}
+		if err := Decode(reflect.ValueOf(test.in).Elem(), dec); err != nil {
+			t.Fatalf("%T: %v", test.in, err)
+		}
+		got := reflect.ValueOf(test.in).Elem().Interface()
+		diff := cmp.Diff(got, test.want, cmp.Comparer(proto.Equal), cmp.AllowUnexported(MyStruct{}))
+		if diff != "" {
+			t.Errorf("%T (got=-, want=+): %s", test.in, diff)
+		}
+	}
+}
+
+func TestDecodeErrors(t *testing.T) {
+	for _, test := range []struct {
+		desc    string
+		in, val interface{}
+	}{
+		{
+			"array too short",
+			new([1]bool),
+			[]bool{true, false},
+		},
+		{
+			"bad map key type",
+			new(map[float64]interface{}),
+			map[string]interface{}{"a": 1},
+		},
+		{
+			"unknown struct field",
+			new(MyStruct),
+			map[string]interface{}{"bad": 1},
+		},
+		{
+			"nil embedded, unexported pointer to struct",
+			new(MyStruct),
+			map[string]interface{}{"E4": "E4"},
+		},
+	} {
+		dec := &testDecoder{test.val}
+		err := Decode(reflect.ValueOf(test.in).Elem(), dec)
+		if e, ok := err.(*gcerr.Error); !ok || err == nil || e.Code != gcerr.InvalidArgument {
+			t.Errorf("%s: got %v, want InvalidArgument Error", test.desc, err)
+			fmt.Printf("%+v\n", test.in)
+		}
+	}
+}
+
+type testDecoder struct {
+	val interface{} // assume encoded by testEncoder.
+}
+
+func (d testDecoder) String() string {
+	return fmt.Sprint(d.val)
+}
+
+func (d testDecoder) AsNull() bool {
+	return d.val == nil
+}
+
+func (d testDecoder) AsBool() (bool, bool)          { x, ok := d.val.(bool); return x, ok }
+func (d testDecoder) AsString() (string, bool)      { x, ok := d.val.(string); return x, ok }
+func (d testDecoder) AsInt() (int64, bool)          { x, ok := d.val.(int64); return x, ok }
+func (d testDecoder) AsUint() (uint64, bool)        { x, ok := d.val.(uint64); return x, ok }
+func (d testDecoder) AsFloat() (float64, bool)      { x, ok := d.val.(float64); return x, ok }
+func (d testDecoder) AsComplex() (complex128, bool) { x, ok := d.val.(complex128); return x, ok }
+func (d testDecoder) AsBytes() ([]byte, bool)       { x, ok := d.val.([]byte); return x, ok }
+
+func (d testDecoder) ListLen() (int, bool) {
+	l, ok := d.val.([]interface{})
+	if !ok {
+		return 0, false
+	}
+	return len(l), true
+}
+
+func (d testDecoder) DecodeList(f func(i int, vd Decoder) bool) {
+	for i, v := range d.val.([]interface{}) {
+		if !f(i, testDecoder{v}) {
+			break
+		}
+	}
+}
+func (d testDecoder) MapLen() (int, bool) {
+	if m, ok := d.val.(map[string]interface{}); ok {
+		return len(m), true
+	}
+	return 0, false
+}
+
+func (d testDecoder) DecodeMap(f func(key string, vd Decoder) bool) {
+	for k, v := range d.val.(map[string]interface{}) {
+		if !f(k, testDecoder{v}) {
+			break
+		}
+	}
+}
+func (d testDecoder) AsInterface() (interface{}, error) {
+	return d.val, nil
+}

--- a/internal/docstore/driver/document.go
+++ b/internal/docstore/driver/document.go
@@ -15,16 +15,21 @@
 package driver
 
 import (
+	"reflect"
+
 	"gocloud.dev/gcerrors"
+	"gocloud.dev/internal/docstore/internal/fields"
 	"gocloud.dev/internal/gcerr"
 )
+
+var fieldCache = fields.NewCache(nil, nil, nil)
 
 // A Document is a lightweight wrapper around either a map[string]interface{} or a
 // struct pointer. It provides operations to get and set fields and field paths.
 type Document struct {
-	m map[string]interface{} // nil if it's a *struct
-	//s      reflect.Value          // the struct reflected
-	//fields fields.List            // for structs
+	m      map[string]interface{} // nil if it's a *struct
+	s      reflect.Value          // the struct reflected
+	fields fields.List            // for structs
 }
 
 // Create a new document from doc, which must be a map[string]interface{} or a struct pointer.
@@ -33,12 +38,20 @@ func NewDocument(doc interface{}) (Document, error) {
 	if m, ok := doc.(map[string]interface{}); ok {
 		return Document{m: m}, nil
 	}
-	panic("unimplemented")
-}
-
-// TODO(jba): remove this method after memdocstore uses the codec framework.
-func (d Document) Map() map[string]interface{} {
-	return d.m
+	v := reflect.ValueOf(doc)
+	t := v.Type()
+	if t.Kind() == reflect.Ptr {
+		v = v.Elem()
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return Document{}, gcerr.Newf(gcerr.InvalidArgument, nil, "expecting struct or map[string]interface{}, got %s", t)
+	}
+	fields, err := fieldCache.Fields(t)
+	if err != nil {
+		return Document{}, err
+	}
+	return Document{s: v, fields: fields}, nil
 }
 
 // GetField returns the value of the named document field.
@@ -49,8 +62,13 @@ func (d Document) GetField(field string) (interface{}, error) {
 			return nil, gcerr.Newf(gcerr.NotFound, nil, "field %q not found in map", field)
 		}
 		return x, nil
+	} else {
+		v, err := d.structField(field)
+		if err != nil {
+			return nil, err
+		}
+		return v.Interface(), nil
 	}
-	panic("unimplemented")
 }
 
 // getDocument gets the value of the given field path, which must be a document.
@@ -87,6 +105,19 @@ func (d Document) Get(fp []string) (interface{}, error) {
 	return d2.GetField(fp[len(fp)-1])
 }
 
+func (d Document) structField(name string) (reflect.Value, error) {
+	f := d.fields.Match(name)
+	if f == nil {
+		return reflect.Value{}, gcerr.Newf(gcerr.NotFound, nil, "field %q not found in struct type %s", name, d.s.Type())
+	}
+	fv, ok := fieldByIndex(d.s, f.Index)
+	if !ok {
+		return reflect.Value{}, gcerr.Newf(gcerr.InvalidArgument, nil, "nil embedded pointer; cannot get field %q from %s",
+			name, d.s.Type())
+	}
+	return fv, nil
+}
+
 // Set sets the value of the field path in the document.
 // This creates sub-maps as necessary, if possible.
 func (d Document) Set(fp []string, val interface{}) error {
@@ -103,5 +134,30 @@ func (d Document) SetField(field string, value interface{}) error {
 		d.m[field] = value
 		return nil
 	}
-	panic("unimplemented")
+	v, err := d.structField(field)
+	if err != nil {
+		return err
+	}
+	if !v.CanSet() {
+		return gcerr.Newf(gcerr.InvalidArgument, nil, "cannot set field %s in struct of type %s: not addressable",
+			field, d.s.Type())
+	}
+	v.Set(reflect.ValueOf(value))
+	return nil
+}
+
+// Encode encodes the document using the given Encoder.
+func (d Document) Encode(e Encoder) error {
+	if d.m != nil {
+		return encodeMap(reflect.ValueOf(d.m), e)
+	}
+	return encodeStructWithFields(d.s, d.fields, e)
+}
+
+// Decode decodes the document using the given Decoder.
+func (d Document) Decode(dec Decoder) error {
+	if d.m != nil {
+		return Decode(reflect.ValueOf(d.m), dec)
+	}
+	return Decode(d.s, dec)
 }

--- a/internal/docstore/driver/document.go
+++ b/internal/docstore/driver/document.go
@@ -45,7 +45,7 @@ func NewDocument(doc interface{}) (Document, error) {
 		t = t.Elem()
 	}
 	if t.Kind() != reflect.Struct {
-		return Document{}, gcerr.Newf(gcerr.InvalidArgument, nil, "expecting struct or map[string]interface{}, got %s", t)
+		return Document{}, gcerr.Newf(gcerr.InvalidArgument, nil, "expecting struct, *struct or map[string]interface{}, got %s", t)
 	}
 	fields, err := fieldCache.Fields(t)
 	if err != nil {

--- a/internal/docstore/driver/document_test.go
+++ b/internal/docstore/driver/document_test.go
@@ -1,0 +1,104 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type S struct {
+	I int
+	M map[string]interface{}
+}
+
+func TestGet(t *testing.T) {
+	in := map[string]interface{}{
+		"S": &S{
+			I: 2,
+			M: map[string]interface{}{
+				"J": 3,
+				"T": &S{I: 4},
+			},
+		},
+	}
+	doc, err := NewDocument(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		fp   string
+		want interface{}
+	}{
+		{"S.I", 2},
+		{"S.i", 2},
+		{"S.M.J", 3},
+		{"S.m.J", 3},
+		{"S.M.T.I", 4},
+		{"S.m.T.i", 4},
+	} {
+		fp := strings.Split(test.fp, ".")
+		got, err := doc.Get(fp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !cmp.Equal(got, test.want) {
+			t.Errorf("%s: got %v, want %v", got, test.fp, test.want)
+		}
+	}
+}
+
+func TestSet(t *testing.T) {
+	in := map[string]interface{}{
+		"S": &S{
+			I: 2,
+			M: map[string]interface{}{
+				"J": 3,
+				"T": &S{I: 4},
+			},
+		},
+	}
+	doc, err := NewDocument(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		fp  string
+		val interface{}
+	}{
+		{"S.I", -1},
+		{"S.i", -2},
+		{"S.M.J", -3},
+		{"S.m.J", -4},
+		{"S.M.T.I", -5},
+		{"S.m.T.i", -6},
+		{"new.field", -7},
+	} {
+		fp := strings.Split(test.fp, ".")
+		if err := doc.Set(fp, test.val); err != nil {
+			t.Fatalf("%q: %v", test.fp, err)
+		}
+		got, err := doc.Get(fp)
+		if err != nil {
+			t.Fatalf("%s: %v", test.fp, err)
+		}
+		if !cmp.Equal(got, test.val) {
+			t.Errorf("got %v, want %v", got, test.val)
+		}
+	}
+}

--- a/internal/docstore/internal/fields/README.md
+++ b/internal/docstore/internal/fields/README.md
@@ -1,0 +1,1 @@
+This package is copied from cloud.google.com/go/internal/fields.

--- a/internal/docstore/internal/fields/fields.go
+++ b/internal/docstore/internal/fields/fields.go
@@ -1,0 +1,480 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fields provides a view of the fields of a struct that follows the Go
+// rules, amended to consider tags and case insensitivity.
+//
+// Usage
+//
+// First define a function that interprets tags:
+//
+//   func parseTag(st reflect.StructTag) (name string, keep bool, other interface{}, err error) { ... }
+//
+// The function's return values describe whether to ignore the field
+// completely or provide an alternate name, as well as other data from the
+// parse that is stored to avoid re-parsing.
+//
+// Then define a function to validate the type:
+//
+//   func validate(t reflect.Type) error { ... }
+//
+// Then, if necessary, define a function to specify leaf types - types
+// which should be considered one field and not be recursed into:
+//
+//   func isLeafType(t reflect.Type) bool { ... }
+//
+// eg:
+//
+//   func isLeafType(t reflect.Type) bool {
+//      return t == reflect.TypeOf(time.Time{})
+//   }
+//
+// Next, construct a Cache, passing your functions. As its name suggests, a
+// Cache remembers validation and field information for a type, so subsequent
+// calls with the same type are very fast.
+//
+//    cache := fields.NewCache(parseTag, validate, isLeafType)
+//
+// To get the fields of a struct type as determined by the above rules, call
+// the Fields method:
+//
+//    fields, err := cache.Fields(reflect.TypeOf(MyStruct{}))
+//
+// The return value can be treated as a slice of Fields.
+//
+// Given a string, such as a key or column name obtained during unmarshalling,
+// call Match on the list of fields to find a field whose name is the best
+// match:
+//
+//   field := fields.Match(name)
+//
+// Match looks for an exact match first, then falls back to a case-insensitive
+// comparison.
+package fields
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// A Field records information about a struct field.
+type Field struct {
+	Name        string       // effective field name
+	NameFromTag bool         // did Name come from a tag?
+	Type        reflect.Type // field type
+	Index       []int        // index sequence, for reflect.Value.FieldByIndex
+	ParsedTag   interface{}  // third return value of the parseTag function
+
+	nameBytes []byte
+	equalFold func(s, t []byte) bool
+}
+
+// ParseTagFunc is a function that accepts a struct tag and returns four values: an alternative name for the field
+// extracted from the tag, a boolean saying whether to keep the field or ignore  it, additional data that is stored
+// with the field information to avoid having to parse the tag again, and an error.
+type ParseTagFunc func(reflect.StructTag) (name string, keep bool, other interface{}, err error)
+
+// ValidateFunc is a function that accepts a reflect.Type and returns an error if the struct type is invalid in any
+// way.
+type ValidateFunc func(reflect.Type) error
+
+// LeafTypesFunc is a function that accepts a reflect.Type and returns true if the struct type a leaf, or false if not.
+// TODO(deklerk) is this description accurate?
+type LeafTypesFunc func(reflect.Type) bool
+
+// A Cache records information about the fields of struct types.
+//
+// A Cache is safe for use by multiple goroutines.
+type Cache struct {
+	parseTag  ParseTagFunc
+	validate  ValidateFunc
+	leafTypes LeafTypesFunc
+	cache     sync.Map // from reflect.Type to cacheValue
+}
+
+// NewCache constructs a Cache.
+//
+// Its first argument should be a function that accepts
+// a struct tag and returns four values: an alternative name for the field
+// extracted from the tag, a boolean saying whether to keep the field or ignore
+// it, additional data that is stored with the field information to avoid
+// having to parse the tag again, and an error.
+//
+// Its second argument should be a function that accepts a reflect.Type and
+// returns an error if the struct type is invalid in any way. For example, it
+// may check that all of the struct field tags are valid, or that all fields
+// are of an appropriate type.
+func NewCache(parseTag ParseTagFunc, validate ValidateFunc, leafTypes LeafTypesFunc) *Cache {
+	if parseTag == nil {
+		parseTag = func(reflect.StructTag) (string, bool, interface{}, error) {
+			return "", true, nil, nil
+		}
+	}
+	if validate == nil {
+		validate = func(reflect.Type) error {
+			return nil
+		}
+	}
+	if leafTypes == nil {
+		leafTypes = func(reflect.Type) bool {
+			return false
+		}
+	}
+
+	return &Cache{
+		parseTag:  parseTag,
+		validate:  validate,
+		leafTypes: leafTypes,
+	}
+}
+
+// A fieldScan represents an item on the fieldByNameFunc scan work list.
+type fieldScan struct {
+	typ   reflect.Type
+	index []int
+}
+
+// Fields returns all the exported fields of t, which must be a struct type. It
+// follows the standard Go rules for embedded fields, modified by the presence
+// of tags. The result is sorted lexicographically by index.
+//
+// These rules apply in the absence of tags:
+// Anonymous struct fields are treated as if their inner exported fields were
+// fields in the outer struct (embedding). The result includes all fields that
+// aren't shadowed by fields at higher level of embedding. If more than one
+// field with the same name exists at the same level of embedding, it is
+// excluded. An anonymous field that is not of struct type is treated as having
+// its type as its name.
+//
+// Tags modify these rules as follows:
+// A field's tag is used as its name.
+// An anonymous struct field with a name given in its tag is treated as
+// a field having that name, rather than an embedded struct (the struct's
+// fields will not be returned).
+// If more than one field with the same name exists at the same level of embedding,
+// but exactly one of them is tagged, then the tagged field is reported and the others
+// are ignored.
+func (c *Cache) Fields(t reflect.Type) (List, error) {
+	if t.Kind() != reflect.Struct {
+		panic("fields: Fields of non-struct type")
+	}
+	return c.cachedTypeFields(t)
+}
+
+// A List is a list of Fields.
+type List []Field
+
+// Match returns the field in the list whose name best matches the supplied
+// name, nor nil if no field does. If there is a field with the exact name, it
+// is returned. Otherwise the first field (sorted by index) whose name matches
+// case-insensitively is returned.
+func (l List) Match(name string) *Field {
+	return l.MatchBytes([]byte(name))
+}
+
+// MatchBytes is identical to Match, except that the argument is a byte slice.
+func (l List) MatchBytes(name []byte) *Field {
+	var f *Field
+	for i := range l {
+		ff := &l[i]
+		if bytes.Equal(ff.nameBytes, name) {
+			return ff
+		}
+		if f == nil && ff.equalFold(ff.nameBytes, name) {
+			f = ff
+		}
+	}
+	return f
+}
+
+type cacheValue struct {
+	fields List
+	err    error
+}
+
+// cachedTypeFields is like typeFields but uses a cache to avoid repeated work.
+// This code has been copied and modified from
+// https://go.googlesource.com/go/+/go1.7.3/src/encoding/json/encode.go.
+func (c *Cache) cachedTypeFields(t reflect.Type) (List, error) {
+	var cv cacheValue
+	x, ok := c.cache.Load(t)
+	if ok {
+		cv = x.(cacheValue)
+	} else {
+		if err := c.validate(t); err != nil {
+			cv = cacheValue{nil, err}
+		} else {
+			f, err := c.typeFields(t)
+			cv = cacheValue{List(f), err}
+		}
+		c.cache.Store(t, cv)
+	}
+	return cv.fields, cv.err
+}
+
+func (c *Cache) typeFields(t reflect.Type) ([]Field, error) {
+	fields, err := c.listFields(t)
+	if err != nil {
+		return nil, err
+	}
+	sort.Sort(byName(fields))
+	// Delete all fields that are hidden by the Go rules for embedded fields.
+
+	// The fields are sorted in primary order of name, secondary order of field
+	// index length. So the first field with a given name is the dominant one.
+	var out []Field
+	for advance, i := 0, 0; i < len(fields); i += advance {
+		// One iteration per name.
+		// Find the sequence of fields with the name of this first field.
+		fi := fields[i]
+		name := fi.Name
+		for advance = 1; i+advance < len(fields); advance++ {
+			fj := fields[i+advance]
+			if fj.Name != name {
+				break
+			}
+		}
+		// Find the dominant field, if any, out of all fields that have the same name.
+		dominant, ok := dominantField(fields[i : i+advance])
+		if ok {
+			out = append(out, dominant)
+		}
+	}
+	sort.Sort(byIndex(out))
+	return out, nil
+}
+
+func (c *Cache) listFields(t reflect.Type) ([]Field, error) {
+	// This uses the same condition that the Go language does: there must be a unique instance
+	// of the match at a given depth level. If there are multiple instances of a match at the
+	// same depth, they annihilate each other and inhibit any possible match at a lower level.
+	// The algorithm is breadth first search, one depth level at a time.
+
+	// The current and next slices are work queues:
+	// current lists the fields to visit on this depth level,
+	// and next lists the fields on the next lower level.
+	current := []fieldScan{}
+	next := []fieldScan{{typ: t}}
+
+	// nextCount records the number of times an embedded type has been
+	// encountered and considered for queueing in the 'next' slice.
+	// We only queue the first one, but we increment the count on each.
+	// If a struct type T can be reached more than once at a given depth level,
+	// then it annihilates itself and need not be considered at all when we
+	// process that next depth level.
+	var nextCount map[reflect.Type]int
+
+	// visited records the structs that have been considered already.
+	// Embedded pointer fields can create cycles in the graph of
+	// reachable embedded types; visited avoids following those cycles.
+	// It also avoids duplicated effort: if we didn't find the field in an
+	// embedded type T at level 2, we won't find it in one at level 4 either.
+	visited := map[reflect.Type]bool{}
+
+	var fields []Field // Fields found.
+
+	for len(next) > 0 {
+		current, next = next, current[:0]
+		count := nextCount
+		nextCount = nil
+
+		// Process all the fields at this depth, now listed in 'current'.
+		// The loop queues embedded fields found in 'next', for processing during the next
+		// iteration. The multiplicity of the 'current' field counts is recorded
+		// in 'count'; the multiplicity of the 'next' field counts is recorded in 'nextCount'.
+		for _, scan := range current {
+			t := scan.typ
+			if visited[t] {
+				// We've looked through this type before, at a higher level.
+				// That higher level would shadow the lower level we're now at,
+				// so this one can't be useful to us. Ignore it.
+				continue
+			}
+			visited[t] = true
+			for i := 0; i < t.NumField(); i++ {
+				f := t.Field(i)
+
+				exported := (f.PkgPath == "")
+
+				// If a named field is unexported, ignore it. An anonymous
+				// unexported field is processed, because it may contain
+				// exported fields, which are visible.
+				if !exported && !f.Anonymous {
+					continue
+				}
+
+				// Examine the tag.
+				tagName, keep, other, err := c.parseTag(f.Tag)
+				if err != nil {
+					return nil, err
+				}
+				if !keep {
+					continue
+				}
+				if c.leafTypes(f.Type) {
+					fields = append(fields, newField(f, tagName, other, scan.index, i))
+					continue
+				}
+
+				var ntyp reflect.Type
+				if f.Anonymous {
+					// Anonymous field of type T or *T.
+					ntyp = f.Type
+					if ntyp.Kind() == reflect.Ptr {
+						ntyp = ntyp.Elem()
+					}
+				}
+
+				// Record fields with a tag name, non-anonymous fields, or
+				// anonymous non-struct fields.
+				if tagName != "" || ntyp == nil || ntyp.Kind() != reflect.Struct {
+					if !exported {
+						continue
+					}
+					fields = append(fields, newField(f, tagName, other, scan.index, i))
+					if count[t] > 1 {
+						// If there were multiple instances, add a second,
+						// so that the annihilation code will see a duplicate.
+						fields = append(fields, fields[len(fields)-1])
+					}
+					continue
+				}
+
+				// Queue embedded struct fields for processing with next level,
+				// but only if the embedded types haven't already been queued.
+				if nextCount[ntyp] > 0 {
+					nextCount[ntyp] = 2 // exact multiple doesn't matter
+					continue
+				}
+				if nextCount == nil {
+					nextCount = map[reflect.Type]int{}
+				}
+				nextCount[ntyp] = 1
+				if count[t] > 1 {
+					nextCount[ntyp] = 2 // exact multiple doesn't matter
+				}
+				var index []int
+				index = append(index, scan.index...)
+				index = append(index, i)
+				next = append(next, fieldScan{ntyp, index})
+			}
+		}
+	}
+	return fields, nil
+}
+
+func newField(f reflect.StructField, tagName string, other interface{}, index []int, i int) Field {
+	name := tagName
+	if name == "" {
+		name = f.Name
+	}
+	sf := Field{
+		Name:        name,
+		NameFromTag: tagName != "",
+		Type:        f.Type,
+		ParsedTag:   other,
+		nameBytes:   []byte(name),
+	}
+	sf.equalFold = foldFunc(sf.nameBytes)
+	sf.Index = append(sf.Index, index...)
+	sf.Index = append(sf.Index, i)
+	return sf
+}
+
+// byName sorts fields using the following criteria, in order:
+// 1. name
+// 2. embedding depth
+// 3. tag presence (preferring a tagged field)
+// 4. index sequence.
+type byName []Field
+
+func (x byName) Len() int { return len(x) }
+
+func (x byName) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x byName) Less(i, j int) bool {
+	if x[i].Name != x[j].Name {
+		return x[i].Name < x[j].Name
+	}
+	if len(x[i].Index) != len(x[j].Index) {
+		return len(x[i].Index) < len(x[j].Index)
+	}
+	if x[i].NameFromTag != x[j].NameFromTag {
+		return x[i].NameFromTag
+	}
+	return byIndex(x).Less(i, j)
+}
+
+// byIndex sorts field by index sequence.
+type byIndex []Field
+
+func (x byIndex) Len() int { return len(x) }
+
+func (x byIndex) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x byIndex) Less(i, j int) bool {
+	xi := x[i].Index
+	xj := x[j].Index
+	ln := len(xi)
+	if l := len(xj); l < ln {
+		ln = l
+	}
+	for k := 0; k < ln; k++ {
+		if xi[k] != xj[k] {
+			return xi[k] < xj[k]
+		}
+	}
+	return len(xi) < len(xj)
+}
+
+// dominantField looks through the fields, all of which are known to have the
+// same name, to find the single field that dominates the others using Go's
+// embedding rules, modified by the presence of tags. If there are multiple
+// top-level fields, the boolean will be false: This condition is an error in
+// Go and we skip all the fields.
+func dominantField(fs []Field) (Field, bool) {
+	// The fields are sorted in increasing index-length order, then by presence of tag.
+	// That means that the first field is the dominant one. We need only check
+	// for error cases: two fields at top level, either both tagged or neither tagged.
+	if len(fs) > 1 && len(fs[0].Index) == len(fs[1].Index) && fs[0].NameFromTag == fs[1].NameFromTag {
+		return Field{}, false
+	}
+	return fs[0], true
+}
+
+// ParseStandardTag extracts the sub-tag named by key, then parses it using the
+// de facto standard format introduced in encoding/json:
+//   "-" means "ignore this tag". It must occur by itself. (parseStandardTag returns an error
+//       in this case, whereas encoding/json accepts the "-" even if it is not alone.)
+//   "<name>" provides an alternative name for the field
+//   "<name>,opt1,opt2,..." specifies options after the name.
+// The options are returned as a []string.
+func ParseStandardTag(key string, t reflect.StructTag) (name string, keep bool, options []string, err error) {
+	s := t.Get(key)
+	parts := strings.Split(s, ",")
+	if parts[0] == "-" {
+		if len(parts) > 1 {
+			return "", false, nil, errors.New(`"-" field tag with options`)
+		}
+		return "", false, nil, nil
+	}
+	if len(parts) > 1 {
+		options = parts[1:]
+	}
+	return parts[0], true, options, nil
+}

--- a/internal/docstore/internal/fields/fields_test.go
+++ b/internal/docstore/internal/fields/fields_test.go
@@ -1,0 +1,560 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fields
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type embed1 struct {
+	Em1    int
+	Dup    int // annihilates with embed2.Dup
+	Shadow int
+	embed3
+}
+
+type embed2 struct {
+	Dup int
+	embed3
+	embed4
+}
+
+type embed3 struct {
+	Em3 int // annihilated because embed3 is in both embed1 and embed2
+	embed5
+}
+
+type embed4 struct {
+	Em4     int
+	Dup     int // annihilation of Dup in embed1, embed2 hides this Dup
+	*embed1     // ignored because it occurs at a higher level
+}
+
+type embed5 struct {
+	x int
+}
+
+type Anonymous int
+
+type S1 struct {
+	Exported   int
+	unexported int
+	Shadow     int // shadows S1.Shadow
+	embed1
+	*embed2
+	Anonymous
+}
+
+type Time struct {
+	time.Time
+}
+
+var intType = reflect.TypeOf(int(0))
+
+func field(name string, tval interface{}, index ...int) *Field {
+	return &Field{
+		Name:      name,
+		Type:      reflect.TypeOf(tval),
+		Index:     index,
+		ParsedTag: []string(nil),
+	}
+}
+
+func tfield(name string, tval interface{}, index ...int) *Field {
+	return &Field{
+		Name:        name,
+		Type:        reflect.TypeOf(tval),
+		Index:       index,
+		NameFromTag: true,
+		ParsedTag:   []string(nil),
+	}
+}
+
+func TestFieldsNoTags(t *testing.T) {
+	c := NewCache(nil, nil, nil)
+	got, err := c.Fields(reflect.TypeOf(S1{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []*Field{
+		field("Exported", int(0), 0),
+		field("Shadow", int(0), 2),
+		field("Em1", int(0), 3, 0),
+		field("Em4", int(0), 4, 2, 0),
+		field("Anonymous", Anonymous(0), 5),
+	}
+	for _, f := range want {
+		f.ParsedTag = nil
+	}
+	if msg, ok := compareFields(got, want); !ok {
+		t.Error(msg)
+	}
+}
+
+func TestAgainstJSONEncodingNoTags(t *testing.T) {
+	// Demonstrates that this package produces the same set of fields as encoding/json.
+	s1 := S1{
+		Exported:   1,
+		unexported: 2,
+		Shadow:     3,
+		embed1: embed1{
+			Em1:    4,
+			Dup:    5,
+			Shadow: 6,
+			embed3: embed3{
+				Em3:    7,
+				embed5: embed5{x: 8},
+			},
+		},
+		embed2: &embed2{
+			Dup: 9,
+			embed3: embed3{
+				Em3:    10,
+				embed5: embed5{x: 11},
+			},
+			embed4: embed4{
+				Em4:    12,
+				Dup:    13,
+				embed1: &embed1{Em1: 14},
+			},
+		},
+		Anonymous: Anonymous(15),
+	}
+	var want S1
+	want.embed2 = &embed2{} // need this because reflection won't create it
+	jsonRoundTrip(t, s1, &want)
+	var got S1
+	got.embed2 = &embed2{}
+	fields, err := NewCache(nil, nil, nil).Fields(reflect.TypeOf(got))
+	if err != nil {
+		t.Fatal(err)
+	}
+	setFields(fields, &got, s1)
+	if !cmp.Equal(got, want,
+		cmp.AllowUnexported(S1{}, embed1{}, embed2{}, embed3{}, embed4{}, embed5{})) {
+		t.Errorf("got\n%+v\nwant\n%+v", got, want)
+	}
+}
+
+// Tests use of LeafTypes parameter to NewCache
+func TestAgainstJSONEncodingEmbeddedTime(t *testing.T) {
+	timeLeafFn := func(t reflect.Type) bool {
+		return t == reflect.TypeOf(time.Time{})
+	}
+	// Demonstrates that this package can produce the same set of
+	// fields as encoding/json for a struct with an embedded time.Time.
+	now := time.Now().UTC()
+	myt := Time{
+		now,
+	}
+	var want Time
+	jsonRoundTrip(t, myt, &want)
+	var got Time
+	fields, err := NewCache(nil, nil, timeLeafFn).Fields(reflect.TypeOf(got))
+	if err != nil {
+		t.Fatal(err)
+	}
+	setFields(fields, &got, myt)
+	if !cmp.Equal(got, want) {
+		t.Errorf("got\n%+v\nwant\n%+v", got, want)
+	}
+}
+
+type S2 struct {
+	NoTag      int
+	XXX        int           `json:"tag"` // tag name takes precedence
+	Anonymous  `json:"anon"` // anonymous non-structs also get their name from the tag
+	unexported int           `json:"tag"`
+	Embed      `json:"em"`   // embedded structs with tags become fields
+	Tag        int
+	YYY        int `json:"Tag"` // tag takes precedence over untagged field of the same name
+	Empty      int `json:""`    // empty tag is noop
+	tEmbed1
+	tEmbed2
+}
+
+type Embed struct {
+	Em int
+}
+
+type tEmbed1 struct {
+	Dup int
+	X   int `json:"Dup2"`
+}
+
+type tEmbed2 struct {
+	Y int `json:"Dup"`  // takes precedence over tEmbed1.Dup because it is tagged
+	Z int `json:"Dup2"` // same name as tEmbed1.X and both tagged, so ignored
+}
+
+func jsonTagParser(t reflect.StructTag) (name string, keep bool, other interface{}, err error) {
+	return ParseStandardTag("json", t)
+}
+
+func validateFunc(t reflect.Type) (err error) {
+	if t.Kind() != reflect.Struct {
+		return errors.New("non-struct type used")
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		if t.Field(i).Type.Kind() == reflect.Slice {
+			return fmt.Errorf("slice field found at field %s on struct %s", t.Field(i).Name, t.Name())
+		}
+	}
+
+	return nil
+}
+
+func TestFieldsWithTags(t *testing.T) {
+	got, err := NewCache(jsonTagParser, nil, nil).Fields(reflect.TypeOf(S2{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []*Field{
+		field("NoTag", int(0), 0),
+		tfield("tag", int(0), 1),
+		tfield("anon", Anonymous(0), 2),
+		tfield("em", Embed{}, 4),
+		tfield("Tag", int(0), 6),
+		field("Empty", int(0), 7),
+		tfield("Dup", int(0), 8, 0),
+	}
+	if msg, ok := compareFields(got, want); !ok {
+		t.Error(msg)
+	}
+}
+
+func TestAgainstJSONEncodingWithTags(t *testing.T) {
+	// Demonstrates that this package produces the same set of fields as encoding/json.
+	s2 := S2{
+		NoTag:     1,
+		XXX:       2,
+		Anonymous: 3,
+		Embed: Embed{
+			Em: 4,
+		},
+		tEmbed1: tEmbed1{
+			Dup: 5,
+			X:   6,
+		},
+		tEmbed2: tEmbed2{
+			Y: 7,
+			Z: 8,
+		},
+	}
+	var want S2
+	jsonRoundTrip(t, s2, &want)
+	var got S2
+	fields, err := NewCache(jsonTagParser, nil, nil).Fields(reflect.TypeOf(got))
+	if err != nil {
+		t.Fatal(err)
+	}
+	setFields(fields, &got, s2)
+	if !cmp.Equal(got, want, cmp.AllowUnexported(S2{})) {
+		t.Errorf("got\n%+v\nwant\n%+v", got, want)
+	}
+}
+
+func TestUnexportedAnonymousNonStruct(t *testing.T) {
+	// An unexported anonymous non-struct field should not be recorded.
+	// This is currently a bug in encoding/json.
+	// https://github.com/golang/go/issues/18009
+	type (
+		u int
+		v int
+		S struct {
+			u
+			v `json:"x"`
+			int
+		}
+	)
+
+	got, err := NewCache(jsonTagParser, nil, nil).Fields(reflect.TypeOf(S{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d fields, want 0", len(got))
+	}
+}
+
+func TestUnexportedAnonymousStruct(t *testing.T) {
+	// An unexported anonymous struct with a tag is ignored.
+	// This is currently a bug in encoding/json.
+	// https://github.com/golang/go/issues/18009
+	type (
+		s1 struct{ X int }
+		S2 struct {
+			s1 `json:"Y"`
+		}
+	)
+	got, err := NewCache(jsonTagParser, nil, nil).Fields(reflect.TypeOf(S2{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d fields, want 0", len(got))
+	}
+}
+
+func TestDominantField(t *testing.T) {
+	// With fields sorted by index length and then by tag presence,
+	// the dominant field is always the first. Make sure all error
+	// cases are caught.
+	for _, test := range []struct {
+		fields []Field
+		wantOK bool
+	}{
+		// A single field is OK.
+		{[]Field{{Index: []int{0}}}, true},
+		{[]Field{{Index: []int{0}, NameFromTag: true}}, true},
+		// A single field at top level is OK.
+		{[]Field{{Index: []int{0}}, {Index: []int{1, 0}}}, true},
+		{[]Field{{Index: []int{0}}, {Index: []int{1, 0}, NameFromTag: true}}, true},
+		{[]Field{{Index: []int{0}, NameFromTag: true}, {Index: []int{1, 0}, NameFromTag: true}}, true},
+		// A single tagged field is OK.
+		{[]Field{{Index: []int{0}, NameFromTag: true}, {Index: []int{1}}}, true},
+		// Two untagged fields at the same level is an error.
+		{[]Field{{Index: []int{0}}, {Index: []int{1}}}, false},
+		// Two tagged fields at the same level is an error.
+		{[]Field{{Index: []int{0}, NameFromTag: true}, {Index: []int{1}, NameFromTag: true}}, false},
+	} {
+		_, gotOK := dominantField(test.fields)
+		if gotOK != test.wantOK {
+			t.Errorf("%v: got %t, want %t", test.fields, gotOK, test.wantOK)
+		}
+	}
+}
+
+func TestIgnore(t *testing.T) {
+	type S struct {
+		X int `json:"-"`
+	}
+	got, err := NewCache(jsonTagParser, nil, nil).Fields(reflect.TypeOf(S{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d fields, want 0", len(got))
+	}
+}
+
+func TestParsedTag(t *testing.T) {
+	type S struct {
+		X int `json:"name,omitempty"`
+	}
+	got, err := NewCache(jsonTagParser, nil, nil).Fields(reflect.TypeOf(S{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []*Field{
+		{Name: "name", NameFromTag: true, Type: intType,
+			Index: []int{0}, ParsedTag: []string{"omitempty"}},
+	}
+	if msg, ok := compareFields(got, want); !ok {
+		t.Error(msg)
+	}
+}
+
+func TestValidateFunc(t *testing.T) {
+	type MyInvalidStruct struct {
+		A string
+		B []int
+	}
+
+	_, err := NewCache(nil, validateFunc, nil).Fields(reflect.TypeOf(MyInvalidStruct{}))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	type MyValidStruct struct {
+		A string
+		B int
+	}
+	_, err = NewCache(nil, validateFunc, nil).Fields(reflect.TypeOf(MyValidStruct{}))
+	if err != nil {
+		t.Fatalf("expected nil, got error: %s\n", err)
+	}
+}
+
+func compareFields(got []Field, want []*Field) (msg string, ok bool) {
+	if len(got) != len(want) {
+		return fmt.Sprintf("got %d fields, want %d", len(got), len(want)), false
+	}
+	for i, g := range got {
+		w := *want[i]
+		if !fieldsEqual(&g, &w) {
+			return fmt.Sprintf("got\n%+v\nwant\n%+v", g, w), false
+		}
+	}
+	return "", true
+}
+
+// Need this because Field contains a function, which cannot be compared.
+func fieldsEqual(f1, f2 *Field) bool {
+	if f1 == nil || f2 == nil {
+		return f1 == f2
+	}
+	return f1.Name == f2.Name &&
+		f1.NameFromTag == f2.NameFromTag &&
+		f1.Type == f2.Type &&
+		cmp.Equal(f1.ParsedTag, f2.ParsedTag)
+}
+
+// Set the fields of dst from those of src.
+// dst must be a pointer to a struct value.
+// src must be a struct value.
+func setFields(fields []Field, dst, src interface{}) {
+	vsrc := reflect.ValueOf(src)
+	vdst := reflect.ValueOf(dst).Elem()
+	for _, f := range fields {
+		fdst := vdst.FieldByIndex(f.Index)
+		fsrc := vsrc.FieldByIndex(f.Index)
+		fdst.Set(fsrc)
+	}
+}
+
+func jsonRoundTrip(t *testing.T, in, out interface{}) {
+	bytes, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(bytes, out); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type S3 struct {
+	S4
+	Abc        int
+	AbC        int
+	Tag        int
+	X          int `json:"Tag"`
+	unexported int
+}
+
+type S4 struct {
+	ABc int
+	Y   int `json:"Abc"` // ignored because of top-level Abc
+}
+
+func TestMatchingField(t *testing.T) {
+	fields, err := NewCache(jsonTagParser, nil, nil).Fields(reflect.TypeOf(S3{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name string
+		want *Field
+	}{
+		// Exact match wins.
+		{"Abc", field("Abc", int(0), 1)},
+		{"AbC", field("AbC", int(0), 2)},
+		{"ABc", field("ABc", int(0), 0, 0)},
+		// If there are multiple matches but no exact match or tag,
+		// the first field wins, lexicographically by index.
+		// Here, "ABc" is at a deeper embedding level, but since S4 appears
+		// first in S3, its index precedes the other fields of S3.
+		{"abc", field("ABc", int(0), 0, 0)},
+		// Tag name takes precedence over untagged field of the same name.
+		{"Tag", tfield("Tag", int(0), 4)},
+		// Unexported fields disappear.
+		{"unexported", nil},
+		// Untagged embedded structs disappear.
+		{"S4", nil},
+	} {
+		if got := fields.Match(test.name); !fieldsEqual(got, test.want) {
+			t.Errorf("match %q:\ngot  %+v\nwant %+v", test.name, got, test.want)
+		}
+	}
+}
+
+func TestAgainstJSONMatchingField(t *testing.T) {
+	s3 := S3{
+		S4:         S4{ABc: 1, Y: 2},
+		Abc:        3,
+		AbC:        4,
+		Tag:        5,
+		X:          6,
+		unexported: 7,
+	}
+	var want S3
+	jsonRoundTrip(t, s3, &want)
+	v := reflect.ValueOf(want)
+	fields, err := NewCache(jsonTagParser, nil, nil).Fields(reflect.TypeOf(S3{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name string
+		got  int
+	}{
+		{"Abc", 3},
+		{"AbC", 4},
+		{"ABc", 1},
+		{"abc", 1},
+		{"Tag", 6},
+	} {
+		f := fields.Match(test.name)
+		if f == nil {
+			t.Fatalf("%s: no match", test.name)
+		}
+		w := v.FieldByIndex(f.Index).Interface()
+		if test.got != w {
+			t.Errorf("%s: got %d, want %d", test.name, test.got, w)
+		}
+	}
+}
+
+func TestTagErrors(t *testing.T) {
+	called := false
+	c := NewCache(func(t reflect.StructTag) (string, bool, interface{}, error) {
+		called = true
+		s := t.Get("f")
+		if s == "bad" {
+			return "", false, nil, errors.New("error")
+		}
+		return s, true, nil, nil
+	}, nil, nil)
+
+	type T struct {
+		X int `f:"ok"`
+		Y int `f:"bad"`
+	}
+
+	_, err := c.Fields(reflect.TypeOf(T{}))
+	if !called {
+		t.Fatal("tag parser not called")
+	}
+	if err == nil {
+		t.Error("want error, got nil")
+	}
+	// Second time, we should cache the error.
+	called = false
+	_, err = c.Fields(reflect.TypeOf(T{}))
+	if called {
+		t.Fatal("tag parser called on second time")
+	}
+	if err == nil {
+		t.Error("want error, got nil")
+	}
+}

--- a/internal/docstore/internal/fields/fold.go
+++ b/internal/docstore/internal/fields/fold.go
@@ -1,0 +1,156 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fields
+
+// This file was copied from https://go.googlesource.com/go/+/go1.7.3/src/encoding/json/fold.go.
+// Only the license and package were changed.
+
+import (
+	"bytes"
+	"unicode/utf8"
+)
+
+const (
+	caseMask     = ^byte(0x20) // Mask to ignore case in ASCII.
+	kelvin       = '\u212a'
+	smallLongEss = '\u017f'
+)
+
+// foldFunc returns one of four different case folding equivalence
+// functions, from most general (and slow) to fastest:
+//
+// 1) bytes.EqualFold, if the key s contains any non-ASCII UTF-8
+// 2) equalFoldRight, if s contains special folding ASCII ('k', 'K', 's', 'S')
+// 3) asciiEqualFold, no special, but includes non-letters (including _)
+// 4) simpleLetterEqualFold, no specials, no non-letters.
+//
+// The letters S and K are special because they map to 3 runes, not just 2:
+//  * S maps to s and to U+017F 'ſ' Latin small letter long s
+//  * k maps to K and to U+212A 'K' Kelvin sign
+// See https://play.golang.org/p/tTxjOc0OGo
+//
+// The returned function is specialized for matching against s and
+// should only be given s. It's not curried for performance reasons.
+func foldFunc(s []byte) func(s, t []byte) bool {
+	nonLetter := false
+	special := false // special letter
+	for _, b := range s {
+		if b >= utf8.RuneSelf {
+			return bytes.EqualFold
+		}
+		upper := b & caseMask
+		if upper < 'A' || upper > 'Z' {
+			nonLetter = true
+		} else if upper == 'K' || upper == 'S' {
+			// See above for why these letters are special.
+			special = true
+		}
+	}
+	if special {
+		return equalFoldRight
+	}
+	if nonLetter {
+		return asciiEqualFold
+	}
+	return simpleLetterEqualFold
+}
+
+// equalFoldRight is a specialization of bytes.EqualFold when s is
+// known to be all ASCII (including punctuation), but contains an 's',
+// 'S', 'k', or 'K', requiring a Unicode fold on the bytes in t.
+// See comments on foldFunc.
+func equalFoldRight(s, t []byte) bool {
+	for _, sb := range s {
+		if len(t) == 0 {
+			return false
+		}
+		tb := t[0]
+		if tb < utf8.RuneSelf {
+			if sb != tb {
+				sbUpper := sb & caseMask
+				if 'A' <= sbUpper && sbUpper <= 'Z' {
+					if sbUpper != tb&caseMask {
+						return false
+					}
+				} else {
+					return false
+				}
+			}
+			t = t[1:]
+			continue
+		}
+		// sb is ASCII and t is not. t must be either kelvin
+		// sign or long s; sb must be s, S, k, or K.
+		tr, size := utf8.DecodeRune(t)
+		switch sb {
+		case 's', 'S':
+			if tr != smallLongEss {
+				return false
+			}
+		case 'k', 'K':
+			if tr != kelvin {
+				return false
+			}
+		default:
+			return false
+		}
+		t = t[size:]
+
+	}
+	if len(t) > 0 {
+		return false
+	}
+	return true
+}
+
+// asciiEqualFold is a specialization of bytes.EqualFold for use when
+// s is all ASCII (but may contain non-letters) and contains no
+// special-folding letters.
+// See comments on foldFunc.
+func asciiEqualFold(s, t []byte) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i, sb := range s {
+		tb := t[i]
+		if sb == tb {
+			continue
+		}
+		if ('a' <= sb && sb <= 'z') || ('A' <= sb && sb <= 'Z') {
+			if sb&caseMask != tb&caseMask {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+// simpleLetterEqualFold is a specialization of bytes.EqualFold for
+// use when s is all ASCII letters (no underscores, etc) and also
+// doesn't contain 'k', 'K', 's', or 'S'.
+// See comments on foldFunc.
+func simpleLetterEqualFold(s, t []byte) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i, b := range s {
+		if b&caseMask != t[i]&caseMask {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/docstore/internal/fields/fold_test.go
+++ b/internal/docstore/internal/fields/fold_test.go
@@ -1,0 +1,129 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fields
+
+// This file was copied from https://go.googlesource.com/go/+/go1.7.3/src/encoding/json/fold_test.go.
+// Only the license and package were changed.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+var foldTests = []struct {
+	fn   func(s, t []byte) bool
+	s, t string
+	want bool
+}{
+	{equalFoldRight, "", "", true},
+	{equalFoldRight, "a", "a", true},
+	{equalFoldRight, "", "a", false},
+	{equalFoldRight, "a", "", false},
+	{equalFoldRight, "a", "A", true},
+	{equalFoldRight, "AB", "ab", true},
+	{equalFoldRight, "AB", "ac", false},
+	{equalFoldRight, "sbkKc", "ſbKKc", true},
+	{equalFoldRight, "SbKkc", "ſbKKc", true},
+	{equalFoldRight, "SbKkc", "ſbKK", false},
+	{equalFoldRight, "e", "é", false},
+	{equalFoldRight, "s", "S", true},
+
+	{simpleLetterEqualFold, "", "", true},
+	{simpleLetterEqualFold, "abc", "abc", true},
+	{simpleLetterEqualFold, "abc", "ABC", true},
+	{simpleLetterEqualFold, "abc", "ABCD", false},
+	{simpleLetterEqualFold, "abc", "xxx", false},
+
+	{asciiEqualFold, "a_B", "A_b", true},
+	{asciiEqualFold, "aa@", "aa`", false}, // verify 0x40 and 0x60 aren't case-equivalent
+}
+
+func TestFold(t *testing.T) {
+	for i, tt := range foldTests {
+		if got := tt.fn([]byte(tt.s), []byte(tt.t)); got != tt.want {
+			t.Errorf("%d. %q, %q = %v; want %v", i, tt.s, tt.t, got, tt.want)
+		}
+		truth := strings.EqualFold(tt.s, tt.t)
+		if truth != tt.want {
+			t.Errorf("strings.EqualFold doesn't agree with case %d", i)
+		}
+	}
+}
+
+func TestFoldAgainstUnicode(t *testing.T) {
+	const bufSize = 5
+	buf1 := make([]byte, 0, bufSize)
+	buf2 := make([]byte, 0, bufSize)
+	var runes []rune
+	for i := 0x20; i <= 0x7f; i++ {
+		runes = append(runes, rune(i))
+	}
+	runes = append(runes, kelvin, smallLongEss)
+
+	funcs := []struct {
+		name   string
+		fold   func(s, t []byte) bool
+		letter bool // must be ASCII letter
+		simple bool // must be simple ASCII letter (not 'S' or 'K')
+	}{
+		{
+			name: "equalFoldRight",
+			fold: equalFoldRight,
+		},
+		{
+			name:   "asciiEqualFold",
+			fold:   asciiEqualFold,
+			simple: true,
+		},
+		{
+			name:   "simpleLetterEqualFold",
+			fold:   simpleLetterEqualFold,
+			simple: true,
+			letter: true,
+		},
+	}
+
+	for _, ff := range funcs {
+		for _, r := range runes {
+			if r >= utf8.RuneSelf {
+				continue
+			}
+			if ff.letter && !isASCIILetter(byte(r)) {
+				continue
+			}
+			if ff.simple && (r == 's' || r == 'S' || r == 'k' || r == 'K') {
+				continue
+			}
+			for _, r2 := range runes {
+				buf1 := append(buf1[:0], 'x')
+				buf2 := append(buf2[:0], 'x')
+				buf1 = buf1[:1+utf8.EncodeRune(buf1[1:bufSize], r)]
+				buf2 = buf2[:1+utf8.EncodeRune(buf2[1:bufSize], r2)]
+				buf1 = append(buf1, 'x')
+				buf2 = append(buf2, 'x')
+				want := bytes.EqualFold(buf1, buf2)
+				if got := ff.fold(buf1, buf2); got != want {
+					t.Errorf("%s(%q, %q) = %v; want %v", ff.name, buf1, buf2, got, want)
+				}
+			}
+		}
+	}
+}
+
+func isASCIILetter(b byte) bool {
+	return ('A' <= b && b <= 'Z') || ('a' <= b && b <= 'z')
+}

--- a/internal/docstore/memdocstore/codec.go
+++ b/internal/docstore/memdocstore/codec.go
@@ -34,7 +34,7 @@ type encoder struct {
 	val interface{}
 }
 
-func (e *encoder) EncodeNull()                                { e.val = nil }
+func (e *encoder) EncodeNil()                                 { e.val = nil }
 func (e *encoder) EncodeBool(x bool)                          { e.val = x }
 func (e *encoder) EncodeInt(x int64)                          { e.val = x }
 func (e *encoder) EncodeUint(x uint64)                        { e.val = int64(x) }

--- a/internal/docstore/memdocstore/codec.go
+++ b/internal/docstore/memdocstore/codec.go
@@ -1,0 +1,162 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memdocstore
+
+import (
+	"fmt"
+	"reflect"
+
+	"gocloud.dev/internal/docstore/driver"
+)
+
+// encodeDoc encodes a driver.Document as a map[string]interface{}.
+func encodeDoc(doc driver.Document) (map[string]interface{}, error) {
+	var e encoder
+	if err := doc.Encode(&e); err != nil {
+		return nil, err
+	}
+	return e.val.(map[string]interface{}), nil
+}
+
+type encoder struct {
+	val interface{}
+}
+
+func (e *encoder) EncodeNull()                                { e.val = nil }
+func (e *encoder) EncodeBool(x bool)                          { e.val = x }
+func (e *encoder) EncodeInt(x int64)                          { e.val = x }
+func (e *encoder) EncodeUint(x uint64)                        { e.val = int64(x) }
+func (e *encoder) EncodeBytes(x []byte)                       { e.val = x }
+func (e *encoder) EncodeFloat(x float64)                      { e.val = x }
+func (e *encoder) EncodeComplex(x complex128)                 { e.val = x }
+func (e *encoder) EncodeString(x string)                      { e.val = x }
+func (e *encoder) ListIndex(int)                              { panic("impossible") }
+func (e *encoder) MapKey(string)                              { panic("impossible") }
+func (e *encoder) EncodeStruct(s reflect.Value) (bool, error) { return false, nil } // no special struct handling
+
+func (e *encoder) EncodeList(n int) driver.Encoder {
+	// All slices and arrays are encoded as []interface{}
+	s := make([]interface{}, n)
+	e.val = s
+	return &listEncoder{s: s}
+}
+
+type listEncoder struct {
+	s []interface{}
+	encoder
+}
+
+func (e *listEncoder) ListIndex(i int) { e.s[i] = e.val }
+
+type mapEncoder struct {
+	m map[string]interface{}
+	encoder
+}
+
+func (e *encoder) EncodeMap(n int) driver.Encoder {
+	m := make(map[string]interface{}, n)
+	e.val = m
+	return &mapEncoder{m: m}
+}
+
+func (e *mapEncoder) MapKey(k string) { e.m[k] = e.val }
+
+////////////////////////////////////////////////////////////////
+
+// decodeDoc decodes m into ddoc.
+func decodeDoc(ddoc driver.Document, m map[string]interface{}) error {
+	return ddoc.Decode(decoder{m})
+}
+
+type decoder struct {
+	val interface{}
+}
+
+func (d decoder) String() string {
+	return fmt.Sprint(d.val)
+}
+
+func (d decoder) AsNull() bool {
+	return d.val == nil
+}
+
+func (d decoder) AsBool() (bool, bool) {
+	b, ok := d.val.(bool)
+	return b, ok
+}
+
+func (d decoder) AsString() (string, bool) {
+	s, ok := d.val.(string)
+	return s, ok
+}
+
+func (d decoder) AsInt() (int64, bool) {
+	i, ok := d.val.(int64)
+	return i, ok
+}
+
+func (d decoder) AsUint() (uint64, bool) {
+	i, ok := d.val.(int64)
+	return uint64(i), ok
+}
+
+func (d decoder) AsFloat() (float64, bool) {
+	f, ok := d.val.(float64)
+	return f, ok
+}
+
+func (d decoder) AsComplex() (complex128, bool) {
+	c, ok := d.val.(complex128)
+	return c, ok
+}
+
+func (d decoder) AsBytes() ([]byte, bool) {
+	bs, ok := d.val.([]byte)
+	return bs, ok
+}
+
+func (d decoder) AsInterface() (interface{}, error) {
+	return d.val, nil
+}
+
+func (d decoder) ListLen() (int, bool) {
+	if s, ok := d.val.([]interface{}); ok {
+		return len(s), true
+	}
+	return 0, false
+}
+
+func (d decoder) DecodeList(f func(i int, d2 driver.Decoder) bool) {
+	for i, e := range d.val.([]interface{}) {
+		if !f(i, decoder{e}) {
+			return
+		}
+	}
+}
+
+func (d decoder) MapLen() (int, bool) {
+	if m, ok := d.val.(map[string]interface{}); ok {
+		return len(m), true
+	}
+	return 0, false
+}
+
+func (d decoder) DecodeMap(f func(key string, d2 driver.Decoder) bool) {
+	for k, v := range d.val.(map[string]interface{}) {
+		if !f(k, decoder{v}) {
+			return
+		}
+	}
+}

--- a/internal/docstore/memdocstore/codec_test.go
+++ b/internal/docstore/memdocstore/codec_test.go
@@ -39,7 +39,7 @@ func TestEncodeDoc(t *testing.T) {
 		want map[string]interface{}
 	}{
 		{
-			map[string]interface{}{
+			in: map[string]interface{}{
 				"x": map[int]interface{}{
 					1: "a",
 					2: 17,
@@ -47,7 +47,7 @@ func TestEncodeDoc(t *testing.T) {
 					4: map[string]bool{"false": false, "true": true},
 				},
 			},
-			map[string]interface{}{
+			want: map[string]interface{}{
 				"x": map[string]interface{}{
 					"1": "a",
 					"2": int64(17),
@@ -57,13 +57,13 @@ func TestEncodeDoc(t *testing.T) {
 			},
 		},
 		{
-			&aStruct{
+			in: &aStruct{
 				X:     3,
 				embed: embed{Y: "y"},
 				Z:     &b,
 				W:     33,
 			},
-			map[string]interface{}{
+			want: map[string]interface{}{
 				"X": int64(3),
 				"Y": "y",
 				"Z": true,

--- a/internal/docstore/memdocstore/codec_test.go
+++ b/internal/docstore/memdocstore/codec_test.go
@@ -1,0 +1,142 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memdocstore
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gocloud.dev/internal/docstore/driver"
+)
+
+type aStruct struct {
+	X int
+	embed
+	Z *bool
+	W uint
+}
+
+type embed struct {
+	Y string
+}
+
+func TestEncodeDoc(t *testing.T) {
+	var b bool = true
+	for _, test := range []struct {
+		in   interface{}
+		want map[string]interface{}
+	}{
+		{
+			map[string]interface{}{
+				"x": map[int]interface{}{
+					1: "a",
+					2: 17,
+					3: []float32{1.0, 2.5},
+					4: map[string]bool{"false": false, "true": true},
+				},
+			},
+			map[string]interface{}{
+				"x": map[string]interface{}{
+					"1": "a",
+					"2": int64(17),
+					"3": []interface{}{float64(1.0), float64(2.5)},
+					"4": map[string]interface{}{"false": false, "true": true},
+				},
+			},
+		},
+		{
+			&aStruct{
+				X:     3,
+				embed: embed{Y: "y"},
+				Z:     &b,
+				W:     33,
+			},
+			map[string]interface{}{
+				"X": int64(3),
+				"Y": "y",
+				"Z": true,
+				"W": int64(33),
+			},
+		},
+	} {
+		doc, err := driver.NewDocument(test.in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := encodeDoc(doc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(got, test.want); diff != "" {
+			t.Errorf("%+v: %s", test.in, diff)
+		}
+	}
+}
+
+func TestDecodeDoc(t *testing.T) {
+	var b bool = true
+	for _, test := range []struct {
+		in   map[string]interface{}
+		val  interface{}
+		want interface{}
+	}{
+		{
+			map[string]interface{}{
+				"x": map[string]interface{}{
+					"1": "a",
+					"2": int64(17),
+					"3": []interface{}{float64(1.0), float64(2.5)},
+					"4": map[string]interface{}{"false": false, "true": true},
+				},
+			},
+			map[string]interface{}{},
+			map[string]interface{}{
+				"x": map[string]interface{}{
+					"1": "a",
+					"2": int64(17),
+					"3": []interface{}{1.0, 2.5},
+					"4": map[string]interface{}{"false": false, "true": true},
+				},
+			},
+		},
+		{
+			map[string]interface{}{
+				"X": int64(3),
+				"Y": "y",
+				"Z": true,
+				"W": int64(33),
+			},
+			&aStruct{},
+			&aStruct{
+				X:     3,
+				embed: embed{Y: "y"},
+				Z:     &b,
+				W:     33,
+			},
+		},
+	} {
+		got := test.val
+		doc, err := driver.NewDocument(test.val)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := decodeDoc(doc, test.in); err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(got, test.want, cmp.AllowUnexported(aStruct{})); diff != "" {
+			t.Errorf("%+v: %s", test.in, diff)
+		}
+	}
+}

--- a/internal/docstore/memdocstore/mem.go
+++ b/internal/docstore/memdocstore/mem.go
@@ -122,7 +122,8 @@ func (c *collection) runAction(a *driver.Action) error {
 	case driver.Get:
 		// We've already retrieved the document into current, above.
 		// Now we copy its fields into the user-provided document.
-		if err := copyFields(a.Doc, current, a.FieldPaths); err != nil {
+		// TODO(jba): support field paths.
+		if err := decodeDoc(a.Doc, current); err != nil {
 			return err
 		}
 	default:
@@ -156,34 +157,6 @@ func deleteAtFieldPath(m map[string]interface{}, fp []string) {
 		deleteAtFieldPath(m2, fp[1:])
 	}
 	// Otherwise do nothing.
-}
-
-// Copy the fields of src to dest.
-func copyFields(dest driver.Document, src map[string]interface{}, fps [][]string) error {
-	if fps == nil {
-		// If no field paths were provided, copy all the fields.
-		for k, v := range src {
-			// TODO(jba): copy v to avoid as much structure-sharing as possible.
-			if err := dest.SetField(k, v); err != nil {
-				return err
-			}
-		}
-	} else {
-		dsrc, err := driver.NewDocument(src)
-		if err != nil {
-			return err
-		}
-		for _, fp := range fps {
-			val, err := dsrc.Get(fp)
-			if err != nil {
-				return err
-			}
-			if err := dest.Set(fp, val); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 // ErrorCode implements driver.ErrorCOde.


### PR DESCRIPTION
Support for structs:
- Getting and setting struct fields (in driver/document.go)
- Encoding an decoding values (including structs) into native representations.

Add struct support to memdocstore.