### PR TITLE
travis: use -mod=readonly when invoking Go

### DIFF
--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -31,7 +31,7 @@ result=0
 # Run Go tests for the root. Only do coverage for the Linux build
 # because it is slow, and codecov will only save the last one anyway.
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  go test -race -coverpkg=./... -coverprofile=coverage.out ./... || result=1
+  go test -mod=readonly -race -coverpkg=./... -coverprofile=coverage.out ./... || result=1
   if [ -f coverage.out ] && [ $result -eq 0 ]; then
     # Filter out test and sample packages.
     grep -v test coverage.out | grep -v samples > coverage2.out
@@ -39,7 +39,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     bash <(curl -s https://codecov.io/bash)
   fi
 else
-  go test -race ./... || result=1
+  go test -mod=readonly -race ./... || result=1
   # No need to run wire checks or other module tests on OSs other than linux.
   exit $result
 fi
@@ -59,7 +59,7 @@ wire diff ./... || { echo "FAIL: wire diff found diffs!" && result=1; }
 
 # Run Go tests for each additional module, without coverage.
 for path in "./internal/contributebot" "./samples/appengine"; do
-  ( cd "$path" && exec go test ./... ) || result=1
+  ( cd "$path" && exec go test -mod=readonly ./... ) || result=1
   ( cd "$path" && exec wire check ./... ) || result=1
   ( cd "$path" && exec wire diff ./... ) || (echo "FAIL: wire diff found diffs!" && result=1)
 done


### PR DESCRIPTION
As per [Maintaining module requirements][1], the recommended way of running `go test` in CI is with `-mod=readonly`. This causes the `go` command to fail if a new dependency was added without adding to go.mod.

(I happened to stumble across this recommendation from @rsc in an unrelated [thread on golang-dev][2].)

[1]: https://golang.org/cmd/go/#hdr-Maintaining_module_requirements
[2]: https://groups.google.com/d/msg/golang-dev/DD88cds-LuI/GiyP3Hf2BgAJ