### PR TITLE
all: replace "concrete type" with "portable type" in doc strings

### DIFF
--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -15,12 +15,12 @@
 package azureblob
 
 import (
-	"os"
 	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
@@ -254,7 +254,7 @@ func TestOpenBucket(t *testing.T) {
 			if err == nil && drv != nil && drv.name != test.want {
 				t.Errorf("got %q want %q", drv.name, test.want)
 			}
-			// Create concrete type.
+			// Create portable type.
 			_, err = OpenBucket(ctx, p, test.accountName, test.containerName, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)

--- a/blob/blob_test.go
+++ b/blob/blob_test.go
@@ -213,7 +213,7 @@ func (b *erroringBucket) ErrorCode(err error) gcerrors.ErrorCode {
 }
 
 // TestErrorsAreWrapped tests that all errors returned from the driver are
-// wrapped exactly once by the concrete type.
+// wrapped exactly once by the portable type.
 func TestErrorsAreWrapped(t *testing.T) {
 	ctx := context.Background()
 	buf := bytes.Repeat([]byte{'A'}, sniffLen)

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -66,7 +66,7 @@ type WriterOptions struct {
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Language
 	ContentLanguage string
 	// ContentMD5 is used as a message integrity check.
-	// The concrete type checks that the MD5 hash of the bytes written matches
+	// The portable type checks that the MD5 hash of the bytes written matches
 	// ContentMD5.
 	// If len(ContentMD5) > 0, driver implementations may pass it to their
 	// underlying network service to guarantee the integrity of the bytes in
@@ -115,7 +115,7 @@ type Attributes struct {
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
 	ContentType string
 	// Metadata holds key/value pairs associated with the blob.
-	// Keys will be lowercased by the concrete type before being returned
+	// Keys will be lowercased by the portable type before being returned
 	// to the user. If there are duplicate case-insensitive keys (e.g.,
 	// "foo" and "FOO"), only one value will be kept, and it is undefined
 	// which one.

--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -1313,7 +1313,7 @@ func testCanceledWrite(t *testing.T, newHarness HarnessMaker) {
 		exists      bool
 	}{
 		{
-			// The write will be buffered in the concrete type as part of
+			// The write will be buffered in the portable type as part of
 			// ContentType detection, so the first call to the Driver will be Close.
 			description: "EmptyContentType",
 		},
@@ -1785,7 +1785,7 @@ func testSignedURL(t *testing.T, newHarness HarnessMaker) {
 	b := blob.NewBucket(drv)
 
 	// Verify that a negative Expiry gives an error. This is enforced in the
-	// concrete type, so works regardless of provider support.
+	// portable type, so works regardless of provider support.
 	_, err = b.SignedURL(ctx, key, &blob.SignedURLOptions{Expiry: -1 * time.Minute})
 	if err == nil {
 		t.Error("got nil error, expected error for negative SignedURLOptions.Expiry")

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -265,7 +265,7 @@ func TestOpenBucket(t *testing.T) {
 				t.Errorf("got %q want %q", drv.name, test.want)
 			}
 
-			// Create concrete type.
+			// Create portable type.
 			_, err = OpenBucket(ctx, client, test.bucketName, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -212,7 +212,7 @@ func TestOpenBucket(t *testing.T) {
 				t.Errorf("got %q want %q", drv.name, test.want)
 			}
 
-			// Create concrete type.
+			// Create portable type.
 			_, err = OpenBucket(ctx, sess, test.bucketName, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)

--- a/internal/gcerr/gcerr.go
+++ b/internal/gcerr/gcerr.go
@@ -179,7 +179,7 @@ func GRPCCode(err error) ErrorCode {
 	}
 }
 
-// ErrorAs is a helper for the ErrorAs method of an API's concrete type.
+// ErrorAs is a helper for the ErrorAs method of an API's portable type.
 // It performs some initial nil checks, and does a single level of unwrapping
 // when err is a *gcerr.Error. Then it calls its errorAs argument, which should
 // be a driver implementation of ErrorAs.

--- a/pubsub/mempubsub/mem.go
+++ b/pubsub/mempubsub/mem.go
@@ -77,7 +77,7 @@ func (*topic) IsRetryable(error) bool { return false }
 
 // As implements driver.Topic.As.
 // It supports *topic so that NewSubscription can recover a *topic
-// from the concrete type (see below). External users won't be able
+// from the portable type (see below). External users won't be able
 // to use As because topic isn't exported.
 func (t *topic) As(i interface{}) bool {
 	x, ok := i.(**topic)

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -360,7 +360,7 @@ func (erroringSubscription) IsRetryable(err error) bool                     { re
 func (erroringSubscription) ErrorCode(error) gcerrors.ErrorCode             { return gcerrors.AlreadyExists }
 
 // TestErrorsAreWrapped tests that all errors returned from the driver are
-// wrapped exactly once by the concrete type.
+// wrapped exactly once by the portable type.
 func TestErrorsAreWrapped(t *testing.T) {
 	ctx := context.Background()
 	top := pubsub.NewTopic(erroringTopic{}, nil)

--- a/runtimevar/driver/driver.go
+++ b/runtimevar/driver/driver.go
@@ -80,7 +80,7 @@ type Watcher interface {
 	// WatchVariable returns the current State of the variable.
 	// If the State has not changed, it returns nil.
 	//
-	// If WatchVariable returns a wait time > 0, the concrete type uses
+	// If WatchVariable returns a wait time > 0, the portable type uses
 	// it as a hint to not call WatchVariable again for the wait time.
 	//
 	// Implementations *may* block, but must return if ctx is Done. If the

--- a/runtimevar/filevar/filevar_test.go
+++ b/runtimevar/filevar/filevar_test.go
@@ -159,7 +159,7 @@ func TestNew(t *testing.T) {
 				drv.Close()
 			}
 
-			// Create concrete type.
+			// Create portable type.
 			w, err := New(test.path, test.decoder, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)

--- a/runtimevar/runtimevar_test.go
+++ b/runtimevar/runtimevar_test.go
@@ -228,7 +228,7 @@ func (b *erroringWatcher) ErrorCode(err error) gcerrors.ErrorCode {
 }
 
 // TestErrorsAreWrapped tests that all errors returned from the driver are
-// wrapped exactly once by the concrete type.
+// wrapped exactly once by the portable type.
 func TestErrorsAreWrapped(t *testing.T) {
 	ctx := context.Background()
 	v := New(&erroringWatcher{})


### PR DESCRIPTION
updates #1470 