### PR TITLE
internal/docstore: implement codecTester for dynamodocstore

### DIFF
--- a/internal/docstore/dynamodocstore/codec.go
+++ b/internal/docstore/dynamodocstore/codec.go
@@ -335,7 +335,7 @@ func (d decoder) AsSpecial(v reflect.Value) (bool, interface{}, error) {
 	switch v.Type() {
 	case typeOfGoTime:
 		if d.av.S == nil {
-			return false, nil, errors.New("time value not found")
+			return false, nil, errors.New("expected string field for time.Time")
 		}
 		t, err := time.Parse(time.RFC3339Nano, *d.av.S)
 		return true, t, err

--- a/internal/docstore/dynamodocstore/codec.go
+++ b/internal/docstore/dynamodocstore/codec.go
@@ -74,7 +74,7 @@ func (e *encoder) EncodeSpecial(v reflect.Value) (bool, error) {
 		ts := v.Interface().(time.Time).Format(time.RFC3339Nano)
 		e.EncodeString(ts)
 	default:
-		return false, errors.New("Not implemented")
+		return false, nil
 	}
 	return true, nil
 }
@@ -334,6 +334,9 @@ func toGoValue(av *dyn.AttributeValue) (interface{}, error) {
 func (d decoder) AsSpecial(v reflect.Value) (bool, interface{}, error) {
 	switch v.Type() {
 	case typeOfGoTime:
+		if d.av.S == nil {
+			return false, nil, errors.New("time value not found")
+		}
 		t, err := time.Parse(time.RFC3339Nano, *d.av.S)
 		return true, t, err
 	default:

--- a/internal/docstore/dynamodocstore/codec.go
+++ b/internal/docstore/dynamodocstore/codec.go
@@ -140,7 +140,7 @@ func encodeFloat(f float64) *dyn.AttributeValue {
 
 ////////////////////////////////////////////////////////////////
 
-func decodeDoc(doc driver.Document, item *dyn.AttributeValue) error {
+func decodeDoc(item *dyn.AttributeValue, doc driver.Document) error {
 	return doc.Decode(decoder{av: item})
 }
 

--- a/internal/docstore/dynamodocstore/codec_test.go
+++ b/internal/docstore/dynamodocstore/codec_test.go
@@ -15,7 +15,6 @@
 package dynamodocstore
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -87,8 +86,8 @@ func (ct *codecTester) NativeEncode(obj interface{}) (interface{}, error) {
 }
 
 func (ct *codecTester) NativeDecode(value, dest interface{}) error {
-	v := value.(map[string]*dyn.AttributeValue)
-	return dynattr.Unmarshal(&dyn.AttributeValue{M: v}, dest)
+	// v := value.(map[string]*dyn.AttributeValue)
+	return dynattr.Unmarshal(value.(*dyn.AttributeValue), dest)
 }
 
 func (ct *codecTester) DocstoreEncode(obj interface{}) (interface{}, error) {
@@ -104,13 +103,5 @@ func (ct *codecTester) DocstoreDecode(value, dest interface{}) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("v: %#v\n\n", value)
-	switch v := value.(type) {
-	case *dyn.AttributeValue:
-		return decodeDoc(doc, v.M)
-	case map[string]*dyn.AttributeValue:
-		return decodeDoc(doc, v)
-	default:
-		return fmt.Errorf("unexpected type: %T", v)
-	}
+	return decodeDoc(doc, value.(*dyn.AttributeValue))
 }

--- a/internal/docstore/dynamodocstore/codec_test.go
+++ b/internal/docstore/dynamodocstore/codec_test.go
@@ -86,7 +86,6 @@ func (ct *codecTester) NativeEncode(obj interface{}) (interface{}, error) {
 }
 
 func (ct *codecTester) NativeDecode(value, dest interface{}) error {
-	// v := value.(map[string]*dyn.AttributeValue)
 	return dynattr.Unmarshal(value.(*dyn.AttributeValue), dest)
 }
 
@@ -103,5 +102,5 @@ func (ct *codecTester) DocstoreDecode(value, dest interface{}) error {
 	if err != nil {
 		return err
 	}
-	return decodeDoc(doc, value.(*dyn.AttributeValue))
+	return decodeDoc(value.(*dyn.AttributeValue), doc)
 }

--- a/internal/docstore/dynamodocstore/dynamo.go
+++ b/internal/docstore/dynamodocstore/dynamo.go
@@ -149,7 +149,7 @@ func (c *collection) get(ctx context.Context, doc driver.Document, fieldpaths []
 	if err != nil {
 		return err
 	}
-	return decodeDoc(doc, &dyn.AttributeValue{M: out.Item})
+	return decodeDoc(&dyn.AttributeValue{M: out.Item}, doc)
 }
 
 func (c *collection) delete(ctx context.Context, doc driver.Document) error {

--- a/internal/docstore/dynamodocstore/dynamo_test.go
+++ b/internal/docstore/dynamodocstore/dynamo_test.go
@@ -55,7 +55,7 @@ func TestConformance(t *testing.T) {
 		clearTable(t)
 	}
 	drivertest.MakeUniqueStringDeterministicForTesting(1)
-	drivertest.RunConformanceTests(t, newHarness, nil)
+	drivertest.RunConformanceTests(t, newHarness, new(codecTester))
 }
 
 func clearTable(t *testing.T) {


### PR DESCRIPTION
Also let the encoder return `*dynamodb.AttributeValue` instead of `map[string]*dynamodb.AttributeValue` as that matches the native encoder's output type.