### PR TITLE
docstore/driver: add SplitActions

### DIFF
--- a/internal/docstore/driver/util.go
+++ b/internal/docstore/driver/util.go
@@ -21,3 +21,30 @@ import (
 // UniqueString generates a string that is unique with high probability.
 // Driver implementations can use it to generate keys for Create actions.
 func UniqueString() string { return uuid.New().String() }
+
+// SplitActions divides the actions slice into sub-slices much like strings.Split.
+// The split function should report whether two consecutive actions should be split,
+// that is, should be in different sub-slices. The first argument to split is the
+// last action of the sub-slice currently under construction; the second argument is
+// the action being considered for addition to that sub-slice.
+// SplitActions doesn't change the order of the input slice.
+func SplitActions(actions []*Action, split func(a, b *Action) bool) [][]*Action {
+	var (
+		groups [][]*Action // the actions, split; the return value
+		cur    []*Action   // the group currently being constructed
+	)
+	collect := func() { // called when the current group is known to be finished
+		if len(cur) > 0 {
+			groups = append(groups, cur)
+			cur = nil
+		}
+	}
+	for _, a := range actions {
+		if len(cur) > 0 && split(cur[len(cur)-1], a) {
+			collect()
+		}
+		cur = append(cur, a)
+	}
+	collect()
+	return groups
+}

--- a/internal/docstore/driver/util_test.go
+++ b/internal/docstore/driver/util_test.go
@@ -1,0 +1,72 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestSplitActions(t *testing.T) {
+	in := []*Action{
+		{Kind: Get},
+		{Kind: Get},
+		{Kind: Put},
+		{Kind: Update},
+		{Kind: Get},
+		{Kind: Create},
+	}
+
+	for _, test := range []struct {
+		desc  string
+		split func(a, b *Action) bool
+		want  [][]*Action
+	}{
+		{
+			"always false",
+			func(a, b *Action) bool { return false },
+			[][]*Action{in},
+		},
+		{
+			"always true",
+			func(a, b *Action) bool { return true },
+			[][]*Action{
+				{{Kind: Get}},
+				{{Kind: Get}},
+				{{Kind: Put}},
+				{{Kind: Update}},
+				{{Kind: Get}},
+				{{Kind: Create}},
+			},
+		},
+		{
+			"Get vs. other",
+			func(a, b *Action) bool { return (a.Kind == Get) != (b.Kind == Get) },
+			[][]*Action{
+				{{Kind: Get}, {Kind: Get}},
+				{{Kind: Put}, {Kind: Update}},
+				{{Kind: Get}},
+				{{Kind: Create}},
+			},
+		},
+	} {
+		got := SplitActions(in, test.split)
+		if diff := cmp.Diff(got, test.want, cmpopts.IgnoreFields(Action{}, "Doc")); diff != "" {
+			t.Errorf("%s: %s", test.desc, diff)
+		}
+	}
+}


### PR DESCRIPTION
More than one driver will want to split a list of actions to run into
groups to optimize RPCs. Since the logic is a little tricky, factor
out to a common function.

Use it for the Firestore driver.