### PR TITLE
aws: refactor aws.Config URL parsing to aws package

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -18,6 +18,7 @@ package aws // import "gocloud.dev/aws"
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -74,11 +75,19 @@ func ConfigFromURLParams(q url.Values) (*aws.Config, error) {
 		case "endpoint":
 			cfg.Endpoint = aws.String(value)
 		case "disableSSL":
-			cfg.DisableSSL = aws.Bool(value == "true")
+			b, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for query parameter %q: %v", param, err)
+			}
+			cfg.DisableSSL = aws.Bool(b)
 		case "s3ForcePathStyle":
-			cfg.S3ForcePathStyle = aws.Bool(value == "true")
+			b, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for query parameter %q: %v", param, err)
+			}
+			cfg.S3ForcePathStyle = aws.Bool(b)
 		default:
-			return nil, fmt.Errorf("unknown S3 query parameter %q", param)
+			return nil, fmt.Errorf("unknown query parameter %q", param)
 		}
 	}
 	return &cfg, nil

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -64,7 +64,9 @@ func (co ConfigOverrider) ClientConfig(serviceName string, cfgs ...*aws.Config) 
 // ConfigFromURLParams returns an aws.Config initialized based on the URL
 // parameters in q. It is intended to be used by URLOpeners for AWS services.
 //
