### PR TITLE
pubsub/tests: add a suite of benchmarks

### DIFF
--- a/pubsub/benchmark_test.go
+++ b/pubsub/benchmark_test.go
@@ -24,6 +24,7 @@ import (
 	"gocloud.dev/internal/retry"
 	"gocloud.dev/pubsub/driver"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/xerrors"
 )
 
 const (
@@ -169,7 +170,7 @@ func runBenchmark(t *testing.T, description string, numGoRoutines int, receivePr
 			// Each goroutine loops until ctx is canceled.
 			for {
 				m, err := sub.Receive(ctx)
-				if err == context.Canceled {
+				if xerrors.Is(err, context.Canceled) {
 					return nil
 				}
 				// TODO(rvangent): This is annoying. Maybe retry should return

--- a/pubsub/benchmark_test.go
+++ b/pubsub/benchmark_test.go
@@ -17,6 +17,7 @@ package pubsub
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -26,35 +27,24 @@ import (
 )
 
 const (
-	// Number of goroutines to use for Receive.
-	nGoRoutines = 100
 	// How long to run the test.
 	runFor = 10 * time.Second
 	// Minimum frequency for reporting throughput.
-	reportPeriod = 1 * time.Second
-)
-
-var (
-	// receiveBatchProfile should return the number of message for ReceiveBatch
-	// to return (<= maxMessages), and the simulated time it took for ReceiveBatch
-	// to run.
-	receiveBatchProfile = func(maxMessages int) (int, time.Duration) {
-		return maxMessages, 0
-	}
-	// processMessageProfile should return whether Message.Ack should be called,
-	// and the simulated time it took to process the message.
-	processMessageProfile = func() (bool, time.Duration) {
-		return true, 0
-	}
+	reportPeriod = 250 * time.Millisecond
+	// Number of output lines per test. We set this to a constant so that it's
+	// easy to copy/paste the output into a Google Sheet with pre-created graphs.
+	// Should be above runFor / reportPeriod.
+	numLinesPerTest = 50
 )
 
 type fakeSub struct {
 	driver.Subscription
-	msgs []*driver.Message
+	profile func(int) (int, time.Duration)
+	msgs    []*driver.Message
 }
 
 func (s *fakeSub) ReceiveBatch(ctx context.Context, maxMessages int) ([]*driver.Message, error) {
-	n, delay := receiveBatchProfile(maxMessages)
+	n, delay := s.profile(maxMessages)
 	if delay > 0 {
 		time.Sleep(delay)
 	}
@@ -64,48 +54,117 @@ func (s *fakeSub) ReceiveBatch(ctx context.Context, maxMessages int) ([]*driver.
 func (s *fakeSub) AckFunc() func() { return func() {} }
 
 // TestReceivePerformance enables characterization of Receive under various
-// situations. Tune the const and var parameters above, disable the Skip,
-// and the test will output a series of timepoints with throughput and the
-// batch size being sent to ReceiveBatch.
+// situations, characterized in "tests" below.
 func TestReceivePerformance(t *testing.T) {
-	t.Skip("Skipping by default")
+	//t.Skip("Skipped by default")
 
+	const defaultNumGoRoutines = 100
+	defaultReceiveProfile := func(maxMessages int) (int, time.Duration) { return maxMessages, 0 }
+	defaultProcessProfile := func() time.Duration { return 0 }
+
+	tests := []struct {
+		description string
+		// See the defaults above.
+		numGoRoutines  int
+		receiveProfile func(int) (int, time.Duration)
+		processProfile func() time.Duration
+		noAck          bool
+	}{
+		{
+			description: "baseline",
+		},
+		{
+			description:   "1 goroutine",
+			numGoRoutines: 1,
+		},
+		{
+			description: "no ack",
+			noAck:       true,
+		},
+		{
+			description:    "receive 100ms",
+			receiveProfile: func(maxMessages int) (int, time.Duration) { return maxMessages, 100 * time.Millisecond },
+		},
+		{
+			description:    "receive 1s",
+			receiveProfile: func(maxMessages int) (int, time.Duration) { return maxMessages, 1 * time.Second },
+		},
+		{
+			description:    "process 100ms",
+			processProfile: func() time.Duration { return 100 * time.Millisecond },
+		},
+		{
+			description:    "process 1s",
+			processProfile: func() time.Duration { return 1 * time.Second },
+		},
+		{
+			description: "receive 250ms+stddev 150ms, process 10ms + stddev 5ms",
+			receiveProfile: func(maxMessages int) (int, time.Duration) {
+				return maxMessages, time.Duration(rand.NormFloat64()*150+250) * time.Millisecond
+			},
+			processProfile: func() time.Duration { return time.Duration(rand.NormFloat64()*5+10) * time.Millisecond },
+		},
+	}
+
+	for _, test := range tests {
+		if test.numGoRoutines == 0 {
+			test.numGoRoutines = defaultNumGoRoutines
+		}
+		if test.receiveProfile == nil {
+			test.receiveProfile = defaultReceiveProfile
+		}
+		if test.processProfile == nil {
+			test.processProfile = defaultProcessProfile
+		}
+		runBenchmark(t, test.description, test.numGoRoutines, test.receiveProfile, test.processProfile, test.noAck)
+	}
+}
+
+func runBenchmark(t *testing.T, description string, numGoRoutines int, receiveProfile func(int) (int, time.Duration), processProfile func() time.Duration, noAck bool) {
 	msgs := make([]*driver.Message, 1000)
 	for i := range msgs {
 		msgs[i] = &driver.Message{}
 	}
-	sub := newSubscription(&fakeSub{msgs: msgs}, nil)
 
-	// Header row.
-	fmt.Println("Elapsed (sec)\tMsgs/sec\tMax Messages")
+	fake := &fakeSub{msgs: msgs, profile: receiveProfile}
+	sub := newSubscription(fake, nil)
 
 	// Configure our output in a hook called whenever ReceiveBatch returns.
 	start := time.Now()
 	lastReport := start
 	numMsgs := 0
-	lastMaxMessages := 0
+	numRPCs := 0
+	nLines := 0
+
+	// Header row.
+	fmt.Printf("%s\tmsgs/sec\tRPCs/sec\tbatchsize\n", description)
+	nLines++
+
 	sub.onReceiveBatchHook = func(numMessages, maxMessages int) {
 		numMsgs += numMessages
+		numRPCs++
 
 		// Emit a timepoint if maxMessages has changed, or if reportPeriod has
 		// elapsed since our last timepoint.
 		now := time.Now()
 		elapsed := now.Sub(lastReport)
-		if lastMaxMessages != maxMessages || elapsed > reportPeriod {
+		if elapsed > reportPeriod {
 			secsSinceStart := now.Sub(start).Seconds()
 			msgsPerSec := float64(numMsgs) / elapsed.Seconds()
-			fmt.Printf("%f\t%f\t%d\n", secsSinceStart, msgsPerSec, maxMessages)
+			rpcsPerSec := float64(numRPCs) / elapsed.Seconds()
+			fmt.Printf("%f\t%f\t%f\t%d\n", secsSinceStart, msgsPerSec, rpcsPerSec, maxMessages)
+			nLines++
 
 			lastReport = now
 			numMsgs = 0
-			lastMaxMessages = maxMessages
+			numRPCs = 0
 		}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	time.AfterFunc(runFor, cancel)
 	var grp errgroup.Group
-	for i := 0; i < nGoRoutines; i++ {
+	for i := 0; i < numGoRoutines; i++ {
 		grp.Go(func() error {
 			// Each goroutine loops until ctx is canceled.
 			for {
@@ -121,17 +180,23 @@ func TestReceivePerformance(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				callAck, delay := processMessageProfile()
+				delay := processProfile()
 				if delay > 0 {
 					time.Sleep(delay)
 				}
-				if callAck {
+				if !noAck {
 					m.Ack()
 				}
 			}
 		})
 	}
 	if err := grp.Wait(); err != nil {
-		t.Error(err)
+		t.Errorf("%s: %v", description, err)
+	}
+	if nLines > numLinesPerTest {
+		t.Errorf("%s: produced too many lines (%d)", description, nLines)
+	}
+	for n := nLines; n < numLinesPerTest; n++ {
+		fmt.Println()
 	}
 }


### PR DESCRIPTION
Instead of running a single benchmark, the test now runs a suite of them.

[Here's](https://docs.google.com/spreadsheets/d/1c3mqHJ33mN64xBQrx42DY1GpYrMUi7IEl-6FRawIv70/edit) the sample spreadsheet I have set up with the results. `out` is the output of the benchmark suite with HEAD. `out2` is the output of the benchmark suite with a single change, to modify `pubsub.desiredQueueDuration` from 2s to 50ms. Each row of the graph corresponds to a specific benchmark profile; the current columns are messages/sec, RPCs/sec, and batch size (== `maxMessages`).

So, for example, you can see that reducing desiredQueueDuration would increase RPCs/sec significantly in various scenarios.

Feedback on the spreadsheet and the specific tests in the suite is welcome!

Updates #1441.