### PR TITLE
internal/website: constrain code blocks to width of content area

### DIFF
--- a/internal/website/static/css/style.css
+++ b/internal/website/static/css/style.css
@@ -43,7 +43,7 @@ body {
 }
 @media (max-width: 768px) {
   .PageLayout {
-    grid-template-columns: 1fr;
+    grid-template-columns: 100%;
     grid-template-areas: "hd" "main" "sd" "ft";
   }
 }
@@ -82,7 +82,6 @@ body {
   font-size: 0.8rem;
   grid-area: sd;
   margin: 0;
-  overflow: auto;
   padding: 1rem 2rem 2rem 1rem;
 }
 .Sidenav-list {
@@ -226,28 +225,27 @@ body {
   font-family: "Source Code Pro", monospace;
 }
 .MainContent pre {
+  box-sizing: border-box;
   background: #f9f9f9;
+  border-radius: 4px;
   display: block;
   font: 0.8rem/1.4 "Source Code Pro", monospace;
   margin: 0 0 1rem;
+  overflow: auto;
   padding: 1rem;
-  white-space: pre-wrap;
   white-space: pre;
+  width: 100%;
   word-break: break-all;
   word-wrap: break-word;
 }
 .MainContent pre code {
-  padding: 0;
   font-size: 100%;
-  color: inherit;
-  background-color: transparent;
 }
 .highlight {
-  margin-bottom: 1rem;
-  border-radius: 4px;
-}
-.highlight pre {
-  margin-bottom: 0;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  width: 100%;
 }
 /* Links */
 .MainContent :link {

--- a/internal/website/static/css/syntax.css
+++ b/internal/website/static/css/syntax.css
@@ -1,66 +1,45 @@
-.hll { background-color: #ffffcc }
- /*{ background: #f0f3f3; }*/
-.c { color: #999; } /* Comment */
-.err { color: #AA0000; background-color: #FFAAAA } /* Error */
-.k { color: #006699; } /* Keyword */
-.o { color: #555555 } /* Operator */
-.cm { color: #0099FF; font-style: italic } /* Comment.Multiline */
-.cp { color: #009999 } /* Comment.Preproc */
-.c1 { color: #999; } /* Comment.Single */
-.cs { color: #999; } /* Comment.Special */
-.gd { background-color: #FFCCCC; border: 1px solid #CC0000 } /* Generic.Deleted */
-.ge { font-style: italic } /* Generic.Emph */
-.gr { color: #FF0000 } /* Generic.Error */
-.gh { color: #003300; } /* Generic.Heading */
-.gi { background-color: #CCFFCC; border: 1px solid #00CC00 } /* Generic.Inserted */
-.go { color: #AAAAAA } /* Generic.Output */
-.gp { color: #000099; } /* Generic.Prompt */
-.gs { } /* Generic.Strong */
-.gu { color: #003300; } /* Generic.Subheading */
-.gt { color: #99CC66 } /* Generic.Traceback */
-.kc { color: #006699; } /* Keyword.Constant */
-.kd { color: #006699; } /* Keyword.Declaration */
-.kn { color: #006699; } /* Keyword.Namespace */
-.kp { color: #006699 } /* Keyword.Pseudo */
-.kr { color: #006699; } /* Keyword.Reserved */
-.kt { color: #007788; } /* Keyword.Type */
-.m { color: #FF6600 } /* Literal.Number */
-.s { color: #d44950 } /* Literal.String */
-.na { color: #4f9fcf } /* Name.Attribute */
-.nb { color: #336666 } /* Name.Builtin */
-.nc { color: #00AA88; } /* Name.Class */
-.no { color: #336600 } /* Name.Constant */
-.nd { color: #9999FF } /* Name.Decorator */
-.ni { color: #999999; } /* Name.Entity */
-.ne { color: #CC0000; } /* Name.Exception */
-.nf { color: #CC00FF } /* Name.Function */
-.nl { color: #9999FF } /* Name.Label */
-.nn { color: #00CCFF; } /* Name.Namespace */
-.nt { color: #2f6f9f; } /* Name.Tag */
-.nv { color: #003333 } /* Name.Variable */
-.ow { color: #000000; } /* Operator.Word */
-.w { color: #bbbbbb } /* Text.Whitespace */
-.mf { color: #FF6600 } /* Literal.Number.Float */
-.mh { color: #FF6600 } /* Literal.Number.Hex */
-.mi { color: #FF6600 } /* Literal.Number.Integer */
-.mo { color: #FF6600 } /* Literal.Number.Oct */
-.sb { color: #CC3300 } /* Literal.String.Backtick */
-.sc { color: #CC3300 } /* Literal.String.Char */
-.sd { color: #CC3300; font-style: italic } /* Literal.String.Doc */
-.s2 { color: #CC3300 } /* Literal.String.Double */
-.se { color: #CC3300; } /* Literal.String.Escape */
-.sh { color: #CC3300 } /* Literal.String.Heredoc */
-.si { color: #AA0000 } /* Literal.String.Interpol */
-.sx { color: #CC3300 } /* Literal.String.Other */
-.sr { color: #33AAAA } /* Literal.String.Regex */
-.s1 { color: #CC3300 } /* Literal.String.Single */
-.ss { color: #FFCC33 } /* Literal.String.Symbol */
-.bp { color: #336666 } /* Name.Builtin.Pseudo */
-.vc { color: #003333 } /* Name.Variable.Class */
-.vg { color: #003333 } /* Name.Variable.Global */
-.vi { color: #003333 } /* Name.Variable.Instance */
-.il { color: #FF6600 } /* Literal.Number.Integer.Long */
-
-.css .o,
-.css .o + .nt,
-.css .nt + .nt { color: #999; }
+/* Keyword */ .chroma .k { color: #00758d; font-weight: bold }
+/* KeywordConstant */ .chroma .kc { color: #00758d; font-weight: bold }
+/* KeywordDeclaration */ .chroma .kd { color: #00758d; font-weight: bold }
+/* KeywordNamespace */ .chroma .kn { color: #00758d; font-weight: bold }
+/* KeywordPseudo */ .chroma .kp { color: #00758d }
+/* KeywordReserved */ .chroma .kr { color: #00758d; font-weight: bold }
+/* KeywordType */ .chroma .kt { color: #00758d }
+/* NameBuiltin */ .chroma .nb { color: #00758d }
+/* LiteralString */ .chroma .s { color: #ce3262 }
+/* LiteralStringAffix */ .chroma .sa { color: #ce3262 }
+/* LiteralStringBacktick */ .chroma .sb { color: #ce3262 }
+/* LiteralStringChar */ .chroma .sc { color: #ce3262 }
+/* LiteralStringDelimiter */ .chroma .dl { color: #ce3262 }
+/* LiteralStringDoc */ .chroma .sd { color: #ce3262; font-style: italic }
+/* LiteralStringDouble */ .chroma .s2 { color: #ce3262 }
+/* LiteralStringEscape */ .chroma .se { color: #ce3262; font-weight: bold }
+/* LiteralStringHeredoc */ .chroma .sh { color: #ce3262 }
+/* LiteralStringInterpol */ .chroma .si { color: #ce3262; font-style: italic }
+/* LiteralStringOther */ .chroma .sx { color: #ce3262 }
+/* LiteralStringRegex */ .chroma .sr { color: #ce3262 }
+/* LiteralStringSingle */ .chroma .s1 { color: #ce3262 }
+/* LiteralStringSymbol */ .chroma .ss { color: #ce3262 }
+/* LiteralNumber */ .chroma .m { color: #ce3262 }
+/* LiteralNumberBin */ .chroma .mb { color: #ce3262 }
+/* LiteralNumberFloat */ .chroma .mf { color: #ce3262 }
+/* LiteralNumberHex */ .chroma .mh { color: #ce3262 }
+/* LiteralNumberInteger */ .chroma .mi { color: #ce3262 }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #ce3262 }
+/* LiteralNumberOct */ .chroma .mo { color: #ce3262 }
+/* Comment */ .chroma .c { color: #555759; font-style: italic }
+/* CommentHashbang */ .chroma .ch { color: #555759; font-style: italic }
+/* CommentMultiline */ .chroma .cm { color: #555759; font-style: italic }
+/* CommentSingle */ .chroma .c1 { color: #555759; font-style: italic }
+/* CommentSpecial */ .chroma .cs { color: #555759; font-style: italic }
+/* CommentPreproc */ .chroma .cp { color: #555759; font-style: italic }
+/* CommentPreprocFile */ .chroma .cpf { color: #555759; font-style: italic }
+/* GenericDeleted */ .chroma .gd { color: #a00000 }
+/* GenericEmph */ .chroma .ge { font-style: italic }
+/* GenericError */ .chroma .gr { color: #ff0000 }
+/* GenericHeading */ .chroma .gh { font-weight: bold }
+/* GenericInserted */ .chroma .gi { color: #00a000 }
+/* GenericPrompt */ .chroma .gp { font-weight: bold }
+/* GenericStrong */ .chroma .gs { font-weight: bold }
+/* GenericSubheading */ .chroma .gu { font-weight: bold }
+/* GenericUnderline */ .chroma .gl { text-decoration: underline }


### PR DESCRIPTION
Overflow of long lines will scroll, not wrap.

Since I was poking around the CSS for code blocks anyway, I simplified the rules and made the syntax highlighting match brand colors.

Fixes #1633