### PR TITLE
doc: add documentation for URLs

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -44,10 +44,10 @@ In addition to creating portable types via provider-specific constructors
 can also be created using a URL. The scheme of the URL specifies the provider,
 and each provider implementation has code to convert the URL into the data
 needed to call its constructor. For example, calling blob.OpenBucket with
-"s3blob://my-bucket" will return a blob.Bucket created using s3blob.OpenBucket.
+s3blob://my-bucket will return a blob.Bucket created using s3blob.OpenBucket.
 
 Each portable API package will document the types that it supports opening
-by URL; for example, the "blob" package supports Buckets, while the "pubsub"
+by URL; for example, the blob package supports Buckets, while the pubsub
 package supports Topics and Subscriptions. Each provider implementation will
 document what scheme(s) it registers for, and what format of URL it expects.
 
@@ -58,14 +58,14 @@ many providers will include provider-specific examples as well.
 URL Muxes
 
 Each portable type that's openable via URL will have a top-level function
-you can call, like "blob.OpenBucket". This top-level function uses a default
-instance of an "URLMux" multiplexer to map schemes to a provider-specific
-opener for the type. For example, "blob" has a "BucketURLOpener" interface that
-providers implement and then register using "RegisterBucket".
+you can call, like blob.OpenBucket. This top-level function uses a default
+instance of an URLMux multiplexer to map schemes to a provider-specific
+opener for the type. For example, blob has a BucketURLOpener interface that
+providers implement and then register using RegisterBucket.
 
 Many applications will work just fine using the default mux through the
-top-level "Open" functions. However, if you want more control, you can create
-your own "URLMux" and register the provider URLOpeners you need. Most providers
+top-level Open functions. However, if you want more control, you can create
+your own URLMux and register the provider URLOpeners you need. Most providers
 will export URLOpeners that give you more fine grained control over the
 arguments needed by the constructor. In particular, portable types opened via
 URL will often use default credentials from the environment. For example, the
@@ -73,12 +73,12 @@ AWS URL openers use the credentials saved by "aws login" (we don't want to
 include credentials in the URL itself, since they are likely to be sensitive).
 
   - Instantiate the provider's URLOpener with the specific fields you need.
-    For example, "s3blob.URLOpener{ConfigProvider: myAWSProvider}" using a
+    For example, s3blob.URLOpener{ConfigProvider: myAWSProvider} using a
     ConfigProvider that holds explicit AWS credentials.
-    - Create your own instance of the URLMux, e.g., "mymux := new(blob.URLMux)".
+    - Create your own instance of the URLMux, e.g., mymux := new(blob.URLMux).
   - Register your custom URLOpener on your mux, e.g.,
-    "mymux.RegisterBucket(s3blob.Scheme, myS3URLOpener)".
-  - Now use your mux to open URLs, e.g. "mymux.OpenBucket('s3://my-bucket')".
+    mymux.RegisterBucket(s3blob.Scheme, myS3URLOpener).
+  - Now use your mux to open URLs, e.g. mymux.OpenBucket('s3://my-bucket').
 
 
 Escaping the abstraction

--- a/doc.go
+++ b/doc.go
@@ -75,7 +75,7 @@ include credentials in the URL itself, since they are likely to be sensitive).
   - Instantiate the provider's URLOpener with the specific fields you need.
     For example, s3blob.URLOpener{ConfigProvider: myAWSProvider} using a
     ConfigProvider that holds explicit AWS credentials.
-    - Create your own instance of the URLMux, e.g., mymux := new(blob.URLMux).
+  - Create your own instance of the URLMux, e.g., mymux := new(blob.URLMux).
   - Register your custom URLOpener on your mux, e.g.,
     mymux.RegisterBucket(s3blob.Scheme, myS3URLOpener).
   - Now use your mux to open URLs, e.g. mymux.OpenBucket('s3://my-bucket').

--- a/doc.go
+++ b/doc.go
@@ -20,10 +20,10 @@ seamlessly deploy cloud applications on any combination of cloud providers.
 It does this by providing stable, idiomatic interfaces for common uses like
 storage and databases. Think `database/sql` for cloud products.
 
-At the core of the Go CDK are common types implemented by cloud providers.
-For example, objects of the blob.Bucket type can be created using
-gcsblob.OpenBucket, s3blob.OpenBucket, or any other provider. Then, the
-*blob.Bucket can be used throughout your application without worrying about
+At the core of the Go CDK are common "portable types" implemented by cloud
+providers. For example, objects of the blob.Bucket portable type can be created
+using gcsblob.OpenBucket, s3blob.OpenBucket, or any other provider. Then, the
+blob.Bucket can be used throughout your application without worrying about
 the underlying implementation.
 
 The Go CDK works well with a code generator called Wire
@@ -35,6 +35,50 @@ increasing compile times or binary sizes, and avoiding any side effects from
 
 For sample applications and a tutorial, see the samples directory
 (https://github.com/google/go-cloud/tree/master/samples).
+
+
+URLs
+
+In addition to creating portable types via provider-specific constructors
+(e.g., creating a blob.Bucket using s3blob.OpenBucket), many portable types
+can also be created using a URL. The scheme of the URL specifies the provider,
+and each provider implementation has code to convert the URL into the data
+needed to call its constructor. For example, calling blob.OpenBucket with
+"s3blob://my-bucket" will return a blob.Bucket created using s3blob.OpenBucket.
+
+Each portable API package will document the types that it supports opening
+by URL; for example, the "blob" package supports Buckets, while the "pubsub"
+package supports Topics and Subscriptions. Each provider implementation will
+document what scheme(s) it registers for, and what format of URL it expects.
+
+Each portable API package should also include an example using a URL, and
+many providers will include provider-specific examples as well.
+
+
+URL Muxes
+
+Each portable type that's openable via URL will have a top-level function
+you can call, like "blob.OpenBucket". This top-level function uses a default
+instance of an "URLMux" multiplexer to map schemes to a provider-specific
+opener for the type. For example, "blob" has a "BucketURLOpener" interface that
+providers implement and then register using "RegisterBucket".
+
+Many applications will work just fine using the default mux through the
+top-level "Open" functions. However, if you want more control, you can create
+your own "URLMux" and register the provider URLOpeners you need. Most providers
+will export URLOpeners that give you more fine grained control over the
+arguments needed by the constructor. In particular, portable types opened via
+URL will often use default credentials from the environment. For example, the
+AWS URL openers use the credentials saved by "aws login" (we don't want to
+include credentials in the URL itself, since they are likely to be sensitive).
+
+  - Instantiate the provider's URLOpener with the specific fields you need.
+    For example, "s3blob.URLOpener{ConfigProvider: myAWSProvider}" using a
+    ConfigProvider that holds explicit AWS credentials.
+    - Create your own instance of the URLMux, e.g., "mymux := new(blob.URLMux)".
+  - Register your custom URLOpener on your mux, e.g.,
+    "mymux.RegisterBucket(s3blob.Scheme, myS3URLOpener)".
+  - Now use your mux to open URLs, e.g. "mymux.OpenBucket('s3://my-bucket')".
 
 
 Escaping the abstraction


### PR DESCRIPTION
My plan is to do something similar to what Eli did for "As" -- remove most of the documentation from the actual code and point to here instead, so we can document well once instead of copypasta everywhere.