### PR TITLE
docstore: support special cases in codec

### DIFF
--- a/internal/docstore/driver/codec.go
+++ b/internal/docstore/driver/codec.go
@@ -90,12 +90,10 @@ type Encoder interface {
 	EncodeMap(n int) Encoder
 	MapKey(string)
 
-	// If the encoder wants to encode a struct in a special way (other than as a map
-	// from its exported fields to values), it should do so here and return true along
-	// with any error from the encoding.
-	// Otherwise, it should return false.
-	// s is the reflection of a struct.
-	EncodeStruct(s reflect.Value) (bool, error)
+	// If the encoder wants to encode a value in a special way it should do so here
+	// and return true along with any error from the encoding. Otherwise, it should
+	// return false.
+	EncodeSpecial(v reflect.Value) (bool, error)
 }
 
 // Encode encodes the value using the given Encoder. It traverses the value,
@@ -123,6 +121,10 @@ func encode(v reflect.Value, enc Encoder) error {
 	if !v.IsValid() {
 		enc.EncodeNil()
 		return nil
+	}
+	didIt, err := enc.EncodeSpecial(v)
+	if didIt {
+		return err
 	}
 	if v.Type().Implements(binaryMarshalerType) {
 		bytes, err := v.Interface().(encoding.BinaryMarshaler).MarshalBinary()
@@ -189,7 +191,11 @@ func encode(v reflect.Value, enc Encoder) error {
 		return encode(v.Elem(), enc)
 
 	case reflect.Struct:
-		return encodeStruct(v, enc)
+		fields, err := fieldCache.Fields(v.Type())
+		if err != nil {
+			return err
+		}
+		return encodeStructWithFields(v, fields, enc)
 
 	default:
 		return gcerr.Newf(gcerr.InvalidArgument, nil, "cannot encode type %s", v.Type())
@@ -259,18 +265,6 @@ func stringifyMapKey(k reflect.Value) (string, error) {
 	default:
 		return "", gcerr.Newf(gcerr.InvalidArgument, nil, "cannot encode key %s of type %s", k, k.Type())
 	}
-}
-
-func encodeStruct(v reflect.Value, e Encoder) error {
-	didIt, err := e.EncodeStruct(v)
-	if didIt {
-		return err
-	}
-	fields, err := fieldCache.Fields(v.Type())
-	if err != nil {
-		return err
-	}
-	return encodeStructWithFields(v, fields, e)
 }
 
 func encodeStructWithFields(v reflect.Value, fields fields.List, e Encoder) error {
@@ -357,6 +351,11 @@ type Decoder interface {
 	// AsInterface should decode the value into the Go value that best represents it.
 	AsInterface() (interface{}, error)
 
+	// If the decoder wants to decode a value in a special way it should do so here
+	// and return true, the decoded value, and any error from the decoding.
+	// Otherwise, it should return false.
+	AsSpecial(reflect.Value) (bool, interface{}, error)
+
 	// String should return a human-readable representation of the Decoder, for error messages.
 	String() string
 }
@@ -380,6 +379,11 @@ func decode(v reflect.Value, d Decoder) error {
 			v.Set(reflect.Zero(v.Type()))
 			return nil
 		}
+	}
+
+	if done, val, err := d.AsSpecial(v); done {
+		v.Set(reflect.ValueOf(val))
+		return err
 	}
 
 	// Handle implemented interfaces first.

--- a/internal/docstore/driver/codec.go
+++ b/internal/docstore/driver/codec.go
@@ -122,8 +122,8 @@ func encode(v reflect.Value, enc Encoder) error {
 		enc.EncodeNil()
 		return nil
 	}
-	didIt, err := enc.EncodeSpecial(v)
-	if didIt {
+	done, err := enc.EncodeSpecial(v)
+	if done {
 		return err
 	}
 	if v.Type().Implements(binaryMarshalerType) {

--- a/internal/docstore/driver/codec_test.go
+++ b/internal/docstore/driver/codec_test.go
@@ -200,7 +200,7 @@ func (e *testEncoder) EncodeBytes(x []byte)       { e.val = x }
 var typeOfSpecial = reflect.TypeOf(special(0))
 
 func (e *testEncoder) EncodeSpecial(v reflect.Value) (bool, error) {
-	// time.Time would normally encode as a []byte, because it implements BinaryMarshaler.
+	// special would normally encode as a []byte, because it implements BinaryMarshaler.
 	// Encode it as an int instead.
 	if v.Type() == typeOfSpecial {
 		e.val = int(v.Interface().(special))

--- a/internal/docstore/driver/codec_test.go
+++ b/internal/docstore/driver/codec_test.go
@@ -43,6 +43,11 @@ func (e *te) UnmarshalText(b []byte) error {
 	return nil
 }
 
+type special int
+
+func (special) MarshalBinary() ([]byte, error) { panic("should never be called") }
+func (*special) UnmarshalBinary([]byte) error  { panic("should never be called") }
+
 type Embed1 struct {
 	E1 string
 }
@@ -119,6 +124,7 @@ func TestEncode(t *testing.T) {
 		{tm, tmb},
 		{ts, tsb},
 		{te{'A'}, "A"},
+		{special(17), 17},
 		{myString("x"), "x"},
 		{[]myString{"x"}, []interface{}{"x"}},
 		{map[myString]myString{"a": "x"}, map[string]interface{}{"a": "x"}},
@@ -173,7 +179,7 @@ func TestEncode(t *testing.T) {
 		}
 		got := enc.val
 		if diff := cmp.Diff(got, test.want); diff != "" {
-			t.Errorf("%#v: %s", test.in, diff)
+			t.Errorf("%#v (got=-, want=+):\n%s", test.in, diff)
 		}
 	}
 }
@@ -191,7 +197,15 @@ func (e *testEncoder) EncodeFloat(x float64)      { e.val = x }
 func (e *testEncoder) EncodeComplex(x complex128) { e.val = x }
 func (e *testEncoder) EncodeBytes(x []byte)       { e.val = x }
 
-func (e *testEncoder) EncodeStruct(reflect.Value) (bool, error) {
+var typeOfSpecial = reflect.TypeOf(special(0))
+
+func (e *testEncoder) EncodeSpecial(v reflect.Value) (bool, error) {
+	// time.Time would normally encode as a []byte, because it implements BinaryMarshaler.
+	// Encode it as an int instead.
+	if v.Type() == typeOfSpecial {
+		e.val = int(v.Interface().(special))
+		return true, nil
+	}
 	return false, nil
 }
 
@@ -258,6 +272,7 @@ func TestDecode(t *testing.T) {
 		{new([]byte), []byte("foo"), []byte("foo")},
 		{new([]string), []interface{}{"a", "b"}, []string{"a", "b"}},
 		{new([]**bool), []interface{}{true, false}, []**bool{&ptru, &pfa}},
+		{new(special), 17, special(17)},
 		{
 			new(map[string]string),
 			map[string]interface{}{"a": "b"},
@@ -433,4 +448,11 @@ func (d testDecoder) DecodeMap(f func(key string, vd Decoder) bool) {
 }
 func (d testDecoder) AsInterface() (interface{}, error) {
 	return d.val, nil
+}
+
+func (d testDecoder) AsSpecial(v reflect.Value) (bool, interface{}, error) {
+	if v.Type() == typeOfSpecial {
+		return true, special(d.val.(int)), nil
+	}
+	return false, nil, nil
 }

--- a/internal/docstore/memdocstore/codec.go
+++ b/internal/docstore/memdocstore/codec.go
@@ -34,17 +34,17 @@ type encoder struct {
 	val interface{}
 }
 
-func (e *encoder) EncodeNil()                                 { e.val = nil }
-func (e *encoder) EncodeBool(x bool)                          { e.val = x }
-func (e *encoder) EncodeInt(x int64)                          { e.val = x }
-func (e *encoder) EncodeUint(x uint64)                        { e.val = int64(x) }
-func (e *encoder) EncodeBytes(x []byte)                       { e.val = x }
-func (e *encoder) EncodeFloat(x float64)                      { e.val = x }
-func (e *encoder) EncodeComplex(x complex128)                 { e.val = x }
-func (e *encoder) EncodeString(x string)                      { e.val = x }
-func (e *encoder) ListIndex(int)                              { panic("impossible") }
-func (e *encoder) MapKey(string)                              { panic("impossible") }
-func (e *encoder) EncodeStruct(s reflect.Value) (bool, error) { return false, nil } // no special struct handling
+func (e *encoder) EncodeNil()                                { e.val = nil }
+func (e *encoder) EncodeBool(x bool)                         { e.val = x }
+func (e *encoder) EncodeInt(x int64)                         { e.val = x }
+func (e *encoder) EncodeUint(x uint64)                       { e.val = int64(x) }
+func (e *encoder) EncodeBytes(x []byte)                      { e.val = x }
+func (e *encoder) EncodeFloat(x float64)                     { e.val = x }
+func (e *encoder) EncodeComplex(x complex128)                { e.val = x }
+func (e *encoder) EncodeString(x string)                     { e.val = x }
+func (e *encoder) ListIndex(int)                             { panic("impossible") }
+func (e *encoder) MapKey(string)                             { panic("impossible") }
+func (e *encoder) EncodeSpecial(reflect.Value) (bool, error) { return false, nil } // no special handling
 
 func (e *encoder) EncodeList(n int) driver.Encoder {
 	// All slices and arrays are encoded as []interface{}
@@ -159,4 +159,8 @@ func (d decoder) DecodeMap(f func(key string, d2 driver.Decoder) bool) {
 			return
 		}
 	}
+}
+
+func (decoder) AsSpecial(reflect.Value) (bool, interface{}, error) {
+	return false, nil, nil
 }


### PR DESCRIPTION
Add Encoder.EncodeSpecial and Decoder.AsSpecial methods to
support special-case encoding and decoding.

Remove Encoder.EncodeStruct.