### PR TITLE
travis: build website before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,6 @@ jobs:
           branch: master
 
 stages:
-  - test
   - name: website
     if: branch = master AND type = push
+  - test


### PR DESCRIPTION
Test failures/flakes should not stop the site from being pushed, and the Hugo deploy process does not take long.