### PR TITLE
pubsub: ensure that the recorded message processing time is > 0

### DIFF
--- a/internal/testing/replay/replay.go
+++ b/internal/testing/replay/replay.go
@@ -202,6 +202,8 @@ func NewGCPDialOptions(t *testing.T, mode recorder.Mode, filename string) (opts 
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Uncomment for more verbose logging from the replayer.
+	// r.SetLogFunc(t.Logf)
 	opts = r.DialOptions()
 	done = func() {
 		if err := r.Close(); err != nil {

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -317,6 +317,11 @@ const (
 
 // Add message processing time d to the weighted moving average.
 func (s *Subscription) addProcessingTime(d time.Duration) {
+	// Ensure d is non-zero; on some platforms, the granularity of time.Time
+	// isn't small enough to capture very fast message processing times.
+	if d == 0 {
+		d = 1 * time.Nanosecond
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.avgProcessTime == 0 {


### PR DESCRIPTION
Fixes #1525.