### PR TITLE
pubsub/awssnssqs: send multiple receive and ack RPCs concurrently

### DIFF
--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -88,9 +88,9 @@ const (
 	maxReceiveConcurrency = 100
 	// maxAckConcurrency limits the number of DeleteMessage RPCs (for Acks) to SQS in flight.
 	maxAckConcurrency = 100
-  // How long ReceiveBatch should wait if no messages are available; controls
-  // the poll interval of requests to SQS.
-   noMessagesPollDuration = 250 * time.Millisecond
+	// How long ReceiveBatch should wait if no messages are available; controls
+	// the poll interval of requests to SQS.
+	noMessagesPollDuration = 250 * time.Millisecond
 )
 
 func init() {

--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -543,7 +543,7 @@ Loop:
 			id := id
 			g.Go(func() error {
 				defer func() { <-s.acksem }()
-				_, err := s.client.DeleteMessage(&sqs.DeleteMessageInput{
+				_, err := s.client.DeleteMessageWithContext(ctx, &sqs.DeleteMessageInput{
 					QueueUrl:      &s.qURL,
 					ReceiptHandle: id.(*string),
 				})

--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -83,7 +83,14 @@ const (
 	base64EncodedKey = "base64encoded"
 	// maxPublishConcurrency limits the number of Publish RPCs to SNS in flight
 	// at once, per Topic.
-	maxPublishConcurrency = 10
+	maxPublishConcurrency = 100
+	// maxReceiveConcurrency limits the number of Receive RPCs to SQS in flight.
+	maxReceiveConcurrency = 100
+	// maxAckConcurrency limits the number of DeleteMessage RPCs (for Acks) to SQS in flight.
+	maxAckConcurrency = 100
+  // How long ReceiveBatch should wait if no messages are available; controls
+  // the poll interval of requests to SQS.
+   noMessagesPollDuration = 250 * time.Millisecond
 )
 
 func init() {
@@ -187,7 +194,7 @@ func (o *URLOpener) OpenSubscriptionURL(ctx context.Context, u *url.URL) (*pubsu
 type topic struct {
 	client *sns.SNS
 	arn    string
-	sem    chan struct{} // limits maximum in-flight Public RPCs across SendBatch
+	sem    chan struct{} // limits maximum in-flight Publish RPCs across SendBatch
 	opts   *TopicOptions
 }
 
@@ -397,6 +404,7 @@ var errorCodeMap = map[string]gcerrors.ErrorCode{
 type subscription struct {
 	client *sqs.SQS
 	qURL   string
+	acksem chan struct{} // limits maximum in-flight DeleteMessage RPCs across SendAcks
 }
 
 // SubscriptionOptions will contain configuration for subscriptions.
@@ -411,21 +419,55 @@ func OpenSubscription(ctx context.Context, client *sqs.SQS, qURL string, opts *S
 
 // openSubscription returns a driver.Subscription.
 func openSubscription(ctx context.Context, client *sqs.SQS, qURL string) driver.Subscription {
-	return &subscription{client: client, qURL: qURL}
+	return &subscription{
+		client: client,
+		qURL:   qURL,
+		acksem: make(chan struct{}, maxAckConcurrency),
+	}
 }
 
-// How long ReceiveBatch should wait if no messages are available; controls
-// the poll interval of requests to SQS.
-const noMessagesPollDuration = 250 * time.Millisecond
-
 // ReceiveBatch implements driver.Subscription.ReceiveBatch.
-func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) (msgs []*driver.Message, er error) {
+func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*driver.Message, error) {
 	// SQS supports receiving at most 10 messages at a time:
 	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html
-	max := int64(maxMessages)
-	if max > 10 {
-		max = 10
+	// If maxMessages is larger than 10, we make up to maxReceiveConcurrency RPCs
+	// in parallel to try to get more.
+	const maxMessagesPerRPC = 10
+
+	var mu sync.Mutex
+	var ms []*driver.Message
+
+	g, ctx := errgroup.WithContext(ctx)
+	for n := 0; n < maxReceiveConcurrency && maxMessages > 0; n++ {
+		maxThisRPC := maxMessages
+		if maxThisRPC > maxMessagesPerRPC {
+			maxThisRPC = maxMessagesPerRPC
+		}
+		maxMessages -= maxThisRPC
+		g.Go(func() error {
+			msgs, err := s.receiveMessages(ctx, int64(maxThisRPC))
+			if err != nil {
+				return err
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			ms = append(ms, msgs...)
+			return nil
+		})
 	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	if len(ms) == 0 {
+		// When we return no messages and no error, the portable type will call
+		// ReceiveBatch again immediately. Sleep for a bit to avoid hammering SQS
+		// with RPCs.
+		time.Sleep(noMessagesPollDuration)
+	}
+	return ms, nil
+}
+
+func (s *subscription) receiveMessages(ctx context.Context, max int64) ([]*driver.Message, error) {
 	output, err := s.client.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
 		QueueUrl:            aws.String(s.qURL),
 		MaxNumberOfMessages: aws.Int64(max),
@@ -483,27 +525,36 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) (msgs 
 		}
 		ms = append(ms, m2)
 	}
-	if len(ms) == 0 {
-		// When we return no messages and no error, the portable type will call
-		// ReceiveBatch again immediately. Sleep for a bit to avoid hammering SQS
-		// with RPCs.
-		time.Sleep(noMessagesPollDuration)
-	}
 	return ms, nil
 }
 
 // SendAcks implements driver.Subscription.SendAcks.
 func (s *subscription) SendAcks(ctx context.Context, ids []driver.AckID) error {
+	g, ctx := errgroup.WithContext(ctx)
+	var ctxErr error
+
+Loop:
 	for _, id := range ids {
-		_, err := s.client.DeleteMessage(&sqs.DeleteMessageInput{
-			QueueUrl:      &s.qURL,
-			ReceiptHandle: id.(*string),
-		})
-		if err != nil {
-			return err
+		select {
+		case <-ctx.Done():
+			ctxErr = ctx.Err()
+			break Loop
+		case s.acksem <- struct{}{}:
+			id := id
+			g.Go(func() error {
+				defer func() { <-s.acksem }()
+				_, err := s.client.DeleteMessage(&sqs.DeleteMessageInput{
+					QueueUrl:      &s.qURL,
+					ReceiptHandle: id.(*string),
+				})
+				return err
+			})
 		}
 	}
-	return nil
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	return ctxErr
 }
 
 // IsRetryable implements driver.Subscription.IsRetryable.

--- a/pubsub/drivertest/drivertest.go
+++ b/pubsub/drivertest/drivertest.go
@@ -583,9 +583,9 @@ func benchmark(b *testing.B, topic *pubsub.Topic, sub *pubsub.Subscription, time
 	attrs := map[string]string{"label": "value"}
 	body := []byte("hello, world")
 	const (
-		nMessages          = 1000
-		concurrencySend    = 10
-		concurrencyReceive = 10
+		nMessages          = 10000
+		concurrencySend    = 100
+		concurrencyReceive = 100
 	)
 	if nMessages%concurrencySend != 0 || nMessages%concurrencyReceive != 0 {
 		b.Fatal("nMessages must be divisible by # of sending/receiving goroutines")
@@ -608,7 +608,7 @@ func benchmark(b *testing.B, topic *pubsub.Topic, sub *pubsub.Subscription, time
 			b.Fatalf("receiving: %v", err)
 		}
 		b.SetBytes(nMessages * 1e6)
-		b.Log("MB/s is actually number of messages received per second")
+		b.Logf("MB/s is actually number of messages received per second, %d/%d", i, b.N)
 		if timeSend {
 			b.StartTimer()
 		}


### PR DESCRIPTION
Benchmark results. The number represents the value of the 3 "max" constants in the code below.

```
HEAD: 102.99 MB/s
10: 509.93 MB/s
25: 1081.00 MB/s
50: 1887.33 MB/s
100: 2493.14 MB/s
250: 2022.15 MB/s
```

Based on that, I've chosen 100 as a sweet spot.

Fixes #1642.
