### PR TITLE
pubsub: fix typo

### DIFF
--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -18,7 +18,7 @@
 //
 // As
 //
-// gcspubsub exposes the following types for As:
+// gcppubsub exposes the following types for As:
 //  - Topic: *raw.PublisherClient
 //  - Subscription: *raw.SubscriberClient
 //  - Message: *pb.PubsubMessage

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -16,7 +16,7 @@
 // subscribe systems.
 //
 // Subpackages contain distinct implementations of pubsub for various providers,
-// including Cloud and on-prem solutions. For example, "gcspubsub" supports
+// including Cloud and on-prem solutions. For example, "gcppubsub" supports
 // Google Cloud Pub/Sub. Your application should import one of these
 // provider-specific subpackages and use its exported functions to get a
 // *Topic and/or *Subscription; do not use the NewTopic/NewSubscription


### PR DESCRIPTION
Fix `gcspubsub` to `gcppubsub`
