### PR TITLE
pubsub: modify mem/aws/rabbit behavior for 0 messages in ReceiveBatch; better cancel error checks

### DIFF
--- a/pubsub/awspubsub/awspubsub.go
+++ b/pubsub/awspubsub/awspubsub.go
@@ -58,6 +58,7 @@ import (
 	"net/url"
 	"path"
 	"sync"
+	"time"
 	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -378,6 +379,7 @@ var errorCodeMap = map[string]gcerrors.ErrorCode{
 	sqs.ErrCodeOverLimit:                            gcerr.ResourceExhausted,
 	sns.ErrCodeKMSThrottlingException:               gcerr.ResourceExhausted,
 	sns.ErrCodeThrottledException:                   gcerr.ResourceExhausted,
+	"RequestCanceled":                               gcerr.Canceled,
 	sns.ErrCodeEndpointDisabledException:            gcerr.Unknown,
 	sns.ErrCodePlatformApplicationDisabledException: gcerr.Unknown,
 }
@@ -401,6 +403,11 @@ func OpenSubscription(ctx context.Context, client *sqs.SQS, qURL string, opts *S
 func openSubscription(ctx context.Context, client *sqs.SQS, qURL string) driver.Subscription {
 	return &subscription{client: client, qURL: qURL}
 }
+
+const (
+	// How often ReceiveBatch should poll if no messages are available.
+	pollDuration = 250 * time.Millisecond
+)
 
 // ReceiveBatch implements driver.Subscription.ReceiveBatch.
 func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) (msgs []*driver.Message, er error) {
@@ -466,6 +473,9 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) (msgs 
 			},
 		}
 		ms = append(ms, m2)
+	}
+	if len(ms) == 0 {
+		time.Sleep(pollDuration)
 	}
 	return ms, nil
 }

--- a/pubsub/driver/driver.go
+++ b/pubsub/driver/driver.go
@@ -107,13 +107,11 @@ type Subscription interface {
 	// should return a nil slice and an error. The concrete API will take
 	// care of retry logic.
 	//
-	// If the service returns no messages for some other reason, this
-	// method should return the empty slice of messages and not attempt to
-	// retry.
-	//
-	// Implementations of ReceiveBatch should request that the underlying
-	// service wait some non-zero amount of time before returning, if there
-	// are no messages yet.
+	// If no messages are currently available, this method can return an empty
+	// slice of messages and no error. ReceiveBatch will be called again
+	// immediately, so implementations should try to wait for messages for some
+	// non-zero amount of time before returning zero messages. If the underlying
+	// service doesn't support waiting, then a time.Sleep can be used.
 	//
 	// ReceiveBatch should be safe for concurrent access from multiple goroutines.
 	ReceiveBatch(ctx context.Context, maxMessages int) ([]*Message, error)

--- a/pubsub/drivertest/drivertest.go
+++ b/pubsub/drivertest/drivertest.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"gocloud.dev/gcerrors"
 	"gocloud.dev/internal/escape"
 	"gocloud.dev/internal/retry"
 	"gocloud.dev/pubsub"
@@ -383,6 +384,12 @@ func testCancelSendReceive(t *testing.T, newHarness HarnessMaker) {
 	if _, err := sub.Receive(ctx); !isCanceled(err) {
 		t.Errorf("sub.Receive returned %v (%T), want context.Canceled", err, err)
 	}
+
+	// It would be nice to add a test that cancels an in-flight blocking Receive.
+	// However, because pubsub.Subscription.Receive repeatedly calls
+	// driver.ReceiveBatch if it returns 0 messages, it's difficult to write
+	// such a test without it being flaky for drivers with record/replay
+	// (the number of times driver.ReceiveBatch is called is timing-dependent).
 }
 
 func testMetadata(t *testing.T, newHarness HarnessMaker) {
@@ -488,7 +495,7 @@ func isCanceled(err error) bool {
 	if cerr, ok := err.(*retry.ContextError); ok {
 		return cerr.CtxErr == context.Canceled
 	}
-	return false
+	return gcerrors.Code(err) == gcerrors.Canceled
 }
 
 func makePair(ctx context.Context, h Harness, testName string) (*pubsub.Topic, *pubsub.Subscription, func(), error) {
@@ -498,6 +505,7 @@ func makePair(ctx context.Context, h Harness, testName string) (*pubsub.Topic, *
 	}
 	ds, subCleanup, err := h.CreateSubscription(ctx, dt, testName)
 	if err != nil {
+		topicCleanup()
 		return nil, nil, nil, err
 	}
 	t := pubsub.NewTopic(dt, nil)

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -563,7 +563,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 
 	// Get up to maxMessages waiting messages, but don't take too long.
 	var ms []*driver.Message
-	maxTime := time.After(50 * time.Millisecond)
+	maxTime := time.Tick(50 * time.Millisecond)
 	for {
 		select {
 		case <-ctx.Done():
@@ -592,8 +592,11 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 			}
 
 		case <-maxTime:
-			// Timed out. Return whatever we have.
-			return ms, nil
+			// Timed out. Return whatever we have, or continue waiting if
+			// we haven't gotten anything yet.
+			if len(ms) > 0 {
+				return ms, nil
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR is a bit of a grab bag now, of things I discovered trying to add a conformance test for canceling an in-flight `Receive`.

* I found that we weren't returning the `Canceled` error code correctly for AWS; fixed (although I couldn't find a constant for that error).
* The test `isCanceled` function wasn't checking for `gcerr.Canceled`.
* `awspubsub` and `mempubsub` weren't handling "got no messages" consistently with what `driver.ReceiveBatch` says.
* I updated the docstring for `driver.ReceiveBatch` to be a bit more explicit.
* I added a comment about why adding a test for canceling an in-flight `Receive` is hard.