### PR TITLE
runtimevar: mark closed before shutting down background goroutine to avoid race

### DIFF
--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -280,10 +280,6 @@ func (c *Variable) Latest(ctx context.Context) (Snapshot, error) {
 
 // Close closes the Variable. The Variable is unusable after Close returns.
 func (c *Variable) Close() error {
-	// Shut down the background goroutine.
-	c.backgroundCancel()
-	<-c.backgroundDone
-
 	// Record that we're closing. Subsequent calls to Watch/Latest will return ErrClosed.
 	c.mu.Lock()
 	if c.lastErr == ErrClosed {
@@ -302,6 +298,10 @@ func (c *Variable) Close() error {
 		close(c.haveGood)
 	}
 	c.mu.Unlock()
+
+	// Shut down the background goroutine.
+	c.backgroundCancel()
+	<-c.backgroundDone
 
 	// Close the driver.
 	err := c.dw.Close()


### PR DESCRIPTION
Fixes #996 