### PR TITLE
pubsub: add a batch constructor to NewTopic

### DIFF
--- a/pubsub/awspubsub/awspubsub.go
+++ b/pubsub/awspubsub/awspubsub.go
@@ -115,7 +115,7 @@ type TopicOptions struct {
 
 // OpenTopic opens the topic on AWS SNS for the given SNS client and topic ARN.
 func OpenTopic(ctx context.Context, client *sns.SNS, topicARN string, opts *TopicOptions) *pubsub.Topic {
-	return pubsub.NewTopic(openTopic(ctx, client, topicARN, opts))
+	return pubsub.NewTopic(openTopic(ctx, client, topicARN, opts), nil)
 }
 
 // openTopic returns the driver for OpenTopic. This function exists so the test

--- a/pubsub/awspubsub/awspubsub_test.go
+++ b/pubsub/awspubsub/awspubsub_test.go
@@ -411,7 +411,7 @@ func BenchmarkAwsPubSub(b *testing.B) {
 		b.Fatal(err)
 	}
 	defer cleanup1()
-	topic := pubsub.NewTopic(dt)
+	topic := pubsub.NewTopic(dt, nil)
 	defer topic.Shutdown(ctx)
 	subName := fmt.Sprintf("%s-subscription", b.Name())
 	ds, cleanup2, err := createSubscription(ctx, dt, subName, sess)

--- a/pubsub/azurepubsub/azurepubsub.go
+++ b/pubsub/azurepubsub/azurepubsub.go
@@ -80,7 +80,7 @@ func NewSubscription(parentTopic *servicebus.Topic, subscriptionName string, opt
 // OpenTopic initializes a pubsub Topic on a given Service Bus Topic.
 func OpenTopic(ctx context.Context, sbTopic *servicebus.Topic, opts *TopicOptions) *pubsub.Topic {
 	t := openTopic(ctx, sbTopic)
-	return pubsub.NewTopic(t)
+	return pubsub.NewTopic(t, nil)
 }
 
 // openTopic returns the driver for OpenTopic. This function exists so the test

--- a/pubsub/drivertest/drivertest.go
+++ b/pubsub/drivertest/drivertest.go
@@ -190,7 +190,7 @@ func testNonExistentTopicSucceedsOnOpenButFailsOnSend(t *testing.T, newHarness H
 		// to them.
 		t.Fatalf("creating a local topic that doesn't exist on the server: %v", err)
 	}
-	top := pubsub.NewTopic(dt)
+	top := pubsub.NewTopic(dt, nil)
 	defer top.Shutdown(ctx)
 
 	m := &pubsub.Message{}
@@ -261,7 +261,7 @@ func testSendReceiveTwo(t *testing.T, newHarness HarnessMaker) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	top := pubsub.NewTopic(dt)
+	top := pubsub.NewTopic(dt, nil)
 	defer top.Shutdown(ctx)
 
 	var ss []*pubsub.Subscription
@@ -500,7 +500,7 @@ func makePair(ctx context.Context, h Harness, testName string) (*pubsub.Topic, *
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	t := pubsub.NewTopic(dt)
+	t := pubsub.NewTopic(dt, nil)
 	s := pubsub.NewSubscription(ds, nil)
 	cleanup := func() {
 		topicCleanup()
@@ -545,7 +545,7 @@ func testAs(t *testing.T, newHarness HarnessMaker, st AsTest) {
 		t.Error(err)
 	}
 
-	top = pubsub.NewTopic(dt)
+	top = pubsub.NewTopic(dt, nil)
 	defer top.Shutdown(ctx)
 	topicErr := top.Send(ctx, &pubsub.Message{})
 	if topicErr == nil {

--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -85,7 +85,7 @@ type TopicOptions struct{}
 // example.
 func OpenTopic(client *raw.PublisherClient, proj gcp.ProjectID, topicName string, opts *TopicOptions) *pubsub.Topic {
 	dt := openTopic(client, proj, topicName)
-	return pubsub.NewTopic(dt)
+	return pubsub.NewTopic(dt, nil)
 }
 
 // openTopic returns the driver for OpenTopic. This function exists so the test

--- a/pubsub/gcppubsub/gcppubsub_test.go
+++ b/pubsub/gcppubsub/gcppubsub_test.go
@@ -145,7 +145,7 @@ func BenchmarkGcpPubSub(b *testing.B) {
 		b.Fatal(err)
 	}
 	defer cleanup1()
-	topic := pubsub.NewTopic(dt)
+	topic := pubsub.NewTopic(dt, nil)
 	defer topic.Shutdown(ctx)
 
 	// Make subscription.

--- a/pubsub/mempubsub/mem.go
+++ b/pubsub/mempubsub/mem.go
@@ -45,7 +45,7 @@ type topic struct {
 
 // NewTopic creates a new in-memory topic.
 func NewTopic() *pubsub.Topic {
-	return pubsub.NewTopic(&topic{})
+	return pubsub.NewTopic(&topic{}, nil)
 }
 
 // SendBatch implements driver.Topic.SendBatch.

--- a/pubsub/pub_test.go
+++ b/pubsub/pub_test.go
@@ -41,7 +41,7 @@ func TestTopicShutdownCanBeCanceledEvenWithHangingSend(t *testing.T) {
 			return ctx.Err()
 		},
 	}
-	top := pubsub.NewTopic(dt)
+	top := pubsub.NewTopic(dt, nil)
 
 	go func() {
 		m := &pubsub.Message{}

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -230,12 +230,11 @@ func (t *Topic) ErrorAs(err error, target interface{}) bool {
 // NewTopic is for use by provider implementations.
 var NewTopic = newTopic
 
-// newTopic makes a pubsub.Topic from a driver.Topic.
-func newTopic(d driver.Topic) *Topic {
-	callCtx, cancel := context.WithCancel(context.Background())
-	tracer := newTracer(d)
-	handler := func(item interface{}) error {
-		ms := item.([]*Message)
+// defaultBatcher creates a batcher for topics, for use with NewTopic.
+func defaultBatcher(ctx context.Context, t *Topic, dt driver.Topic) driver.Batcher {
+	const maxHandlers = 1
+	handler := func(items interface{}) error {
+		ms := items.([]*Message)
 		var dms []*driver.Message
 		for _, m := range ms {
 			dm := &driver.Message{
@@ -244,25 +243,31 @@ func newTopic(d driver.Topic) *Topic {
 			}
 			dms = append(dms, dm)
 		}
-
-		err := retry.Call(callCtx, gax.Backoff{}, d.IsRetryable, func() (err error) {
-			ctx := tracer.Start(callCtx, "driver.Topic.SendBatch")
-			defer func() { tracer.End(ctx, err) }()
-			return d.SendBatch(ctx, dms)
+		err := retry.Call(ctx, gax.Backoff{}, t.driver.IsRetryable, func() (err error) {
+			ctx2 := t.tracer.Start(ctx, "driver.Topic.SendBatch")
+			defer func() { t.tracer.End(ctx2, err) }()
+			return dt.SendBatch(ctx2, dms)
 		})
 		if err != nil {
-			return wrapError(d, err)
+			return wrapError(dt, err)
 		}
 		return nil
 	}
-	maxHandlers := 1
-	b := batcher.New(reflect.TypeOf(&Message{}), maxHandlers, handler)
+	return batcher.New(reflect.TypeOf(&Message{}), maxHandlers, handler)
+}
+
+// newTopic makes a pubsub.Topic from a driver.Topic.
+func newTopic(d driver.Topic, newBatcher func(context.Context, *Topic, driver.Topic) driver.Batcher) *Topic {
+	ctx, cancel := context.WithCancel(context.Background())
 	t := &Topic{
-		driver:  d,
-		batcher: b,
-		tracer:  tracer,
-		cancel:  cancel,
+		driver: d,
+		tracer: newTracer(d),
+		cancel: cancel,
 	}
+	if newBatcher == nil {
+		newBatcher = defaultBatcher
+	}
+	t.batcher = newBatcher(ctx, t, d)
 	return t
 }
 
@@ -506,8 +511,6 @@ func newSubscription(ds driver.Subscription, newAckBatcher func(context.Context,
 	s.ackBatcher = newAckBatcher(ctx, s, ds)
 	return s
 }
-
-type ackBatchSender func(context.Context, []driver.AckID) error
 
 // defaultAckBatcher creates a batcher for acknowledgements, for use with
 // NewSubscription.

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -114,7 +114,7 @@ func TestSendReceive(t *testing.T) {
 	dt := &driverTopic{
 		subs: []*driverSub{ds},
 	}
-	topic := pubsub.NewTopic(dt)
+	topic := pubsub.NewTopic(dt, nil)
 	defer topic.Shutdown(ctx)
 	m := &pubsub.Message{Body: []byte("user signed up")}
 	if err := topic.Send(ctx, m); err != nil {
@@ -174,7 +174,7 @@ func TestConcurrentReceivesGetAllTheMessages(t *testing.T) {
 	}
 
 	// Send messages. Each message has a unique body used as a key to receivedMsgs.
-	topic := pubsub.NewTopic(dt)
+	topic := pubsub.NewTopic(dt, nil)
 	defer topic.Shutdown(ctx)
 	for i := 0; i < howManyToSend; i++ {
 		key := fmt.Sprintf("message #%d", i)
@@ -204,7 +204,7 @@ func TestCancelSend(t *testing.T) {
 	dt := &driverTopic{
 		subs: []*driverSub{ds},
 	}
-	topic := pubsub.NewTopic(dt)
+	topic := pubsub.NewTopic(dt, nil)
 	defer topic.Shutdown(ctx)
 	m := &pubsub.Message{}
 
@@ -273,7 +273,7 @@ func TestCancelTwoReceives(t *testing.T) {
 func TestRetryTopic(t *testing.T) {
 	// Test that Send is retried if the driver returns a retryable error.
 	ft := &failTopic{}
-	top := pubsub.NewTopic(ft)
+	top := pubsub.NewTopic(ft, nil)
 	err := top.Send(context.Background(), &pubsub.Message{})
 	if err != nil {
 		t.Errorf("Send: got %v, want nil", err)
@@ -363,7 +363,7 @@ func (erroringSubscription) ErrorCode(error) gcerrors.ErrorCode             { re
 // wrapped exactly once by the concrete type.
 func TestErrorsAreWrapped(t *testing.T) {
 	ctx := context.Background()
-	top := pubsub.NewTopic(erroringTopic{})
+	top := pubsub.NewTopic(erroringTopic{}, nil)
 	sub := pubsub.NewSubscription(erroringSubscription{}, nil)
 
 	verify := func(err error) {

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -65,7 +65,7 @@ type SubscriptionOptions struct{}
 // The documentation of the amqp package recommends using separate connections for
 // publishing and subscribing.
 func OpenTopic(conn *amqp.Connection, name string, opts *TopicOptions) *pubsub.Topic {
-	return pubsub.NewTopic(newTopic(&connection{conn}, name))
+	return pubsub.NewTopic(newTopic(&connection{conn}, name), nil)
 }
 
 func newTopic(conn amqpConnection, name string) *topic {

--- a/pubsub/rabbitpubsub/rabbit_test.go
+++ b/pubsub/rabbitpubsub/rabbit_test.go
@@ -94,7 +94,7 @@ func BenchmarkRabbit(b *testing.B) {
 		b.Fatal(err)
 	}
 	defer cleanup()
-	drivertest.RunBenchmarks(b, pubsub.NewTopic(dt), pubsub.NewSubscription(ds, nil))
+	drivertest.RunBenchmarks(b, pubsub.NewTopic(dt, nil), pubsub.NewSubscription(ds, nil))
 }
 
 type harness struct {


### PR DESCRIPTION
This is basically the same thing that was already done for `NewSubscription`, but for `NewTopic` this time.

In a separate PR, I will update the `drivertest` conformance tests to pass non-nil values for the batchers, so that record/replay tests are repeatable. Currently they are flaky because they are based on timing. For example, Windows is dog slow and so the second "ReceiveBatch" call has a different `maxMessages` argument than the current goldens (1000).

Updates #1423.

