### PR TITLE
internal/gcerr: make Error() behave like %s

### DIFF
--- a/internal/gcerr/gcerr.go
+++ b/internal/gcerr/gcerr.go
@@ -91,10 +91,7 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	if e.msg == "" {
-		return fmt.Sprintf("code=%v", e.Code)
-	}
-	return fmt.Sprintf("%s (code=%v)", e.msg, e.Code)
+	return fmt.Sprint(e)
 }
 
 func (e *Error) Format(s fmt.State, c rune) {
@@ -102,7 +99,11 @@ func (e *Error) Format(s fmt.State, c rune) {
 }
 
 func (e *Error) FormatError(p xerrors.Printer) (next error) {
-	p.Print(e.Error())
+	if e.msg == "" {
+		p.Printf("code=%v", e.Code)
+	} else {
+		p.Printf("%s (code=%v)", e.msg, e.Code)
+	}
 	e.frame.Format(p)
 	return e.err
 }

--- a/internal/gcerr/gcerr_test.go
+++ b/internal/gcerr/gcerr_test.go
@@ -102,3 +102,18 @@ func TestFormatting(t *testing.T) {
 		})
 	}
 }
+
+func TestError(t *testing.T) {
+	// Check that err.Error() == fmt.Sprintf("%s", err)
+	for _, err := range []*Error{
+		New(NotFound, nil, 1, "message"),
+		New(AlreadyExists, errors.New("wrapped"), 1, "message"),
+		New(AlreadyExists, errors.New("wrapped"), 1, ""),
+	} {
+		got := err.Error()
+		want := fmt.Sprint(err)
+		if got != want {
+			t.Errorf("%v: got %q, want %q", err, got, want)
+		}
+	}
+}


### PR DESCRIPTION
(*Error).Error() now produces the same output as fmt.Sprintf("%s", ...).

Fixes #1356.