### PR TITLE
all: use a single interface for URLOpeners

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -101,7 +101,7 @@ const (
 )
 
 func init() {
-	blob.DefaultURLMux().RegisterBucket(Scheme, new(lazyCredsOpener))
+	blob.DefaultURLMux().Register(Scheme, new(lazyCredsOpener))
 }
 
 // lazyCredsOpener obtains credentials from the environment on the first call

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -854,12 +854,12 @@ type WriterOptions struct {
 	BeforeWrite func(asFunc func(interface{}) bool) error
 }
 
-// BucketURLOpener represents types that can open buckets based on a URL.
+// URLOpener represents types that can open Buckets based on a URL.
 // The opener must not modify the URL argument. OpenBucketURL must be safe to
 // call from multiple goroutines.
 //
 // This interface is generally implemented by types in driver packages.
-type BucketURLOpener interface {
+type URLOpener interface {
 	OpenBucketURL(ctx context.Context, u *url.URL) (*Bucket, error)
 }
 
@@ -872,10 +872,10 @@ type URLMux struct {
 	schemes openurl.SchemeMap
 }
 
-// RegisterBucket registers the opener with the given scheme. If an opener
-// already exists for the scheme, RegisterBucket panics.
-func (mux *URLMux) RegisterBucket(scheme string, opener BucketURLOpener) {
-	mux.schemes.Register("blob", "Bucket", scheme, opener)
+// Register registers the opener with the given scheme. If an opener
+// already exists for the scheme, Register panics.
+func (mux *URLMux) Register(scheme string, opener URLOpener) {
+	mux.schemes.Register("blob", scheme, opener)
 }
 
 // OpenBucket calls OpenBucketURL with the URL parsed from urlstr.
@@ -885,7 +885,7 @@ func (mux *URLMux) OpenBucket(ctx context.Context, urlstr string) (*Bucket, erro
 	if err != nil {
 		return nil, err
 	}
-	return opener.(BucketURLOpener).OpenBucketURL(ctx, u)
+	return opener.(URLOpener).OpenBucketURL(ctx, u)
 }
 
 // OpenBucketURL dispatches the URL to the opener that is registered with the
@@ -895,14 +895,14 @@ func (mux *URLMux) OpenBucketURL(ctx context.Context, u *url.URL) (*Bucket, erro
 	if err != nil {
 		return nil, err
 	}
-	return opener.(BucketURLOpener).OpenBucketURL(ctx, u)
+	return opener.(URLOpener).OpenBucketURL(ctx, u)
 }
 
 var defaultURLMux = new(URLMux)
 
 // DefaultURLMux returns the URLMux used by OpenBucket.
 //
-// Driver packages can use this to register their BucketURLOpener on the mux.
+// Driver packages can use this to register their URLOpener on the mux.
 func DefaultURLMux() *URLMux {
 	return defaultURLMux
 }

--- a/blob/blob_test.go
+++ b/blob/blob_test.go
@@ -294,12 +294,12 @@ func TestURLMux(t *testing.T) {
 
 	mux := new(URLMux)
 	// Register scheme foo to always return nil. Sets got as a side effect
-	mux.RegisterBucket("foo", bucketURLOpenFunc(func(_ context.Context, u *url.URL) (*Bucket, error) {
+	mux.Register("foo", bucketURLOpenFunc(func(_ context.Context, u *url.URL) (*Bucket, error) {
 		got = u
 		return nil, nil
 	}))
 	// Register scheme err to always return an error.
-	mux.RegisterBucket("err", bucketURLOpenFunc(func(_ context.Context, u *url.URL) (*Bucket, error) {
+	mux.Register("err", bucketURLOpenFunc(func(_ context.Context, u *url.URL) (*Bucket, error) {
 		return nil, errors.New("fail")
 	}))
 

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -65,7 +65,7 @@ import (
 const defaultPageSize = 1000
 
 func init() {
-	blob.DefaultURLMux().RegisterBucket(Scheme, &URLOpener{})
+	blob.DefaultURLMux().Register(Scheme, &URLOpener{})
 }
 
 // Scheme is the URL scheme fileblob registers its URLOpener under on

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -71,7 +71,7 @@ import (
 const defaultPageSize = 1000
 
 func init() {
-	blob.DefaultURLMux().RegisterBucket(Scheme, new(lazyCredsOpener))
+	blob.DefaultURLMux().Register(Scheme, new(lazyCredsOpener))
 }
 
 // lazyCredsOpener obtains Application Default Credentials on the first call

--- a/blob/memblob/memblob.go
+++ b/blob/memblob/memblob.go
@@ -52,7 +52,7 @@ var (
 )
 
 func init() {
-	blob.DefaultURLMux().RegisterBucket(Scheme, &URLOpener{})
+	blob.DefaultURLMux().Register(Scheme, &URLOpener{})
 }
 
 // Scheme is the URL scheme memblob registers its URLOpener under on

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -79,7 +79,7 @@ import (
 const defaultPageSize = 1000
 
 func init() {
-	blob.DefaultURLMux().RegisterBucket(Scheme, new(lazySessionOpener))
+	blob.DefaultURLMux().Register(Scheme, new(lazySessionOpener))
 }
 
 // URLOpener opens S3 URLs like "s3://mybucket".

--- a/internal/openurl/openurl.go
+++ b/internal/openurl/openurl.go
@@ -28,14 +28,13 @@ type SchemeMap map[string]interface{}
 // api is the portable API name (e.g., "blob") and typ is the portable type
 // (e.g., "Bucket").
 // Register panics if scheme has already been registered.
-// TODO(rvangent): Remove typ from here and use a single URLOpener per API.
 // TODO(rvangent): Remove api from the From* functions by storing it in the map in Register.
-func (m *SchemeMap) Register(api, typ, scheme string, value interface{}) {
+func (m *SchemeMap) Register(api, scheme string, value interface{}) {
 	if *m == nil {
 		*m = map[string]interface{}{}
 	}
 	if _, exists := (*m)[scheme]; exists {
-		panic(fmt.Errorf("scheme %q already registered for %s.%s", scheme, api, typ))
+		panic(fmt.Errorf("scheme %q already registered for %s", scheme, api))
 	}
 	(*m)[scheme] = value
 }

--- a/internal/openurl/openurl_test.go
+++ b/internal/openurl/openurl_test.go
@@ -33,8 +33,8 @@ func TestSchemeMap(t *testing.T) {
 	}
 
 	var emptyM, m openurl.SchemeMap
-	m.Register("api", "type", "foo", foo)
-	m.Register("api", "type", "bar", bar)
+	m.Register("api", "foo", foo)
+	m.Register("api", "bar", bar)
 
 	for _, test := range tests {
 		// Empty SchemeMap should always return an error.
@@ -56,5 +56,4 @@ func TestSchemeMap(t *testing.T) {
 			t.Errorf("%s: got %v want %v", test.url, got, test.want)
 		}
 	}
-
 }

--- a/runtimevar/blobvar/blobvar.go
+++ b/runtimevar/blobvar/blobvar.go
@@ -52,7 +52,7 @@ import (
 )
 
 func init() {
-	runtimevar.DefaultURLMux().RegisterVariable(Scheme, &URLOpener{Mux: blob.DefaultURLMux()})
+	runtimevar.DefaultURLMux().Register(Scheme, &URLOpener{Mux: blob.DefaultURLMux()})
 }
 
 // Scheme is the URL scheme blobvar registers its URLOpener under on runtimevar.DefaultMux.

--- a/runtimevar/constantvar/constantvar.go
+++ b/runtimevar/constantvar/constantvar.go
@@ -48,7 +48,7 @@ import (
 )
 
 func init() {
-	runtimevar.DefaultURLMux().RegisterVariable(Scheme, &URLOpener{})
+	runtimevar.DefaultURLMux().Register(Scheme, &URLOpener{})
 }
 
 // Scheme is the URL scheme constantvar registers its URLOpener under on blob.DefaultMux.

--- a/runtimevar/etcdvar/etcdvar.go
+++ b/runtimevar/etcdvar/etcdvar.go
@@ -52,7 +52,7 @@ import (
 )
 
 func init() {
-	runtimevar.DefaultURLMux().RegisterVariable(Scheme, &lazyClientOpener{})
+	runtimevar.DefaultURLMux().Register(Scheme, &lazyClientOpener{})
 }
 
 // Scheme is the URL scheme etcdvar registers its URLOpener under on runtimevar.DefaultMux.

--- a/runtimevar/filevar/filevar.go
+++ b/runtimevar/filevar/filevar.go
@@ -56,7 +56,7 @@ import (
 )
 
 func init() {
-	runtimevar.DefaultURLMux().RegisterVariable(Scheme, &URLOpener{})
+	runtimevar.DefaultURLMux().Register(Scheme, &URLOpener{})
 }
 
 // Scheme is the URL scheme filevar registers its URLOpener under on runtimevar.DefaultMux.

--- a/runtimevar/paramstore/paramstore.go
+++ b/runtimevar/paramstore/paramstore.go
@@ -51,7 +51,7 @@ import (
 )
 
 func init() {
-	runtimevar.DefaultURLMux().RegisterVariable(Scheme, new(lazySessionOpener))
+	runtimevar.DefaultURLMux().Register(Scheme, new(lazySessionOpener))
 }
 
 // URLOpener opens AWS Paramstore URLs like "paramstore://myvar".

--- a/runtimevar/runtimeconfigurator/runtimeconfigurator.go
+++ b/runtimevar/runtimeconfigurator/runtimeconfigurator.go
@@ -81,7 +81,7 @@ func Dial(ctx context.Context, ts gcp.TokenSource) (pb.RuntimeConfigManagerClien
 }
 
 func init() {
-	runtimevar.DefaultURLMux().RegisterVariable(Scheme, new(lazyCredsOpener))
+	runtimevar.DefaultURLMux().Register(Scheme, new(lazyCredsOpener))
 }
 
 // lazyCredsOpener obtains Application Default Credentials on the first call

--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -346,12 +346,12 @@ func (c *Variable) ErrorAs(err error, i interface{}) bool {
 	return gcerr.ErrorAs(err, i, c.dw.ErrorAs)
 }
 
-// VariableURLOpener represents types than can open Variables based on a URL.
+// URLOpener represents types than can open Variables based on a URL.
 // The opener must not modify the URL argument. OpenVariableURL must be safe to
 // call from multiple goroutines.
 //
 // This interface is generally implemented by types in driver packages.
-type VariableURLOpener interface {
+type URLOpener interface {
 	OpenVariableURL(ctx context.Context, u *url.URL) (*Variable, error)
 }
 
@@ -364,10 +364,10 @@ type URLMux struct {
 	schemes openurl.SchemeMap
 }
 
-// RegisterVariable registers the opener with the given scheme. If an opener
-// already exists for the scheme, RegisterVariable panics.
-func (mux *URLMux) RegisterVariable(scheme string, opener VariableURLOpener) {
-	mux.schemes.Register("runtimevar", "Variable", scheme, opener)
+// Register registers the opener with the given scheme. If an opener
+// already exists for the scheme, Register panics.
+func (mux *URLMux) Register(scheme string, opener URLOpener) {
+	mux.schemes.Register("runtimevar", scheme, opener)
 }
 
 // OpenVariable calls OpenVariableURL with the URL parsed from urlstr.
@@ -377,7 +377,7 @@ func (mux *URLMux) OpenVariable(ctx context.Context, urlstr string) (*Variable, 
 	if err != nil {
 		return nil, err
 	}
-	return opener.(VariableURLOpener).OpenVariableURL(ctx, u)
+	return opener.(URLOpener).OpenVariableURL(ctx, u)
 }
 
 // OpenVariableURL dispatches the URL to the opener that is registered with the
@@ -387,14 +387,14 @@ func (mux *URLMux) OpenVariableURL(ctx context.Context, u *url.URL) (*Variable, 
 	if err != nil {
 		return nil, err
 	}
-	return opener.(VariableURLOpener).OpenVariableURL(ctx, u)
+	return opener.(URLOpener).OpenVariableURL(ctx, u)
 }
 
 var defaultURLMux = new(URLMux)
 
 // DefaultURLMux returns the URLMux used by OpenVariable.
 //
-// Driver packages can use this to register their VariableURLOpener on the mux.
+// Driver packages can use this to register their URLOpener on the mux.
 func DefaultURLMux() *URLMux {
 	return defaultURLMux
 }
@@ -477,7 +477,7 @@ func bytesDecode(b []byte, obj interface{}) error {
 }
 
 // DecoderByName returns a *Decoder based on decoderName.
-// It is intended to be used by VariableURLOpeners in driver packages.
+// It is intended to be used by URLOpeners in driver packages.
 // Supported values include:
 //   - (empty string), "bytes": Returns the default, BytesDecoder;
 //       Snapshot.Valuewill be of type []byte.

--- a/runtimevar/runtimevar_test.go
+++ b/runtimevar/runtimevar_test.go
@@ -435,12 +435,12 @@ func TestURLMux(t *testing.T) {
 
 	mux := new(URLMux)
 	// Register scheme foo to always return nil. Sets got as a side effect
-	mux.RegisterVariable("foo", variableURLOpenFunc(func(_ context.Context, u *url.URL) (*Variable, error) {
+	mux.Register("foo", variableURLOpenFunc(func(_ context.Context, u *url.URL) (*Variable, error) {
 		got = u
 		return nil, nil
 	}))
 	// Register scheme err to always return an error.
-	mux.RegisterVariable("err", variableURLOpenFunc(func(_ context.Context, u *url.URL) (*Variable, error) {
+	mux.Register("err", variableURLOpenFunc(func(_ context.Context, u *url.URL) (*Variable, error) {
 		return nil, errors.New("fail")
 	}))
 

--- a/secrets/awskms/kms.go
+++ b/secrets/awskms/kms.go
@@ -52,7 +52,7 @@ import (
 )
 
 func init() {
-	secrets.DefaultURLMux().RegisterKeeper(Scheme, new(lazySessionOpener))
+	secrets.DefaultURLMux().Register(Scheme, new(lazySessionOpener))
 }
 
 // Dial gets an AWS KMS service client.

--- a/secrets/azurekeyvault/akv.go
+++ b/secrets/azurekeyvault/akv.go
@@ -65,7 +65,7 @@ var (
 )
 
 func init() {
-	secrets.DefaultURLMux().RegisterKeeper(Scheme, new(lazyDialer))
+	secrets.DefaultURLMux().Register(Scheme, new(lazyDialer))
 }
 
 // URLOpener opens secrets.Keeper URLs for Azure KeyVault, like

--- a/secrets/gcpkms/kms.go
+++ b/secrets/gcpkms/kms.go
@@ -61,7 +61,7 @@ func Dial(ctx context.Context, ts gcp.TokenSource) (*cloudkms.KeyManagementClien
 }
 
 func init() {
-	secrets.DefaultURLMux().RegisterKeeper(Scheme, new(lazyCredsOpener))
+	secrets.DefaultURLMux().Register(Scheme, new(lazyCredsOpener))
 }
 
 // lazyCredsOpener obtains Application Default Credentials on the first call

--- a/secrets/localsecrets/localsecrets.go
+++ b/secrets/localsecrets/localsecrets.go
@@ -44,8 +44,8 @@ import (
 )
 
 func init() {
-	secrets.DefaultURLMux().RegisterKeeper(SchemeString, &URLOpener{})
-	secrets.DefaultURLMux().RegisterKeeper(SchemeBase64, &URLOpener{base64: true})
+	secrets.DefaultURLMux().Register(SchemeString, &URLOpener{})
+	secrets.DefaultURLMux().Register(SchemeBase64, &URLOpener{base64: true})
 }
 
 // SchemeString/SchemeBase64 are the URL schemes localsecrets registers its URLOpener under on secrets.DefaultMux.

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -140,12 +140,12 @@ func wrapError(k *Keeper, err error) error {
 	return gcerr.New(k.k.ErrorCode(err), err, 2, "secrets")
 }
 
-// KeeperURLOpener represents types that can open Keepers based on a URL.
+// URLOpener represents types that can open Keepers based on a URL.
 // The opener must not modify the URL argument. OpenKeeperURL must be safe to
 // call from multiple goroutines.
 //
 // This interface is generally implemented by types in driver packages.
-type KeeperURLOpener interface {
+type URLOpener interface {
 	OpenKeeperURL(ctx context.Context, u *url.URL) (*Keeper, error)
 }
 
@@ -158,10 +158,10 @@ type URLMux struct {
 	schemes openurl.SchemeMap
 }
 
-// RegisterKeeper registers the opener with the given scheme. If an opener
-// already exists for the scheme, RegisterKeeper panics.
-func (mux *URLMux) RegisterKeeper(scheme string, opener KeeperURLOpener) {
-	mux.schemes.Register("secrets", "Keeper", scheme, opener)
+// Register registers the opener with the given scheme. If an opener
+// already exists for the scheme, Register panics.
+func (mux *URLMux) Register(scheme string, opener URLOpener) {
+	mux.schemes.Register("secrets", scheme, opener)
 }
 
 // OpenKeeper calls OpenKeeperURL with the URL parsed from urlstr.
@@ -171,7 +171,7 @@ func (mux *URLMux) OpenKeeper(ctx context.Context, urlstr string) (*Keeper, erro
 	if err != nil {
 		return nil, err
 	}
-	return opener.(KeeperURLOpener).OpenKeeperURL(ctx, u)
+	return opener.(URLOpener).OpenKeeperURL(ctx, u)
 }
 
 // OpenKeeperURL dispatches the URL to the opener that is registered with the
@@ -181,14 +181,14 @@ func (mux *URLMux) OpenKeeperURL(ctx context.Context, u *url.URL) (*Keeper, erro
 	if err != nil {
 		return nil, err
 	}
-	return opener.(KeeperURLOpener).OpenKeeperURL(ctx, u)
+	return opener.(URLOpener).OpenKeeperURL(ctx, u)
 }
 
 var defaultURLMux = new(URLMux)
 
 // DefaultURLMux returns the URLMux used by OpenKeeper.
 //
-// Driver packages can use this to register their KeeperURLOpener on the mux.
+// Driver packages can use this to register their URLOpener on the mux.
 func DefaultURLMux() *URLMux {
 	return defaultURLMux
 }

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -98,12 +98,12 @@ func TestURLMux(t *testing.T) {
 
 	mux := new(URLMux)
 	// Register scheme foo to always return nil. Sets got as a side effect
-	mux.RegisterKeeper("foo", keeperURLOpenFunc(func(_ context.Context, u *url.URL) (*Keeper, error) {
+	mux.Register("foo", keeperURLOpenFunc(func(_ context.Context, u *url.URL) (*Keeper, error) {
 		got = u
 		return nil, nil
 	}))
 	// Register scheme err to always return an error.
-	mux.RegisterKeeper("err", keeperURLOpenFunc(func(_ context.Context, u *url.URL) (*Keeper, error) {
+	mux.Register("err", keeperURLOpenFunc(func(_ context.Context, u *url.URL) (*Keeper, error) {
 		return nil, errors.New("fail")
 	}))
 

--- a/secrets/vault/vault.go
+++ b/secrets/vault/vault.go
@@ -73,7 +73,7 @@ func Dial(ctx context.Context, cfg *Config) (*api.Client, error) {
 }
 
 func init() {
-	secrets.DefaultURLMux().RegisterKeeper(Scheme, new(lazyDialer))
+	secrets.DefaultURLMux().Register(Scheme, new(lazyDialer))
 }
 
 // lazyDialer lazily dials unique Vault servers.


### PR DESCRIPTION
I don't see a real down side to this, as the mux has context in the specific `Open` function about what kind of resource is being opened. It reduces the boilerplate significantly in provider APIs that have multiple openable types.

Drivers that only support a subset of the types can return an error for the ones they don't.

Drivers can even support different schemes for different resources (if they want, I think this is unlikely) by registering multiple `URLOpeners`.

Updates #1174.