### PR TITLE
pubsub/gcppubsub: make Pull requests in parallel

### DIFF
--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -361,9 +361,10 @@ const (
 	// by more than that.
 	maxShrinkFactor = 0.75
 
-	// The maximum batch size to request.
-	// TODO(rvangent): Increase this.
-	maxBatchSize = 1000
+	// The maximum batch size to request. Setting this too low doesn't allow
+	// drivers to get lots of messages at once; setting it too small risks having
+	// drivers spend a long time in ReceiveBatch trying to achieve it.
+	maxBatchSize = 3000
 )
 
 // updateBatchSize updates the # of messages to request in ReceiveBatch based


### PR DESCRIPTION
Benchmark results. The number represents the value of the 3 "max" constants in the code below.

```
HEAD: 1725.95 MB/s
PR: 2093.29 MB/s
```

Not a huge win, but something. The numbers get better (including the advantage from this change) if you increase the number of message for the benchmark; it tends to be pretty slow at startup, with each RPC taking a full second (not sure why), and then at some point it ramps up and gets going pretty good.

Fixes #1643.