### PR TITLE
pubsub: add AckFunc method to driver Subscription

### DIFF
--- a/pubsub/acks_test.go
+++ b/pubsub/acks_test.go
@@ -54,6 +54,8 @@ func (s *ackingDriverSub) IsRetryable(error) bool { return false }
 
 func (s *ackingDriverSub) ErrorCode(error) gcerrors.ErrorCode { return gcerrors.Internal }
 
+func (s *ackingDriverSub) AckFunc() func() { return nil }
+
 func TestAckTriggersDriverSendAcksForOneMessage(t *testing.T) {
 	ctx := context.Background()
 	var mu sync.Mutex
@@ -365,6 +367,8 @@ func (s *callbackDriverSub) SendAcks(ctx context.Context, acks []driver.AckID) e
 func (s *callbackDriverSub) IsRetryable(error) bool { return false }
 
 func (s *callbackDriverSub) ErrorCode(error) gcerrors.ErrorCode { return gcerrors.Internal }
+
+func (s *callbackDriverSub) AckFunc() func() { return nil }
 
 // This test detects the root cause of
 // https://github.com/google/go-cloud/issues/1238.

--- a/pubsub/awspubsub/awspubsub.go
+++ b/pubsub/awspubsub/awspubsub.go
@@ -415,3 +415,6 @@ func errorAs(err error, target interface{}) bool {
 	*p = e
 	return true
 }
+
+// AckFunc implements driver.Subscription.AckFunc.
+func (*subscription) AckFunc() func() { return nil }

--- a/pubsub/azurepubsub/azurepubsub.go
+++ b/pubsub/azurepubsub/azurepubsub.go
@@ -379,3 +379,6 @@ func errorCode(err error) gcerrors.ErrorCode {
 		return gcerrors.Unknown
 	}
 }
+
+// AckFunc implements driver.Subscription.AckFunc.
+func (*subscription) AckFunc() func() { return nil }

