### PR TITLE
secrets: add support for URLOpeners to all drivers

### DIFF
--- a/internal/testing/setup/setup.go
+++ b/internal/testing/setup/setup.go
@@ -291,10 +291,7 @@ func FakeGCPDefaultCredentials(t *testing.T) func() {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := f.Write(jsonCred); err != nil {
-		t.Fatal(err)
-	}
-	if err := f.Close(); err != nil {
+	if err := ioutil.WriteFile(f.Name(), jsonCred, 0666); err != nil {
 		t.Fatal(err)
 	}
 	oldEnvVal := os.Getenv(envVar)

--- a/internal/testing/setup/setup.go
+++ b/internal/testing/setup/setup.go
@@ -15,6 +15,7 @@
 package setup // import "gocloud.dev/internal/testing/setup"
 
 import (
+	"io/ioutil"
 	"context"
 	"flag"
 	"net"
@@ -279,4 +280,27 @@ func NewAzureTestPipeline(ctx context.Context, t *testing.T, api string, credent
 		}),
 	})
 	return p, done, httpClient
+}
+
+// FakeGCPDefaultCredentials sets up the environment with fake GCP credentials.
+// It returns a cleanup function.
+func FakeGCPDefaultCredentials(t *testing.T) func() {
+	const envVar = "GOOGLE_APPLICATION_CREDENTIALS"
+	jsonCred := []byte(`{"client_id": "foo.apps.googleusercontent.com", "client_secret": "bar", "refresh_token": "baz", "type": "authorized_user"}`)
+	f, err := ioutil.TempFile("", "fake-gcp-creds")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(jsonCred); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	oldEnvVal := os.Getenv(envVar)
+	os.Setenv(envVar, f.Name())
+	return func() {
+		os.Remove(f.Name())
+		os.Setenv(envVar, oldEnvVal)
+	}
 }

--- a/secrets/awskms/example_test.go
+++ b/secrets/awskms/example_test.go
@@ -19,6 +19,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws/session"
+	"gocloud.dev/secrets"
 	"gocloud.dev/secrets/awskms"
 )
 
@@ -55,4 +56,15 @@ func Example() {
 	}
 	decrypted, err := keeper.Decrypt(ctx, ciphertext)
 	_ = decrypted
+}
+
+func Example_openKeeper() {
+	ctx := context.Background()
+
+	// OpenKeeper creates a *secrets.Keeper from a URL.
+	// The host + path are the key resource ID; this example uses an alias. See
+	// https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn
+	// for more details.
+	k, err := secrets.OpenKeeper(ctx, "awskms://alias/my-key")
+	_, _ = k, err
 }

