### PR TITLE
runtimevar: add a DecryptDecoder

### DIFF
--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -485,8 +485,8 @@ func BytesDecode(b []byte, obj interface{}) error {
 // DecryptDecode returns a decode function that can be passed to NewDecoder when
 // decoding an encrypted message (https://godoc.org/gocloud.dev/secrets).
 //
-// The decode function default to BytesDecode. An optional decoder can be passed
-// in to do further decode operation based on the decrypted message.
+// post defaults to BytesDecode. An optional decoder can be passed in to do
+// further decode operation based on the decrypted message.
 func DecryptDecode(ctx context.Context, k *secrets.Keeper, post Decode) Decode {
 	return func(b []byte, obj interface{}) error {
 		decrypted, err := k.Decrypt(ctx, b)

--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -454,10 +454,10 @@ func (d *Decoder) Decode(b []byte) (interface{}, error) {
 
 var (
 	// StringDecoder decodes into strings.
-	StringDecoder = NewDecoder("", stringDecode)
+	StringDecoder = NewDecoder("", StringDecode)
 
 	// BytesDecoder copies the slice of bytes.
-	BytesDecoder = NewDecoder([]byte{}, bytesDecode)
+	BytesDecoder = NewDecoder([]byte{}, BytesDecode)
 
 	// JSONDecode can be passed to NewDecoder when decoding JSON (https://golang.org/pkg/encoding/json/).
 	JSONDecode = json.Unmarshal
@@ -468,13 +468,15 @@ func GobDecode(data []byte, obj interface{}) error {
 	return gob.NewDecoder(bytes.NewBuffer(data)).Decode(obj)
 }
 
-func stringDecode(b []byte, obj interface{}) error {
+// StringDecode decodes raw bytes b into a string.
+func StringDecode(b []byte, obj interface{}) error {
 	v := obj.(*string)
 	*v = string(b)
 	return nil
 }
 
-func bytesDecode(b []byte, obj interface{}) error {
+// BytesDecode copies the slice of bytes b into obj.
+func BytesDecode(b []byte, obj interface{}) error {
 	v := obj.(*[]byte)
 	*v = b[:]
 	return nil
@@ -483,9 +485,8 @@ func bytesDecode(b []byte, obj interface{}) error {
 // DecryptDecode returns a decode function that can be passed to NewDecoder when
 // decoding an encrypted message (https://godoc.org/gocloud.dev/secrets).
 //
-// The decode function by default will decode the input into raw bytes. An
-// optional decoder can be passed in to do further decode operation based on the
-// decrypted message.
+// The decode function default to BytesDecode. An optional decoder can be passed
+// in to do further decode operation based on the decrypted message.
 func DecryptDecode(ctx context.Context, k *secrets.Keeper, post Decode) Decode {
 	return func(b []byte, obj interface{}) error {
 		decrypted, err := k.Decrypt(ctx, b)
@@ -493,9 +494,7 @@ func DecryptDecode(ctx context.Context, k *secrets.Keeper, post Decode) Decode {
 			return err
 		}
 		if post == nil {
-			v := obj.(*[]byte)
-			*v = decrypted
-			return nil
+			return BytesDecode(decrypted, obj)
 		}
 		return post(decrypted, obj)
 	}

--- a/runtimevar/runtimevar_test.go
+++ b/runtimevar/runtimevar_test.go
@@ -656,9 +656,15 @@ func TestDecryptDecoder(t *testing.T) {
 		postDecFn Decode
 	}{
 		{
-			desc:     "Raw Bytes",
+			desc:     "Bytes",
 			in:       []byte("hello world"),
 			encodeFn: func(obj interface{}) ([]byte, error) { return obj.([]byte), nil },
+		},
+		{
+			desc:      "String",
+			in:        "hello world",
+			encodeFn:  func(obj interface{}) ([]byte, error) { return []byte(obj.(string)), nil },
+			postDecFn: StringDecode,
 		},
 		{
 			desc: "JSON",
@@ -670,12 +676,12 @@ func TestDecryptDecoder(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run("Decrypt+"+tc.desc, func(t *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			decoder := NewDecoder(tc.in, DecryptDecode(ctx, keeper, tc.postDecFn))
 
 			b, err := tc.encodeFn(tc.in)
 			if err != nil {
-				t.Fatalf("marshal error %v", err)
+				t.Fatalf("encode error %v", err)
 			}
 			encrypted, err := keeper.Encrypt(ctx, b)
 			if err != nil {

--- a/runtimevar/runtimevar_test.go
+++ b/runtimevar/runtimevar_test.go
@@ -33,6 +33,7 @@ import (
 	"gocloud.dev/gcerrors"
 	"gocloud.dev/internal/gcerr"
 	"gocloud.dev/runtimevar/driver"
+	"gocloud.dev/secrets/localsecrets"
 )
 
 // How long we wait on a call that is expected to block forever before cancelling it.
@@ -640,5 +641,57 @@ func TestBytesDecoder(t *testing.T) {
 	}
 	if diff := cmp.Diff(got, input); diff != "" {
 		t.Errorf("output got %v, want %q", got, input)
+	}
+}
+
+func TestDecryptDecoder(t *testing.T) {
+	ctx := context.Background()
+	secretKey := localsecrets.ByteKey("I'm a secret string!")
+	keeper := localsecrets.NewKeeper(secretKey)
+
+	tests := []struct {
+		desc      string
+		in        interface{}
+		encodeFn  func(interface{}) ([]byte, error)
+		postDecFn Decode
+	}{
+		{
+			desc:     "Raw Bytes",
+			in:       []byte("hello world"),
+			encodeFn: func(obj interface{}) ([]byte, error) { return obj.([]byte), nil },
+		},
+		{
+			desc: "JSON",
+			in: map[string]string{
+				"slice": "pizza",
+			},
+			encodeFn:  json.Marshal,
+			postDecFn: JSONDecode,
+		},
+	}
+	for _, tc := range tests {
+		t.Run("Decrypt+"+tc.desc, func(t *testing.T) {
+			decoder := NewDecoder(tc.in, DecryptDecode(ctx, keeper, tc.postDecFn))
+
+			b, err := tc.encodeFn(tc.in)
+			if err != nil {
+				t.Fatalf("marshal error %v", err)
+			}
+			encrypted, err := keeper.Encrypt(ctx, b)
+			if err != nil {
+				t.Fatalf("encrypt error: %v", err)
+			}
+
+			got, err := decoder.Decode(encrypted)
+			if err != nil {
+				t.Fatalf("parse input\n%s\nerror: %v", string(b), err)
+			}
+			if reflect.TypeOf(got) != reflect.TypeOf(tc.in) {
+				t.Errorf("type mismatch got %T, want %T", got, tc.in)
+			}
+			if diff := cmp.Diff(got, tc.in); diff != "" {
+				t.Errorf("value diff:\n%v", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
A follow-up PR will support `DecoderByName` used by URLOpeners.

Updates #1290 