### PR TITLE
travis: only go-get wire on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ install:
   # converting \n to \r\n.
   - "git config --global core.autocrlf input"
   - "git checkout -- ."
-  - "go install github.com/google/wire/cmd/wire"
+  # We only use "wire" on linux.
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      go install github.com/google/wire/cmd/wire;
+    fi
 
 script:
   - 'internal/testing/runchecks.sh'


### PR DESCRIPTION
We only use Wire on linux, per `runchecks.sh`, so there's no point in "go get"ing it on other platforms.