--- a/pubsub/driver/driver.go
+++ b/pubsub/driver/driver.go
@@ -121,6 +121,11 @@ type Subscription interface {
 	// ReceiveBatch should be safe for concurrent access from multiple goroutines.
 	ReceiveBatch(ctx context.Context, maxMessages int) ([]*Message, error)
 
+	// For at-most-once systems, AckFunc should return a function to be called
+	// whenever pubsub.Message.Ack is called. For at-least-once systems (those that
+	// support Ack), AckFunc should return nil.
+	AckFunc() func()
+
 	// SendAcks should acknowledge the messages with the given ackIDs on
 	// the server so that they will not be received again for this
 	// subscription if the server gets the acks before their deadlines.

--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -256,3 +256,6 @@ func (*subscription) ErrorAs(err error, target interface{}) bool {
 func (*subscription) ErrorCode(err error) gcerrors.ErrorCode {
 	return gcerr.GRPCCode(err)
 }
+
+// AckFunc implements driver.Subscription.AckFunc.
+func (*subscription) AckFunc() func() { return nil }

--- a/pubsub/mempubsub/mem.go
+++ b/pubsub/mempubsub/mem.go
@@ -235,3 +235,6 @@ func (*subscription) ErrorAs(error, interface{}) bool {
 
 // ErrorCode implements driver.Subscription.ErrorCode
 func (*subscription) ErrorCode(error) gcerrors.ErrorCode { return gcerrors.Unknown }
+
+// AckFunc implements driver.Subscription.AckFunc.
+func (*subscription) AckFunc() func() { return nil }

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -296,6 +296,7 @@ type Subscription struct {
 	tracer *oc.Tracer
 	// ackBatcher makes batches of acks and sends them to the server.
 	ackBatcher driver.Batcher
+	ackFunc    func() // if non-nil, used for Ack
 	cancel     func() // for canceling all SendAcks calls
 
 	mu             sync.Mutex    // protects everything below
@@ -441,16 +442,23 @@ func (s *Subscription) getNextBatch(ctx context.Context, nMessages int) ([]*Mess
 			Metadata: m.Metadata,
 			asFunc:   m.AsFunc,
 		}
-		m2.ack = func() {
-			// Note: This call locks s.mu, and m2.mu is locked here as well. Deadlock
-			// will result if Message.Ack is ever called with s.mu held. That
-			// currently cannot happen, but we should be careful if/when implementing
-			// features like auto-ack.
-			s.addProcessingTime(time.Since(m2.processingStartTime))
+		if s.ackFunc == nil {
+			m2.ack = func() {
+				// Note: This call locks s.mu, and m2.mu is locked here as well. Deadlock
+				// will result if Message.Ack is ever called with s.mu held. That
+				// currently cannot happen, but we should be careful if/when implementing
+				// features like auto-ack.
+				s.addProcessingTime(time.Since(m2.processingStartTime))
 
-			// Ignore the error channel. Errors are dealt with
-			// in the ackBatcher handler.
-			_ = s.ackBatcher.AddNoWait(id)
+				// Ignore the error channel. Errors are dealt with
+				// in the ackBatcher handler.
+				_ = s.ackBatcher.AddNoWait(id)
+			}
+		} else {
+			m2.ack = func() {
+				s.addProcessingTime(time.Since(m2.processingStartTime)) // see note above
+				s.ackFunc()
+			}
 		}
 		q = append(q, m2)
 	}
@@ -509,6 +517,7 @@ func newSubscription(ds driver.Subscription, newAckBatcher func(context.Context,
 		newAckBatcher = defaultAckBatcher
 	}
 	s.ackBatcher = newAckBatcher(ctx, s, ds)
+	s.ackFunc = ds.AckFunc()
 	return s
 }
 

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -108,6 +108,8 @@ func (s *driverSub) IsRetryable(error) bool { return false }
 
 func (*driverSub) ErrorCode(error) gcerrors.ErrorCode { return gcerrors.Internal }
 
+func (*driverSub) AckFunc() func() { return nil }
+
 func TestSendReceive(t *testing.T) {
 	ctx := context.Background()
 	ds := NewDriverSub()
@@ -241,6 +243,8 @@ func (b blockingDriverSub) ReceiveBatch(ctx context.Context, maxMessages int) ([
 	return nil, ctx.Err()
 }
 
+func (blockingDriverSub) AckFunc() func() { return nil }
+
 func TestCancelTwoReceives(t *testing.T) {
 	// We want to create the following situation:
 	// 1. Goroutine 1 calls Receive, obtains the lock (Subscription.mu),
@@ -335,6 +339,8 @@ func (t *failSub) ReceiveBatch(ctx context.Context, maxMessages int) ([]*driver.
 
 func (t *failSub) IsRetryable(err error) bool { return isRetryable(err) }
 
+func (*failSub) AckFunc() func() { return nil }
+
 // TODO(jba): add a test for retry of SendAcks.
 
 var errDriver = errors.New("driver error")
@@ -358,6 +364,7 @@ func (erroringSubscription) ReceiveBatch(context.Context, int) ([]*driver.Messag
 func (erroringSubscription) SendAcks(context.Context, []driver.AckID) error { return errDriver }
 func (erroringSubscription) IsRetryable(err error) bool                     { return isRetryable(err) }
 func (erroringSubscription) ErrorCode(error) gcerrors.ErrorCode             { return gcerrors.AlreadyExists }
+func (erroringSubscription) AckFunc() func()                                { return nil }
 
 // TestErrorsAreWrapped tests that all errors returned from the driver are
 // wrapped exactly once by the concrete type.

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -588,3 +588,6 @@ func (s *subscription) As(i interface{}) bool {
 func (*subscription) ErrorAs(err error, target interface{}) bool {
 	return errorAs(err, target)
 }
+
+// AckFunc implements driver.Subscription.AckFunc.
+func (*subscription) AckFunc() func() { return nil }

--- a/pubsub/sub_test.go
+++ b/pubsub/sub_test.go
@@ -43,6 +43,8 @@ func (s *scriptedSub) SendAcks(ctx context.Context, ackIDs []driver.AckID) error
 	return nil
 }
 
+func (*scriptedSub) AckFunc() func() { return nil }
+
 func TestReceiveWithEmptyBatchReturnedFromDriver(t *testing.T) {
 	ctx := context.Background()
 	ds := &scriptedSub{


### PR DESCRIPTION
WIP: TESTS WILL FAIL

This allows providers to communicate whether they support Ack.  If a
provider doesn't, it needs to a provide an alternate implementation of
Ack.

Fixes #1378.