### PR TITLE
samples: check for empty messages when publishing to gcp in gcmsg

### DIFF
--- a/samples/gcmsg/main.go
+++ b/samples/gcmsg/main.go
@@ -72,6 +72,10 @@ func (p *pubCmd) pub(ctx context.Context, topicURL string, r io.Reader) error {
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
+		if line == "" && u.Provider == "gcp" {
+			log.Printf("skipping empty message for %s", u.Provider)
+			continue
+		}
 		m := &pubsub.Message{Body: []byte(line)}
 		if err := t.Send(ctx, m); err != nil {
 			return err


### PR DESCRIPTION
Fixes #1408 