--- a/secrets/awskms/example_test.go
+++ b/secrets/awskms/example_test.go
@@ -40,7 +40,7 @@ func Example() {
 	// Construct a *secrets.Keeper.
 	keeper := awskms.NewKeeper(
 		client,
-		// Get the key resource ID. Here is an example of using an alias. See
+		// Get the key ID. Here is an example of using an alias. See
 		// https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn
 		// for more details.
 		"alias/test-secrets",
@@ -62,7 +62,7 @@ func Example_openKeeper() {
 	ctx := context.Background()
 
 	// OpenKeeper creates a *secrets.Keeper from a URL.
-	// The host + path are the key resource ID; this example uses an alias. See
+	// The host + path are the key ID; this example uses an alias. See
 	// https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn
 	// for more details.
 	k, err := secrets.OpenKeeper(ctx, "awskms://alias/my-key")

--- a/secrets/awskms/kms.go
+++ b/secrets/awskms/kms.go
@@ -18,7 +18,7 @@
 // URLs
 //
 // For secrets.OpenKeeper URLs, awskms registers for the scheme "awskms".
-// The host+path are used as the keyID; see
+// The host+path are used as the key ID; see
 // https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn
 // for more details. Example: "awskms://alias/my-key".
 //
@@ -64,11 +64,11 @@ func Dial(p client.ConfigProvider) (*kms.KMS, error) {
 }
 
 // URLOpener opens secrets.Keeper URLs for AWS KMS, like "awskms://keyID".
-// The keyID can be in the form of an Amazon Resource Name (ARN), alias
+// The key ID can be in the form of an Amazon Resource Name (ARN), alias
 // name, or alias ARN. See
 // https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn
 // for more details.
-// The URL Host + Path are used as the keyID, to support alias names like "awskms://alias/foo".
+// The URL Host + Path are used as the key ID, to support alias names like "awskms://alias/foo".
 // See gocloud.dev/aws/ConfigFromURLParams for supported query parameters
 // for modifying the aws.Session.
 type URLOpener struct {
@@ -125,7 +125,7 @@ func (o *URLOpener) OpenKeeperURL(ctx context.Context, u *url.URL) (*secrets.Kee
 }
 
 // NewKeeper returns a *secrets.Keeper that uses AWS KMS.
-// The keyID can be in the form of an Amazon Resource Name (ARN), alias
+// The key ID can be in the form of an Amazon Resource Name (ARN), alias
 // name, or alias ARN. See
 // https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn
 // for more details.

--- a/secrets/awskms/kms_test.go
+++ b/secrets/awskms/kms_test.go
@@ -113,3 +113,22 @@ func TestNoConnectionError(t *testing.T) {
 		t.Error("got nil, want UnrecognizedClientException")
 	}
 }
+
+func TestOpenKeeper(t *testing.T) {
+	tests := []struct {
+		URL     string
+		WantErr bool
+	}{
+		{"awskms://alias/my-key", false},
+		{"awskms://alias/my-key?region=us-west1", false},
+		{"awskms://alias/my-key?someparam=foo", true},
+	}
+
+	ctx := context.Background()
+	for _, test := range tests {
+		_, err := secrets.OpenKeeper(ctx, test.URL)
+		if (err != nil) != test.WantErr {
+			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
+		}
+	}
+}

--- a/secrets/gcpkms/example_test.go
+++ b/secrets/gcpkms/example_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log"
 
+	"gocloud.dev/secrets"
 	"gocloud.dev/secrets/gcpkms"
 )
 
@@ -51,4 +52,15 @@ func Example() {
 	}
 	decrypted, err := keeper.Decrypt(ctx, ciphertext)
 	_ = decrypted
+}
+
+func Example_openKeeper() {
+	ctx := context.Background()
+
+	// OpenKeeper creates a *secrets.Keeper from a URL.
+	// The host + path are the key resourceID; see
+	// https://cloud.google.com/kms/docs/object-hierarchy#key
+	// for more information.
+	k, err := secrets.OpenKeeper(ctx, "gcpkms://projects/MYPROJECT/locations/MYLOCATION/keyRings/MYKEYRING/cryptoKeys/MYKEY")
+	_, _ = k, err
 }

--- a/secrets/gcpkms/kms.go
+++ b/secrets/gcpkms/kms.go
@@ -15,6 +15,17 @@
 // Package gcpkms provides a secrets implementation backed by Google Cloud KMS.
 // Use NewKeeper to construct a *secrets.Keeper.
 //
+// URLs
+//
+// For secrets.OpenKeeper URLs, gcpkms registers for the scheme "gcpkms".
+// The host+path are used as the key resource ID; see
+// https://cloud.google.com/kms/docs/object-hierarchy#key for more details.
+// Example: "gcpkms://projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEY_RING]/cryptoKeys/[KEY]".
+//
+// secrets.OpenKeeper will use Application Default Credentials, as described in
+// https://cloud.google.com/docs/authentication/production.
+// If you want to use different credentials, see URLOpener.
+//
 // As
 //
 // gcpkms exposes the following type for As:
@@ -24,6 +35,9 @@ package gcpkms // import "gocloud.dev/secrets/gcpkms"
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"path"
+	"sync"
 
 	cloudkms "cloud.google.com/go/kms/apiv1"
 	"gocloud.dev/gcerrors"
@@ -46,9 +60,63 @@ func Dial(ctx context.Context, ts gcp.TokenSource) (*cloudkms.KeyManagementClien
 	return c, func() { c.Close() }, err
 }
 
+func init() {
+	secrets.DefaultURLMux().RegisterKeeper(Scheme, new(lazyCredsOpener))
+}
+
+// lazyCredsOpener obtains Application Default Credentials on the first call
+// to OpenKeeperURL.
+type lazyCredsOpener struct {
+	init   sync.Once
+	opener *URLOpener
+	err    error
+}
+
+func (o *lazyCredsOpener) OpenKeeperURL(ctx context.Context, u *url.URL) (*secrets.Keeper, error) {
+	o.init.Do(func() {
+		creds, err := gcp.DefaultCredentials(ctx)
+		if err != nil {
+			o.err = err
+			return
+		}
+		client, _, err := Dial(ctx, creds.TokenSource)
+		if err != nil {
+			o.err = err
+			return
+		}
+		o.opener = &URLOpener{Client: client}
+	})
+	if o.err != nil {
+		return nil, fmt.Errorf("open GCP KMS %q: %v", u, o.err)
+	}
+	return o.opener.OpenKeeperURL(ctx, u)
+}
+
+// Scheme is the URL scheme gcpkms registers its URLOpener under on secrets.DefaultMux.
+const Scheme = "gcpkms"
+
+// URLOpener opens GCP KMS URLs like "gcpkms://projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEY_RING]/cryptoKeys/[KEY]".
+// The URL host+path are used as the key resource ID; see
+// https://cloud.gogle.com/kms/docs/object-hierarchy#key for more details.
+// No query parameters are accepted.
+type URLOpener struct {
+	// Client must be non-nil and be authenticated with "cloudkms" scope or equivalent.
+	Client *cloudkms.KeyManagementClient
+
+	// Options specifies the default options to pass to NewKeeper.
+	Options KeeperOptions
+}
+
+// OpenKeeperURL opens the GCP KMS URLs.
+func (o *URLOpener) OpenKeeperURL(ctx context.Context, u *url.URL) (*secrets.Keeper, error) {
+	for param := range u.Query() {
+		return nil, fmt.Errorf("open keeper %q: invalid query parameter %q", u, param)
+	}
+	return NewKeeper(o.Client, path.Join(u.Host, u.Path), &o.Options), nil
+}
+
 // NewKeeper returns a *secrets.Keeper that uses Google Cloud KMS.
-// See https://cloud.google.com/kms/docs/object-hierarchy#key for more
-// information about the keyID format.
+// See https://cloud.google.com/kms/docs/object-hierarchy#key for more details.
 // See the package documentation for an example.
 func NewKeeper(client *cloudkms.KeyManagementClient, keyID string, opts *KeeperOptions) *secrets.Keeper {
 	return secrets.NewKeeper(&keeper{
@@ -58,14 +126,13 @@ func NewKeeper(client *cloudkms.KeyManagementClient, keyID string, opts *KeeperO
 }
 
 // KeyResourceID constructs a key resourceID for GCP KMS.
-// See https://cloud.google.com/kms/docs/object-hierarchy#key for more
-// information.
+// See https://cloud.google.com/kms/docs/object-hierarchy#key for more details.
 func KeyResourceID(projectID, location, keyRing, key string) string {
 	return fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
 		projectID, location, keyRing, key)
 }
 
-// keeper contains information to construct the pull path of a key.
+// keeper implements driver.Keeper.
 type keeper struct {
 	keyID  string
 	client *cloudkms.KeyManagementClient

--- a/secrets/gcpkms/kms_test.go
+++ b/secrets/gcpkms/kms_test.go
@@ -104,6 +104,9 @@ func TestNoConnectionError(t *testing.T) {
 }
 
 func TestOpenKeeper(t *testing.T) {
+	cleanup := setup.FakeGCPDefaultCredentials(t)
+	defer cleanup()
+
 	tests := []struct {
 		URL     string
 		WantErr bool

--- a/secrets/gcpkms/kms_test.go
+++ b/secrets/gcpkms/kms_test.go
@@ -102,3 +102,21 @@ func TestNoConnectionError(t *testing.T) {
 		t.Error("got nil, want rpc error")
 	}
 }
+
+func TestOpenKeeper(t *testing.T) {
+	tests := []struct {
+		URL     string
+		WantErr bool
+	}{
+		{"gcpkms://projects/MYPROJECT/locations/MYLOCATION/keyRings/MYKEYRING/cryptoKeys/MYKEY", false},
+		{"gcpkms://projects/MYPROJECT/locations/MYLOCATION/keyRings/MYKEYRING/cryptoKeys/MYKEY?param=val", true},
+	}
+
+	ctx := context.Background()
+	for _, test := range tests {
+		_, err := secrets.OpenKeeper(ctx, test.URL)
+		if (err != nil) != test.WantErr {
+			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
+		}
+	}
+}

--- a/secrets/localsecrets/example_test.go
+++ b/secrets/localsecrets/example_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 
+	"gocloud.dev/secrets"
 	"gocloud.dev/secrets/localsecrets"
 )
 
@@ -43,4 +44,18 @@ func Example() {
 
 	// Output:
 	// Hello, Secrets!
+}
+
+func Example_openKeeper() {
+	ctx := context.Background()
+
+	// OpenKeeper creates a *secrets.Keeper from a URL.
+
+	// Using "stringkey://", the first 32 bytes of the URL hostname is used as the secret.
+	k, err := secrets.OpenKeeper(ctx, "stringkey://my-secret-key")
+
+	// Using "base64key://", the URL hostname must be a base64-encoded key.
+	// The first 32 bytes of the decoding are used as the secret key.
+	k, err = secrets.OpenKeeper(ctx, "base64key://bXktc2VjcmV0LWtleQ==")
+	_, _ = k, err
 }

--- a/secrets/localsecrets/localsecrets.go
+++ b/secrets/localsecrets/localsecrets.go
@@ -48,11 +48,12 @@ func init() {
 	secrets.DefaultURLMux().RegisterKeeper(SchemeBase64, &URLOpener{base64: true})
 }
 
-// SchemeString is the URL scheme localsecrets registers its URLOpener under on secrets.DefaultMux.
-const SchemeString = "stringkey"
-
-// SchemeBase64 is the URL scheme localsecrets registers its URLOpener under on secrets.DefaultMux.
-const SchemeBase64 = "base64key"
+// SchemeString/SchemeBase64 are the URL schemes localsecrets registers its URLOpener under on secrets.DefaultMux.
+// See the package documentation and/or URLOpener for details.
+const (
+	SchemeString = "stringkey"
+	SchemeBase64 = "base64key"
+)
 
 // URLOpener opens localsecrets URLs like "stringkey://mykey" and "base64key://c2VjcmV0IGtleQ==".
 //

--- a/secrets/localsecrets/localsecrets_test.go
+++ b/secrets/localsecrets/localsecrets_test.go
@@ -53,3 +53,24 @@ func (v verifyAs) ErrorCheck(k *secrets.Keeper, err error) error {
 	}
 	return nil
 }
+
+func TestOpenKeeper(t *testing.T) {
+	tests := []struct {
+		URL     string
+		WantErr bool
+	}{
+		{"stringkey://my-secret", false},
+		{"stringkey://my-secret?param=value", true},
+		{"base64key://bXktc2VjcmV0LWtleQ==", false},
+		{"base64key://bXktc2VjcmV0LWtleQ==?param=value", true},
+		{"base64key://not-valid-base64", true},
+	}
+
+	ctx := context.Background()
+	for _, test := range tests {
+		_, err := secrets.OpenKeeper(ctx, test.URL)
+		if (err != nil) != test.WantErr {
+			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
+		}
+	}
+}

--- a/secrets/vault/example_test.go
+++ b/secrets/vault/example_test.go
@@ -19,6 +19,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/vault/api"
+	"gocloud.dev/secrets"
 	"gocloud.dev/secrets/vault"
 )
 
@@ -28,7 +29,7 @@ func Example_encrypt() {
 	ctx := context.Background()
 	client, err := vault.Dial(ctx, &vault.Config{
 		Token: "<Client (Root) Token>",
-		APIConfig: &api.Config{
+		APIConfig: api.Config{
 			Address: "http://127.0.0.1:8200",
 		},
 	})
@@ -44,4 +45,15 @@ func Example_encrypt() {
 	}
 	decrypted, err := keeper.Decrypt(ctx, ciphertext)
 	_ = decrypted
+}
+
+func Example_openKeeper() {
+	ctx := context.Background()
+
+	// OpenKeeper creates a *secrets.Keeper from a URL.
+	// The host+path are used as the keyID, and the "address" and "token"
+	// query parameters specify which Vault server to dial, and the auth token
+	// to use.
+	k, err := secrets.OpenKeeper(ctx, "vault://MYKEY?address=http://MYVAULT.SERVER.COM:8080&token=MYTOKEN")
+	_, _ = k, err
 }

--- a/secrets/vault/vault.go
+++ b/secrets/vault/vault.go
@@ -20,7 +20,7 @@
 //
 // For secrets.OpenKeeper URLs, vault registers for the scheme "vault"; URLs
 // start with "vault://". secrets.OpenKeeper will dial a Vault server once per
-// unique cpmbination of the following supported URL parameters:
+// unique combination of the following supported URL parameters:
 //   - address: Sets Config.APIConfig.Address; should be a full URL with the
 //       address of the Vault server.
 //   - token: Sets Config.Token; the access token the Vault client will use.


### PR DESCRIPTION
This is mostly mechanical, copying the pattern @zombiezen established for `blob`.

The interesting parts are probably:

* I made `localsecrets` register for 2 schemes, 'stringkey://" and "base64key://".
* `vault` is a bit interesting since the URL contains the Vault server address + token; I made it Dial but cache the result.

Updates #1174.