### PR TITLE
internal/retry: support the errors.Is method

### DIFF
--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -72,3 +72,7 @@ type ContextError struct {
 func (e *ContextError) Error() string {
 	return fmt.Sprintf("%v; last error: %v", e.CtxErr, e.FuncErr)
 }
+
+func (e *ContextError) Is(target error) bool {
+	return e.CtxErr == target || e.FuncErr == target
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -17,10 +17,12 @@ package retry
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
 	gax "github.com/googleapis/gax-go"
+	"golang.org/x/xerrors"
 )
 
 // Errors to distinguish retryable and non-retryable cases.
@@ -128,4 +130,16 @@ func equalContextError(got error, want *ContextError) bool {
 		return false
 	}
 	return cerr.CtxErr == want.CtxErr && cerr.FuncErr == want.FuncErr
+}
+
+func TestErrorsIs(t *testing.T) {
+	err := &ContextError{
+		CtxErr:  context.Canceled,
+		FuncErr: os.ErrExist,
+	}
+	for _, target := range []error{err, context.Canceled, os.ErrExist} {
+		if !xerrors.Is(err, target) {
+			t.Errorf("xerrors.Is(%v) == false, want true", target)
+		}
+	}
 }


### PR DESCRIPTION
After this PR, you can test if a retry error is the result
of cancelation using
```
xerrors.Is(err, context.Canceled)
```

Updates #1591.