### PR TITLE
docs: move As documentation to doc.go

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -55,8 +55,9 @@ Using As implies that the resulting code is no longer portable; the
 provider-specific code will need to be ported in order to switch providers.
 Therefore, it should be avoided if possible.
 
-Each provider implementation must document what type(s) it supports for each of
-the As functions.
+Each API will include examples demonstrating how to use its various As
+functions, and each provider implementation will document what types it
+supports for each.
 
 */
 package cloud // import "gocloud.dev"

--- a/doc.go
+++ b/doc.go
@@ -42,46 +42,21 @@ Escaping the abstraction
 It is not feasible or desirable for APIs like blob.Bucket to encompass the full
 functionality of every provider. Rather, we intend to provide a subset of the
 most commonly used functionality. There will be cases where a developer wants
-to access provider-specific functionality, which might consist of:
-
-1. Top-level APIs. For example, blob does not expose a Copy, but some provider
-might.
-
-2. Data fields. For example, blob exposes a few attributes like ContentType
-and Size, but S3 and GCS both have many more.
-
-3. Errors. For example, S3 returns awserr.Error.
-
-4. Options. Different providers may support different options for functionality.
+to access provider-specific functionality, such as unexposed APIs or data
+fields, errors or options.
 
 As functions in the APIs provide the user a way to escape the Go CDK
 abstraction to access provider-specific types. They might be used as an interim
 solution until a feature request to the Go CDK is implemented. Or, the Go CDK
 may choose not to support specific features, and the use of As will be
-permanent. As an example, both S3 and GCS blobs have the concept of ACLs, but
-it might be difficult to represent them in a generic way (although, we have not
-tried).
+permanent.
 
 Using As implies that the resulting code is no longer portable; the
 provider-specific code will need to be ported in order to switch providers.
-Therefore, it should be avoided if possible. For example:
+Therefore, it should be avoided if possible.
 
-	// The existing blob.Reader exposes some blob attributes, but not everything
-	// that every provider exposes.
-	type Reader struct {...}
-
-	// As converts i to provider-specific types.
-	func (r *Reader) As(i interface{}) bool {...}
-
-	// User code would look like:
-	r, _ := bucket.NewReader(ctx, "foo.txt", nil)
-	var s3type s3.GetObjectOutput
-	if r.As(&s3type) {
-		... use s3type...
-	}
-
-Each provider implementation documents what type(s) it supports for each of the
-As functions.
+Each provider implementation must document what type(s) it supports for each of
+the As functions.
 
 */
 package cloud // import "gocloud.dev"

--- a/internal/docs/design.md
+++ b/internal/docs/design.md
@@ -416,66 +416,6 @@ Concrete types should:
 [cascading failure]:
 https://landing.google.com/sre/book/chapters/addressing-cascading-failures.html
 
-## As
-
-It is not feasible or desirable for APIs like [`blob.Bucket`] to encompass the
-full functionality of every provider. Rather, we intend to provide a subset of
-the most commonly used functionality. There will be cases where a developer
-wants to access provider-specific functionality, which might consist of:
-
-1.  **Top-level APIs**. For example, `blob` does not expose a `Copy`, but some
-    provider might.
-1.  **Data fields**. For example, **blob** exposes a few attributes like
-    ContentType and Size, but S3 and GCS both have many more.
-1.  **Errors**. For example, S3 returns `awserr.Error`.
-1.  **Options**. Different providers may support different options for
-    functionality.
-
-**As** functions in the APIs provide the user a way to escape the Go CDK
-abstraction to access provider-specific types. They might be used as an interim
-solution until a feature request to the Go CDK is implemented. Or, the Go CDK
-may choose not to support specific features, and the use of `As` will be
-permanent. As an example, both S3 and GCS blobs have the concept of ACLs, but it
-might be difficult to represent them in a generic way (although, we have not
-tried).
-
-Using `As`implies that the resulting code is no longer portable; the
-provider-specific code will need to be ported in order to switch providers.
-Therefore, it should be avoided if possible.
-
-### Example
-
-```
-// The existing blob.Reader exposes some blob attributes, but not everything
-// that every provider exposes.
-type Reader struct {...}
-
-// As converts i to provider-specific types.
-func (r *Reader) As(i interface{}) bool {...}
-
-// User code would look like:
-r, _ := bucket.NewReader(ctx, "foo.txt", nil)
-var s3type s3.GetObjectOutput
-if r.As(&s3type) {
-  ... use s3type...
-}
-```
-
-Each provider implementation documents what type(s) it supports for each of the
-`As` functions.
-
-### Other Ways To Access Provider-Specific Features
-
-Users can always access the provider service directly, by constructing the
-top-level handle and making API calls, bypassing the Go CDK.
-
-*   For top-level operations, this may be fine, although it might require a
-    bunch of plumbing code to pass the provider service handle to where it is
-    needed.
-*   For data objects, it implies dropping the Go CDK entirely; for example,
-    instead of using `blob.Reader` to read a blob, the user would have to use
-    the provider-specific method for reading.
-
 ## Enforcing Portability
 
 The Go CDK APIs will end up exposing functionality that is not supported by all


### PR DESCRIPTION
This will make it easier for us to point to this documentation for more details from all the places where As is described

For #1274
