### PR TITLE
docstore: a conformance test for native codecs

### DIFF
--- a/internal/docstore/drivertest/drivertest.go
+++ b/internal/docstore/drivertest/drivertest.go
@@ -39,6 +39,8 @@ type Harness interface {
 // It is called exactly once per test; Harness.Close() will be called when the test is complete.
 type HarnessMaker func(ctx context.Context, t *testing.T) (Harness, error)
 
+// CodecTester describes functions that encode and decode values using both the
+// docstore codec for a provider, and that provider's own "native" codec.
 type CodecTester interface {
 	NativeEncode(interface{}) (interface{}, error)
 	NativeDecode(value, dest interface{}) error

--- a/internal/docstore/memdocstore/mem_test.go
+++ b/internal/docstore/memdocstore/mem_test.go
@@ -35,5 +35,6 @@ func (h *harness) MakeCollection(context.Context) (driver.Collection, error) {
 func (h *harness) Close() {}
 
 func TestConformance(t *testing.T) {
-	drivertest.RunConformanceTests(t, newHarness)
+	// CodecTester is nil because memdocstore has no native representation.
+	drivertest.RunConformanceTests(t, newHarness, nil)
 }


### PR DESCRIPTION
Preliminary version of a test that checks that the docstore encoding
of values interoperates with a provider's native encoding.

See #1477.