### PR TITLE
secrets/gcpkms: use a string as the key resourceID instead of a struct

### DIFF
--- a/secrets/gcpkms/example_test.go
+++ b/secrets/gcpkms/example_test.go
@@ -38,12 +38,8 @@ func Example() {
 		// Get the key resource ID.
 		// See https://cloud.google.com/kms/docs/object-hierarchy#key for more
 		// information.
-		&gcpkms.KeyID{
-			ProjectID: "project-id",
-			Location:  "global",
-			KeyRing:   "test",
-			Key:       "key-name",
-		},
+		// You can also use gcpkms.KeyResourceID to construct the string.
+		"projects/MYPROJECT/locations/MYLOCATION/keyRings/MYKEYRING/cryptoKeys/MYKEY",
 		nil,
 	)
 

--- a/secrets/gcpkms/kms_test.go
+++ b/secrets/gcpkms/kms_test.go
@@ -35,11 +35,8 @@ import (
 // 2. Enable the Cloud KMS API.
 // 3. Create a key ring and a key, change their name below accordingly.
 const (
-	projectID = "go-cloud-test-216917"
-	location  = "global"
-	keyRing   = "test"
-	keyID1    = "password"
-	keyID2    = "password2"
+	key1ResourceID = "projects/go-cloud-test-216917/locations/global/keyRings/test/cryptoKeys/password"
+	key2ResourceID = "projects/go-cloud-test-216917/locations/global/keyRings/test/cryptoKeys/password2"
 )
 
 type harness struct {
@@ -48,24 +45,7 @@ type harness struct {
 }
 
 func (h *harness) MakeDriver(ctx context.Context) (driver.Keeper, driver.Keeper, error) {
-	return &keeper{
-			keyID: &KeyID{
-				ProjectID: projectID,
-				Location:  location,
-				KeyRing:   keyRing,
-				Key:       keyID1,
-			},
-			client: h.client,
-		},
-		&keeper{
-			keyID: &KeyID{
-				ProjectID: projectID,
-				Location:  location,
-				KeyRing:   keyRing,
-				Key:       keyID2,
-			},
-			client: h.client,
-		}, nil
+	return &keeper{key1ResourceID, h.client}, &keeper{key2ResourceID, h.client}, nil
 }
 
 func (h *harness) Close() {
@@ -117,7 +97,7 @@ func TestNoConnectionError(t *testing.T) {
 	}
 	defer done()
 
-	keeper := NewKeeper(client, &KeyID{}, nil)
+	keeper := NewKeeper(client, "", nil)
 	if _, err := keeper.Encrypt(ctx, []byte("test")); err == nil {
 		t.Error("got nil, want rpc error")
 	}


### PR DESCRIPTION
Users will probably have a key resourceID copied from the UI or whatever.