### PR TITLE
docstore: move atomic-update test to memdocstore

### DIFF
--- a/internal/docstore/drivertest/drivertest.go
+++ b/internal/docstore/drivertest/drivertest.go
@@ -296,24 +296,6 @@ func testUpdate(t *testing.T, coll *ds.Collection) {
 			return coll.Update(ctx, dm, ds.Mods{"s": "c"})
 		})
 	})
-
-	// TODO(jba): this test doesn't work for all providers, because some (e.g. Firestore) do allow
-	// setting a subpath of a non-map field. So move this test to memdocstore.
-
-	// Check that update is atomic.
-	// doc = got
-	// mods := ds.Mods{"a": "Y", "c.d": "Z"} // "c" is not a map, so "c.d" is an error
-	// if err := coll.Update(ctx, doc, mods); err == nil {
-	// 	t.Fatal("got nil, want error")
-	// }
-	// got = docmap{KeyField: doc[KeyField]}
-	// if err := coll.Get(ctx, got); err != nil {
-	// 	t.Fatal(err)
-	// }
-	// // want should be unchanged
-	// if !cmp.Equal(got, want) {
-	// 	t.Errorf("got %v, want %v", got, want)
-	// }
 }
 
 func testRevisionField(t *testing.T, coll *ds.Collection, write func(docmap) error) {

--- a/internal/docstore/memdocstore/mem_test.go
+++ b/internal/docstore/memdocstore/mem_test.go
@@ -63,7 +63,6 @@ func TestUpdateAtomic(t *testing.T) {
 		"a":                    "A",
 		"b":                    "B",
 	}
-	// want should be unchanged
 	if !cmp.Equal(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}

--- a/internal/docstore/memdocstore/mem_test.go
+++ b/internal/docstore/memdocstore/mem_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"gocloud.dev/internal/docstore"
 	"gocloud.dev/internal/docstore/driver"
 	"gocloud.dev/internal/docstore/drivertest"
 )
@@ -37,4 +39,32 @@ func (h *harness) Close() {}
 func TestConformance(t *testing.T) {
 	// CodecTester is nil because memdocstore has no native representation.
 	drivertest.RunConformanceTests(t, newHarness, nil)
+}
+
+type docmap = map[string]interface{}
+
+func TestUpdateAtomic(t *testing.T) {
+	// Check that update is atomic.
+	ctx := context.Background()
+	coll := docstore.NewCollection(newCollection(drivertest.KeyField))
+	doc := docmap{drivertest.KeyField: "testUpdateAtomic", "a": "A", "b": "B"}
+
+	mods := docstore.Mods{"a": "Y", "b.c": "Z"} // "b" is not a map, so "b.c" is an error
+	if _, err := coll.Actions().Put(doc).Update(doc, mods).Do(ctx); err == nil {
+		t.Fatal("got nil, want error")
+	}
+	got := docmap{drivertest.KeyField: doc[drivertest.KeyField]}
+	if err := coll.Get(ctx, got); err != nil {
+		t.Fatal(err)
+	}
+	want := docmap{
+		drivertest.KeyField:    doc[drivertest.KeyField],
+		docstore.RevisionField: got[docstore.RevisionField],
+		"a":                    "A",
+		"b":                    "B",
+	}
+	// want should be unchanged
+	if !cmp.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
 }


### PR DESCRIPTION
The test in drivertest that verifies updates are atomic doesn't work
for all providers. So just test memdocstore.