### PR TITLE
blob/fileblob: initialize opts to empty struct

### DIFF
--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -129,6 +129,9 @@ func openBucket(dir string, opts *Options) (driver.Bucket, error) {
 	if !info.IsDir() {
 		return nil, fmt.Errorf("%s is not a directory", dir)
 	}
+	if opts == nil {
+		opts = &Options{}
+	}
 	return &bucket{dir: dir, opts: opts}, nil
 }
 


### PR DESCRIPTION
Release 0.11.0 added support for SignedUrl with fileblob. The implementation however assumes the opts struct fields has been initialised when it calls `b.opts.URLSigner == nil`. Other blob providers such as gcs and s3 initialise opts to the empty struct if the one provided by openBucket is nil. This behaviour lets consumers use the field without checking it has been set. This adds similar code to fileBlob and will prevent the SignedUrl function from panicking, as happened here:

```
runtime error: invalid memory address or nil pointer dereference
goroutine 22 [running]:
net/http.(*conn).serve.func1(0xc000264000)
	/usr/local/Cellar/go/1.11.5/libexec/src/net/http/server.go:1746 +0xd0
panic(0x147aa40, 0x18b1450)
	/usr/local/Cellar/go/1.11.5/libexec/src/runtime/panic.go:513 +0x1b9
gocloud.dev/blob/fileblob.(*bucket).SignedURL(0xc0001c4040, 0x158b120, 0xc00024c600, 0xc00025603b, 0x1c, 0xc000258110, 0x151225b, 0x18, 0x0, 0x372f355f)
	/go/pkg/mod/gocloud.dev@v0.11.0/blob/fileblob/fileblob.go:529 +0x2a
gocloud.dev/blob.(*Bucket).SignedURL(0xc0001c4060, 0x158b120, 0xc00024c600, 0xc00025603b, 0x1c, 0xc0000cb590, 0x0, 0x0, 0x0, 0x0)
	/go/pkg/mod/gocloud.dev@v0.11.0/blob/blob.go:791 +0x104
```