### PR TITLE
runtimevar/blobvar: only support a single Bucket URL via env variable

### DIFF
--- a/runtimevar/blobvar/blobvar.go
+++ b/runtimevar/blobvar/blobvar.go
@@ -19,6 +19,8 @@
 // URLs
 //
 // For runtimevar.OpenVariable, blobvar registers for the scheme "blob".
+// The default URL opener will open a blob.Bucket based on the environment
+// variable "BLOBVAR_BUCKET_URL".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
 // See https://godoc.org/gocloud.dev#hdr-URLs for background information.
@@ -33,8 +35,10 @@ package blobvar // import "gocloud.dev/runtimevar/blobvar"
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"path"
 	"sync"
 	"time"
@@ -46,7 +50,33 @@ import (
 )
 
 func init() {
-	runtimevar.DefaultURLMux().RegisterVariable(Scheme, &URLOpener{Mux: blob.DefaultURLMux()})
+	runtimevar.DefaultURLMux().RegisterVariable(Scheme, &defaultOpener{})
+}
+
+type defaultOpener struct {
+	init   sync.Once
+	opener *URLOpener
+	err    error
+}
+
+func (o *defaultOpener) OpenVariableURL(ctx context.Context, u *url.URL) (*runtimevar.Variable, error) {
+	o.init.Do(func() {
+		bucketURL := os.Getenv("BLOBVAR_BUCKET_URL")
+		if bucketURL == "" {
+			o.err = errors.New("BLOBVAR_BUCKET_URL environment variable is not set")
+			return
+		}
+		bucket, err := blob.OpenBucket(ctx, bucketURL)
+		if err != nil {
+			o.err = fmt.Errorf("failed to open default bucket %q: %v", bucketURL, err)
+			return
+		}
+		o.opener = &URLOpener{Bucket: bucket}
+	})
+	if o.err != nil {
+		return nil, fmt.Errorf("open variable %v: %v", u, o.err)
+	}
+	return o.opener.OpenVariableURL(ctx, u)
 }
 
 // Scheme is the URL scheme blobvar registers its URLOpener under on runtimevar.DefaultMux.
@@ -54,19 +84,11 @@ const Scheme = "blob"
 
 // URLOpener opens blob-backed URLs like "blob://myblobkey?decoder=string".
 // It supports the following URL parameters:
-//   - bucket: The URL to be passed to blob.OpenBucket. Required unless
-//       URLOpener.Bucket is provided explicitly.
-//       blob.OpenBucket will be called once per unique bucket URL.
 //   - decoder: The decoder to use. Defaults to URLOpener.Decoder, or
 //       runtimevar.BytesDecoder if URLOpener.Decoder is nil.
 //       See runtimevar.DecoderByName for supported values.
 type URLOpener struct {
-	// Mux is required unless Bucket is provided. The "bucket" URL parameter
-	// must be provided, and Mux will be used to open it. Opened buckets are
-	// cached.
-	Mux *blob.URLMux
-
-	// Bucket is optional; if it is provided, it is always used.
+	// Bucket is required.
 	Bucket *blob.Bucket
 
 	// Decoder specifies the decoder to use if one is not specified in the URL.
@@ -75,14 +97,6 @@ type URLOpener struct {
 
 	// Options specifies the Options for NewVariable.
 	Options Options
-
-	mu      sync.Mutex
-	buckets map[string]*refCountBucket
-}
-
-type refCountBucket struct {
-	bucket *blob.Bucket
-	refs   int
 }
 
 // OpenVariableURL opens the variable at the URL's path. See the package doc
@@ -90,24 +104,8 @@ type refCountBucket struct {
 func (o *URLOpener) OpenVariableURL(ctx context.Context, u *url.URL) (*runtimevar.Variable, error) {
 	q := u.Query()
 
-	bucket := o.Bucket
-	var watcherOpener *URLOpener // Set if bucket opened via URL to decrement references.
-
-	if bucket == nil {
-		if o.Mux == nil {
-			return nil, fmt.Errorf("open variable %v: URLOpener.Mux is required if Bucket is not provided", u)
-		}
-		bucketURL := u.Query().Get("bucket")
-		if bucketURL == "" {
-			return nil, fmt.Errorf("open variable %v: URL parameter \"bucket\" is required", u)
-		}
-		var err error
-		bucket, err = o.bucketForURL(ctx, bucketURL)
-		if err != nil {
-			return nil, fmt.Errorf("open variable %v: %v", u, err)
-		}
-		watcherOpener = o
-		q.Del("bucket")
+	if o.Bucket == nil {
+		return nil, fmt.Errorf("open variable %v: bucket is required", u)
 	}
 
 	decoderName := q.Get("decoder")
@@ -120,48 +118,7 @@ func (o *URLOpener) OpenVariableURL(ctx context.Context, u *url.URL) (*runtimeva
 	for param := range q {
 		return nil, fmt.Errorf("open variable %v: invalid query parameter %q", u, param)
 	}
-	return runtimevar.New(newWatcher(bucket, path.Join(u.Host, u.Path), decoder, watcherOpener, &o.Options)), nil
-}
-
-func (o *URLOpener) bucketForURL(ctx context.Context, bucketURL string) (*blob.Bucket, error) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	if o.buckets == nil {
-		o.buckets = make(map[string]*refCountBucket)
-	}
-	rcBucket := o.buckets[bucketURL]
-	if rcBucket == nil {
-		var err error
-		newBucket, err := o.Mux.OpenBucket(ctx, bucketURL)
-		if err != nil {
-			return nil, err
-		}
-		rcBucket = &refCountBucket{bucket: newBucket}
-		o.buckets[bucketURL] = rcBucket
-	}
-	rcBucket.refs++
-	return rcBucket.bucket, nil
-}
-
-func (o *URLOpener) decBucketRef(bucket *blob.Bucket) error {
-	occurrences, drops := 0, 0
-	o.mu.Lock()
-	for key, rcBucket := range o.buckets {
-		if rcBucket.bucket != bucket {
-			continue
-		}
-		occurrences++
-		rcBucket.refs--
-		if rcBucket.refs <= 0 {
-			delete(o.buckets, key)
-			drops++
-		}
-	}
-	o.mu.Unlock()
-	if drops > 0 && occurrences == drops {
-		return bucket.Close()
-	}
-	return nil
+	return NewVariable(o.Bucket, path.Join(u.Host, u.Path), decoder, &o.Options)
 }
 
 // Options sets options.
@@ -267,12 +224,7 @@ func (w *watcher) WatchVariable(ctx context.Context, prev driver.State) (driver.
 
 // Close implements driver.Close.
 func (w *watcher) Close() error {
-	var err error
-	if w.opener != nil {
-		err = w.opener.decBucketRef(w.bucket)
-		w.opener = nil // Ensure that we don't call multiple times.
-	}
-	return err
+	return nil
 }
 
 // ErrorAs implements driver.ErrorAs.

--- a/runtimevar/blobvar/example_test.go
+++ b/runtimevar/blobvar/example_test.go
@@ -69,6 +69,9 @@ func Example_openVariable() {
 	// OpenVariable creates a *runtimevar.Variable from a URL.
 	// The default opener opens a blob.Bucket via a URL, based on the environment
 	// variable BLOBVAR_BUCKET_URL.
+
+
+
 	// This example watches a JSON variable.
 	ctx := context.Background()
 	v, err := runtimevar.OpenVariable(ctx, "blob://myvar.json?decoder=json")

--- a/runtimevar/blobvar/example_test.go
+++ b/runtimevar/blobvar/example_test.go
@@ -69,9 +69,6 @@ func Example_openVariable() {
 	// OpenVariable creates a *runtimevar.Variable from a URL.
 	// The default opener opens a blob.Bucket via a URL, based on the environment
 	// variable BLOBVAR_BUCKET_URL.
-
-
-
 	// This example watches a JSON variable.
 	ctx := context.Background()
 	v, err := runtimevar.OpenVariable(ctx, "blob://myvar.json?decoder=json")

--- a/runtimevar/blobvar/example_test.go
+++ b/runtimevar/blobvar/example_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/url"
 
 	"gocloud.dev/blob/memblob"
 	"gocloud.dev/runtimevar"
@@ -68,9 +67,11 @@ func Example() {
 
 func Example_openVariable() {
 	// OpenVariable creates a *runtimevar.Variable from a URL.
-	// This example watches a variable based on a file-based blob.Bucket with JSON.
+	// The default opener opens a blob.Bucket via a URL, based on the environment
+	// variable BLOBVAR_BUCKET_URL.
+	// This example watches a JSON variable.
 	ctx := context.Background()
-	v, err := runtimevar.OpenVariable(ctx, "blob://myvar.json?bucket="+url.QueryEscape("file://mypath")+"&decoder=json")
+	v, err := runtimevar.OpenVariable(ctx, "blob://myvar.json?decoder=json")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Per discussion on #1488.

Fixes #1488.
Fixes #1498.