-// It returns an error if q contains any unknown query parameters.
+// It returns an error if q contains any unknown query parameters; callers
+// should remove any query parameters they know about from q before calling
+// ConfigFromURLParams.
 func ConfigFromURLParams(q url.Values) (*aws.Config, error) {
 	var cfg aws.Config
 	for param, values := range q {

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -63,6 +63,7 @@ func (co ConfigOverrider) ClientConfig(serviceName string, cfgs ...*aws.Config) 
 
 // ConfigFromURLParams returns an aws.Config initialized based on the URL
 // parameters in q. It is intended to be used by URLOpeners for AWS services.
+// https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config
 //
 // It returns an error if q contains any unknown query parameters; callers
 // should remove any query parameters they know about from q before calling

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -67,6 +67,12 @@ func (co ConfigOverrider) ClientConfig(serviceName string, cfgs ...*aws.Config) 
 // It returns an error if q contains any unknown query parameters; callers
 // should remove any query parameters they know about from q before calling
 // ConfigFromURLParams.
+//
+// The following query options are supported:
+//  - region: The AWS region for requests; sets aws.Config.Region.
+//  - endpoint: The endpoint URL (hostname only or fully qualified URI); sets aws.Config.Endpoint.
+//  - disableSSL: A value of "true" disables SSL when sending requests; sets aws.Config.DisableSSL.
+//  - s3ForcePathStyle: A value of "true" forces the request to use path-style addressing; sets aws.Config.S3ForcePathStyle.
 func ConfigFromURLParams(q url.Values) (*aws.Config, error) {
 	var cfg aws.Config
 	for param, values := range q {

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -1,0 +1,89 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/google/go-cmp/cmp"
+	gcaws "gocloud.dev/aws"
+)
+
+func TestURLOpenerForParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   url.Values
+		wantCfg *aws.Config
+		wantErr bool
+	}{
+		{
+			name:    "No overrides",
+			query:   url.Values{},
+			wantCfg: &aws.Config{},
+		},
+		{
+			name:    "Invalid query parameter",
+			query:   url.Values{"foo": {"bar"}},
+			wantErr: true,
+		},
+		{
+			name:    "Region",
+			query:   url.Values{"region": {"my_region"}},
+			wantCfg: &aws.Config{Region: aws.String("my_region")},
+		},
+		{
+			name:    "Endpoint",
+			query:   url.Values{"endpoint": {"foo"}},
+			wantCfg: &aws.Config{Endpoint: aws.String("foo")},
+		},
+		{
+			name:    "DisableSSL true",
+			query:   url.Values{"disableSSL": {"true"}},
+			wantCfg: &aws.Config{DisableSSL: aws.Bool(true)},
+		},
+		{
+			name:    "DisableSSL false",
+			query:   url.Values{"disableSSL": {"not-true"}},
+			wantCfg: &aws.Config{DisableSSL: aws.Bool(false)},
+		},
+		{
+			name:    "S3ForcePathStyle true",
+			query:   url.Values{"s3ForcePathStyle": {"true"}},
+			wantCfg: &aws.Config{S3ForcePathStyle: aws.Bool(true)},
+		},
+		{
+			name:    "S3ForcePathStyle false",
+			query:   url.Values{"s3ForcePathStyle": {"not-true"}},
+			wantCfg: &aws.Config{S3ForcePathStyle: aws.Bool(false)},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := gcaws.ConfigFromURLParams(test.query)
+			if (err != nil) != test.wantErr {
+				t.Errorf("got err %v want error %v", err, test.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(got, test.wantCfg); diff != "" {
+				t.Errorf("opener.forParams(...) diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -57,8 +57,13 @@ func TestURLOpenerForParams(t *testing.T) {
 		},
 		{
 			name:    "DisableSSL false",
-			query:   url.Values{"disableSSL": {"not-true"}},
+			query:   url.Values{"disableSSL": {"false"}},
 			wantCfg: &aws.Config{DisableSSL: aws.Bool(false)},
+		},
+		{
+			name:    "DisableSSL false",
+			query:   url.Values{"disableSSL": {"invalid"}},
+			wantErr: true,
 		},
 		{
 			name:    "S3ForcePathStyle true",
@@ -67,8 +72,13 @@ func TestURLOpenerForParams(t *testing.T) {
 		},
 		{
 			name:    "S3ForcePathStyle false",
-			query:   url.Values{"s3ForcePathStyle": {"not-true"}},
+			query:   url.Values{"s3ForcePathStyle": {"false"}},
 			wantCfg: &aws.Config{S3ForcePathStyle: aws.Bool(false)},
+		},
+		{
+			name:    "S3ForcePathStyle false",
+			query:   url.Values{"s3ForcePathStyle": {"invalid"}},
+			wantErr: true,
 		},
 	}
 

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -82,11 +82,7 @@ func init() {
 }
 
 // URLOpener opens S3 URLs like "s3://mybucket".
-// The following query options are supported:
-//  - region: The AWS region for requests; sets aws.Config.Region.
-//  - endpoint: The endpoint URL (hostname only or fully qualified URI); sets aws.Config.Endpoint.
-//  - disableSSL: A value of "true" disables SSL when sending requests; sets aws.Config.DisableSSL.
-//  - s3ForcePathStyle: A value of "true" forces the request to use path-style addressing; sets aws.Config.S3ForcePathStyle.
+// See gocloud.dev/aws/ConfigFromURLParams for supported query parameters.
 type URLOpener struct {
 	// ConfigProvider must be set to a non-nil value.
 	ConfigProvider client.ConfigProvider

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -18,9 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"net/http"
-	"net/url"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -218,74 +216,6 @@ func TestOpenBucket(t *testing.T) {
 			_, err = OpenBucket(ctx, sess, test.bucketName, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)
-			}
-		})
-	}
-}
-
-func TestURLOpenerForParams(t *testing.T) {
-	ctx := context.Background()
-
-	tests := []struct {
-		name    string
-		query   url.Values
-		wantCfg *aws.Config
-		wantErr bool
-	}{
-		{
-			name:    "No overrides",
-			query:   url.Values{},
-			wantCfg: nil,
-		},
-		{
-			name:    "Invalid query parameter",
-			query:   url.Values{"foo": {"bar"}},
-			wantErr: true,
-		},
-		{
-			name:    "Region",
-			query:   url.Values{"region": {"my_region"}},
-			wantCfg: &aws.Config{Region: aws.String("my_region")},
-		},
-		{
-			name:    "Endpoint",
-			query:   url.Values{"endpoint": {"foo"}},
-			wantCfg: &aws.Config{Endpoint: aws.String("foo")},
-		},
-		{
-			name:    "DisableSSL true",
-			query:   url.Values{"disableSSL": {"true"}},
-			wantCfg: &aws.Config{DisableSSL: aws.Bool(true)},
-		},
-		{
-			name:    "DisableSSL false",
-			query:   url.Values{"disableSSL": {"not-true"}},
-			wantCfg: &aws.Config{DisableSSL: aws.Bool(false)},
-		},
-		{
-			name:    "S3ForcePathStyle true",
-			query:   url.Values{"s3ForcePathStyle": {"true"}},
-			wantCfg: &aws.Config{S3ForcePathStyle: aws.Bool(true)},
-		},
-		{
-			name:    "S3ForcePathStyle false",
-			query:   url.Values{"s3ForcePathStyle": {"not-true"}},
-			wantCfg: &aws.Config{S3ForcePathStyle: aws.Bool(false)},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			u := &URLOpener{}
-			got, err := u.forParams(ctx, test.query)
-			if (err != nil) != test.wantErr {
-				t.Errorf("got err %v want error %v", err, test.wantErr)
-			}
-			if err != nil {
-				return
-			}
-			if diff := cmp.Diff(got, test.wantCfg); diff != "" {
-				t.Errorf("opener.forParams(...) diff (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This moves some code from `s3blob` to `aws`, in preparation for using it from other APIs.

Updates #1174.