### PR TITLE
travis: add codecov.yml with threshold=0

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 0
+        threshold: null
+        base: auto


### PR DESCRIPTION
I think this should prevent `codecov` from blocking commits like it is in #1355 (because of the target=0).

Updates #1352.