### PR TITLE
memdocstore: change arg order for decodeDoc

### DIFF
--- a/internal/docstore/memdocstore/codec.go
+++ b/internal/docstore/memdocstore/codec.go
@@ -76,7 +76,7 @@ func (e *mapEncoder) MapKey(k string) { e.m[k] = e.val }
 ////////////////////////////////////////////////////////////////
 
 // decodeDoc decodes m into ddoc.
-func decodeDoc(ddoc driver.Document, m map[string]interface{}) error {
+func decodeDoc(m map[string]interface{}, ddoc driver.Document) error {
 	return ddoc.Decode(decoder{m})
 }
 

--- a/internal/docstore/memdocstore/codec_test.go
+++ b/internal/docstore/memdocstore/codec_test.go
@@ -132,7 +132,7 @@ func TestDecodeDoc(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := decodeDoc(doc, test.in); err != nil {
+		if err := decodeDoc(test.in, doc); err != nil {
 			t.Fatal(err)
 		}
 		if diff := cmp.Diff(got, test.want, cmp.AllowUnexported(aStruct{})); diff != "" {

--- a/internal/docstore/memdocstore/mem.go
+++ b/internal/docstore/memdocstore/mem.go
@@ -130,7 +130,7 @@ func (c *collection) runAction(a *driver.Action) error {
 		// We've already retrieved the document into current, above.
 		// Now we copy its fields into the user-provided document.
 		// TODO(jba): support field paths.
-		if err := decodeDoc(a.Doc, current); err != nil {
+		if err := decodeDoc(current, a.Doc); err != nil {
 			return err
 		}
 	default:


### PR DESCRIPTION
Follow encoding/json convention of having the destination second.