### PR TITLE
travis: add a check for incompatible API changes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -699,6 +699,7 @@ golang.org/x/tools v0.0.0-20181017214349-06f26fdaaa28/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20181030000716-a0a13e073c7b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181221154417-3ad2d988d5e2/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190226205152-f727befe758c h1:vamGzbGri8IKo20MQncCuljcQ5uAO6kaCeawQPVblAI=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/xerrors v0.0.0-20190129162528-20feca13ea86 h1:kMgZCSynBSIN3PHpvuFeMExQwPWtUZ/xfnt2Yr2cp20=
 golang.org/x/xerrors v0.0.0-20190129162528-20feca13ea86/go.mod h1:/lyp46tcDBI65C0XC8F4d0/XVb7MT7RScVRech7dX/4=

--- a/internal/testing/check_api_change.sh
+++ b/internal/testing/check_api_change.sh
@@ -25,7 +25,7 @@ echo
 
 go install -mod=readonly golang.org/x/exp/cmd/apidiff
 
-MASTER_CLONE_DIR="/tmp/go-cloud"
+MASTER_CLONE_DIR="$(mktemp -d)"
 PKGINFO_BRANCH=$(mktemp)
 PKGINFO_MASTER=$(mktemp)
 
@@ -52,9 +52,7 @@ for pkg in ${PKGS}; do
   apidiff -w ${PKGINFO_BRANCH} ${pkg}
 
   # Compute export data for master@HEAD.
-  cd ${MASTER_CLONE_DIR}
-  apidiff -w ${PKGINFO_MASTER} ${pkg}
-  cd - > /dev/null
+  (cd ${MASTER_CLONE_DIR}; apidiff -w ${PKGINFO_MASTER} ${pkg})
 
   # Print all changes for posterity.
   apidiff ${PKGINFO_MASTER} ${PKGINFO_BRANCH}

--- a/internal/testing/check_api_change.sh
+++ b/internal/testing/check_api_change.sh
@@ -15,8 +15,8 @@
 
 # This script checks to see if there are any incompatible API changes on the
 # current branch relative to master@HEAD.
-# It fails if it finds any, unless there is a commit message with
-# BREAKING_CHANGE_OK in it.
+# It fails if it finds any, unless there is a commit with BREAKING_CHANGE_OK
+# in the first line of the commit message.
 
 set -euo pipefail
 
@@ -80,6 +80,6 @@ if git cherry -v master | grep -q "BREAKING_CHANGE_OK"; then
   exit 0;
 fi
 
-echo "FAIL. If this is expected and OK, you can pass this check by adding a commit message with BREAKING_CHANGE_OK in it."
+echo "FAIL. If this is expected and OK, you can pass this check by adding a commit with BREAKING_CHANGE_OK in the first line of the message."
 exit 1
 

--- a/internal/testing/check_api_change.sh
+++ b/internal/testing/check_api_change.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Go Cloud Development Kit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script checks to see if there are any incompatible API changes on the
+# current branch relative to master@HEAD.
+# It fails if it finds any, unless there is a commit message with
+# BREAKING_CHANGE_OK in it.
+
+set -euo pipefail
+
+echo "Checking for incompatible API changes relative to master@HEAD..."
+echo
+
+go install -mod=readonly golang.org/x/exp/cmd/apidiff
+
+MASTER_CLONE_DIR="/tmp/go-cloud"
+PKGINFO_BRANCH=$(mktemp)
+PKGINFO_MASTER=$(mktemp)
+
+function cleanup() {
+  rm -rf ${MASTER_CLONE_DIR}
+  rm -f ${PKGINFO_BRANCH}
+  rm -f ${PKGINFO_MASTER}
+}
+trap cleanup EXIT
+
+# We compare against master@HEAD. This is unfortunate in some cases: if you're
+# working on an out-of-date branch, and master gets some new feature (that has
+# nothing to do with your work on your branch), you'll get an error message.
+# Thankfully the fix is quite simple: rebase your branch.
+git clone https://github.com/google/go-cloud ${MASTER_CLONE_DIR}
+echo
+
+incompatible_change_pkgs=()
+PKGS=$(go list ./... | grep -v internal | grep -v test | grep -v samples)
+for pkg in ${PKGS}; do
+  echo "Testing ${pkg}..."
+
+  # Compute export data for the current branch.
+  apidiff -w ${PKGINFO_BRANCH} ${pkg}
+
+  # Compute export data for master@HEAD.
+  cd ${MASTER_CLONE_DIR}
+  apidiff -w ${PKGINFO_MASTER} ${pkg}
+  cd - > /dev/null
+
+  # Print all changes for posterity.
+  apidiff ${PKGINFO_MASTER} ${PKGINFO_BRANCH}
+
+  # Note if there's an incompatible change.
+  ic=$(apidiff -incompatible ${PKGINFO_MASTER} ${PKGINFO_BRANCH})
+  if [ ! -z "${ic}" ]; then
+    incompatible_change_pkgs+=(${pkg});
+  fi
+done
+echo
+
+if [ ${#incompatible_change_pkgs[@]} -eq 0 ]; then
+  # No incompatible changes, we are good.
+  echo "OK: No incompatible changes found."
+  exit 0;
+fi
+echo "Found breaking API change(s) in: ${incompatible_change_pkgs[@]}."
+
+# Found incompatible changes; see if they were declared as OK via a commit.
+if git cherry -v master | grep -q "BREAKING_CHANGE_OK"; then
+  echo "Allowing them due to a commit message with BREAKING_CHANGE_OK.";
+  exit 0;
+fi
+
+echo "FAIL. If this is expected and OK, you can pass this check by adding a commit message with BREAKING_CHANGE_OK in it."
+exit 1
+

--- a/internal/testing/listdeps.sh
+++ b/internal/testing/listdeps.sh
@@ -33,5 +33,5 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-# Sort usnig the native byte values to keep results from different environment consistent.
+# Sort using the native byte values to keep results from different environment consistent.
 LC_ALL=C sort "$tmpfile" | uniq

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -68,7 +68,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   fi
 else
   go test -mod=readonly -race ./... || result=1
-  # No need to run wire checks or other module tests on OSs other than linux.
+  # No need to run other checks on OSs other than linux.
   exit $result
 fi
 
@@ -80,6 +80,12 @@ fi
 ./internal/testing/listdeps.sh | diff ./internal/testing/alldeps - || {
   echo "FAIL: dependencies changed; compare listdeps.sh output with alldeps" && result=1
 }
+
+# For pull requests, check if there are undeclared incompatible API changes.
+# Skip this if we're already going to fail since it is expensive.
+if [[ ${result} -eq 0 ]] && [[ ! -z "$TRAVIS_BRANCH" ]] && [[ ! -z "$TRAVIS_PULL_REQUEST_SHA" ]]; then
+  ./internal/testing/check_api_change.sh || result=1;
+fi
 
 go install -mod=readonly github.com/google/wire/cmd/wire
 wire check ./... || result=1


### PR DESCRIPTION
Fixes #1570.

The checks are relatively slow; it takes about 1 second to run `apidiff` on a package, and we need to run it twice (actually, we run it 4 times, but the `-w` ones to export pkg data are the expensive ones). We have about 50 packages.

It would be nice to use `git diff --names-only master` to quickly figure out which packages have changes, and skip packages that don't have changes, but it's not obvious to me how to map file names from `git diff` to package names from `go list`.