### PR TITLE
blob: add As example

### DIFF
--- a/blob/example_test.go
+++ b/blob/example_test.go
@@ -288,8 +288,7 @@ func ExampleBucket_As() {
 		log.Fatal(err)
 	}
 
-	// Bucket exposes the internal storage.Client type through the As method. Use
-	// it to access a non-portable method of storage.Client.
+	// Access storage.Client fields via gcsClient here.
 	var gcsClient *storage.Client
 	if b.As(&gcsClient) {
 		email, err := gcsClient.ServiceAccount(ctx, "project-name")
@@ -298,7 +297,7 @@ func ExampleBucket_As() {
 		}
 		_ = email
 	} else {
-		log.Fatal("Unable to access storage.Client through Bucket.As")
+		log.Println("Unable to access storage.Client through Bucket.As")
 	}
 }
 

--- a/blob/gcsblob/example_test.go
+++ b/blob/gcsblob/example_test.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"log"
 
+	"cloud.google.com/go/storage"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/gcsblob"
 	"gocloud.dev/gcp"
 )
 
-func Example() {
+func Example_read() {
 	// Your GCP credentials.
 	// See https://cloud.google.com/docs/authentication/production
 	// for more info on alternatives.
@@ -63,4 +64,28 @@ func Example_open() {
 	b, err := blob.OpenBucket(ctx, "gs://my-bucket")
 	_ = b
 	_ = err
+}
+
+func Example_As() {
+	ctx := context.Background()
+
+	// Open creates a *blob.Bucket from a URL.
+	// This URL will open the bucket "my-bucket" using default credentials.
+	b, err := blob.OpenBucket(ctx, "gs://my-bucket")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Bucket exposes the internal storage.Client type through the As method. Use
+	// it to access a non-portable method of storage.Client.
+	var gcsClient *storage.Client
+	if b.As(&gcsClient) {
+		email, err := gcsClient.ServiceAccount(ctx, "project-name")
+		if err != nil {
+			log.Fatal(err)
+		}
+		_ = email
+	} else {
+		log.Fatal("Unable to access storage.Client through Bucket.As")
+	}
 }

--- a/blob/gcsblob/example_test.go
+++ b/blob/gcsblob/example_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"log"
 
-	"cloud.google.com/go/storage"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/gcsblob"
 	"gocloud.dev/gcp"
@@ -64,28 +63,4 @@ func Example_open() {
 	b, err := blob.OpenBucket(ctx, "gs://my-bucket")
 	_ = b
 	_ = err
-}
-
-func Example_As() {
-	ctx := context.Background()
-
-	// Open creates a *blob.Bucket from a URL.
-	// This URL will open the bucket "my-bucket" using default credentials.
-	b, err := blob.OpenBucket(ctx, "gs://my-bucket")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Bucket exposes the internal storage.Client type through the As method. Use
-	// it to access a non-portable method of storage.Client.
-	var gcsClient *storage.Client
-	if b.As(&gcsClient) {
-		email, err := gcsClient.ServiceAccount(ctx, "project-name")
-		if err != nil {
-			log.Fatal(err)
-		}
-		_ = email
-	} else {
-		log.Fatal("Unable to access storage.Client through Bucket.As")
-	}
 }

--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -84,8 +84,8 @@ type Snapshot struct {
 // provider-specific, and using them will make that part of your application
 // non-portable, so use with care.
 //
-// See the documentation for the subpackage used to instantiate Snapshot to see
-// which type(s) are supported.
+// See the documentation for the subpackage you used to instantiate Variable to
+// see which type(s) are supported.
 //
 // Usage:
 //

--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -84,7 +84,7 @@ type Snapshot struct {
 // provider-specific, and using them will make that part of your application
 // non-portable, so use with care.
 //
-// See the documentation for the subpackage used to instantiate Variable to see
+// See the documentation for the subpackage used to instantiate Snapshot to see
 // which type(s) are supported.
 //
 // Usage:

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -121,7 +121,7 @@ func (k *Keeper) Decrypt(ctx context.Context, ciphertext []byte) (plaintext []by
 }
 
 // ErrorAs converts i to provider-specific error types when you want to directly
-// handle the raw error types returned by the provider. This means that your
+// handle the raw error types returned by the provider. This means that you
 // will write some provider-specific code to handle the error, so use with care.
 //
 // See the documentation for the subpackage used to instantiate Keeper to see


### PR DESCRIPTION
Adding an example of As where the As call actually succeeds (the fileblog example in the main blob package shows how it can fail). Also renaming to make examples appear in the right places on godoc

Part of addressing #1274 