### PR TITLE
internal/website/content/howto/secrets: add section

### DIFF
--- a/internal/website/content/howto/secrets/_index.md
+++ b/internal/website/content/howto/secrets/_index.md
@@ -6,7 +6,17 @@ draft: true
 ---
 
 Cloud applications frequently need to store sensitive information like web
-API credentials or encryption keys in a medium that is not fully secure. The
-Go CDK provides access to key management providers in a portable way. These
-guides show how to work with secret keepers in the Go CDK.
+API credentials or encryption keys in a medium that is not fully secure. For
+example, an application that interacts with GitHub needs to store its OAuth2
+client secret and use it when obtaining end-user credentials. If this
+information was compromised, it could allow someone else to impersonate the
+application. In order to keep such information secret and secure, you can
+encrypt the data, but then you need to worry about rotating the encryption
+keys and distributing them securely to all of your application servers.
+Most cloud providers include a key management service to perform these tasks,
+usually with hardware-level security and audit logging.
+
+The Go CDK provides access to key management providers in a portable way
+called "secret keepers". These guides show how to work with secret keepers in
+the Go CDK.
 

--- a/internal/website/content/howto/secrets/_index.md
+++ b/internal/website/content/howto/secrets/_index.md
@@ -1,0 +1,12 @@
+---
+title: "Secrets"
+date: 2019-03-21T17:42:18-07:00
+showInSidenav: true
+draft: true
+---
+
+Cloud applications frequently need to store sensitive information like web
+API credentials or encryption keys in a medium that is not fully secure. The
+Go CDK provides access to key management providers in a portable way. These
+guides show how to work with secret keepers in the Go CDK.
+

--- a/internal/website/content/howto/secrets/crypt.md
+++ b/internal/website/content/howto/secrets/crypt.md
@@ -49,7 +49,7 @@ encrypting or decrypting large amounts of data is prohibitively slow (and in
 some providers not permitted). If you need your application to encrypt or
 decrypt large amounts of data, you should:
 
-1. generate a key for the encryption algorithm (16KiB chunks with
+1. Generate a key for the encryption algorithm (16KiB chunks with
    [`secretbox`][] is a reasonable approach).
 2. Encrypt the key with secret keeper.
 3. Store the encrypted key somewhere accessible to the application.

--- a/internal/website/content/howto/secrets/crypt.md
+++ b/internal/website/content/howto/secrets/crypt.md
@@ -1,0 +1,58 @@
+---
+title: "Encrypt & Decrypt Data"
+date: 2019-03-21T17:44:28-07:00
+draft: true
+weight: 2
+---
+
+Once you have [opened a secrets keeper][] for the secrets provider you want,
+you can encrypt and decrypt small messages using the keeper.
+
+[opened a secrets keeper]: {{< ref "./open-keeper.md" >}}
+
+## Encrypting data
+
+To encrypt data with a keeper, you call `Encrypt` with the byte slice you
+want to encrypt.
+
+```go
+plainText := []byte("Secrets secrets...")
+cipherText, err := keeper.Encrypt(ctx, plainText)
+if err != nil {
+    return err
+}
+```
+
+## Decrypting data
+
+To decrypt data with a keeper, you call `Decrypt` with the byte slice you
+want to decrypt. This should be data that you obtained from a previous call
+to `Encrypt` with a keeper that uses the same secret material (e.g. two AWS
+KMS keepers created with the same customer master key ID). The `Decrypt`
+method will return an error if the input data did not come from the same
+secret keeper (**TODO(light)**: verify with @clausti and @shantuo that this
+is correct).
+
+```go
+var cipherText []byte // obtained from elsewhere and random-looking
+plainText, err := keeper.Decrypt(ctx, cipherText)
+if err != nil {
+    return err
+}
+```
+
+## Large Messages
+
+The secrets keeper API is designed to work with small messages (i.e. <10 KiB
+in length.) Cloud key management services are high enough latency that using
+them for encrypting or decrypting large amounts of data is prohibitively slow
+(and in some cases not permitted). If you need your application to encrypt or
+decrypt large amounts of data, your application should generate a key for the
+encryption algorithm (16KiB chunks with [`secretbox`][] is a reasonable
+approach), encrypt the key with the secret keeper, and then store the
+encrypted key somewhere accessible to the application. When your application
+needs to encrypt or decrypt a large message, it would first decrypt the key
+from storage using the secret keeper then use the decrypted key to encrypt or
+decrypt the message in your application's local address space.
+
+[`secretbox`]: https://godoc.org/golang.org/x/crypto/nacl/secretbox

--- a/internal/website/content/howto/secrets/crypt.md
+++ b/internal/website/content/howto/secrets/crypt.md
@@ -44,15 +44,20 @@ if err != nil {
 ## Large Messages
 
 The secrets keeper API is designed to work with small messages (i.e. <10 KiB
-in length.) Cloud key management services are high enough latency that using
-them for encrypting or decrypting large amounts of data is prohibitively slow
-(and in some cases not permitted). If you need your application to encrypt or
-decrypt large amounts of data, your application should generate a key for the
-encryption algorithm (16KiB chunks with [`secretbox`][] is a reasonable
-approach), encrypt the key with the secret keeper, and then store the
-encrypted key somewhere accessible to the application. When your application
-needs to encrypt or decrypt a large message, it would first decrypt the key
-from storage using the secret keeper then use the decrypted key to encrypt or
-decrypt the message in your application's local address space.
+in length.) Cloud key management services are high latency; using them for
+encrypting or decrypting large amounts of data is prohibitively slow (and in
+some providers not permitted). If you need your application to encrypt or
+decrypt large amounts of data, you should:
+
+1. generate a key for the encryption algorithm (16KiB chunks with
+   [`secretbox`][] is a reasonable approach).
+2. Encrypt the key with secret keeper.
+3. Store the encrypted key somewhere accessible to the application.
+
+When your application needs to encrypt or decrypt a large message:
+
+1. Decrypt the key from storage using the secret keeper
+2. Use the decrypted key to encrypt or decrypt the message inside your
+   application.
 
 [`secretbox`]: https://godoc.org/golang.org/x/crypto/nacl/secretbox

--- a/internal/website/content/howto/secrets/open-keeper.md
+++ b/internal/website/content/howto/secrets/open-keeper.md
@@ -112,7 +112,8 @@ if err != nil {
 ## Google Cloud Key Management Service
 
 The Go CDK can use keys from Google Cloud Platform's [Key Management
-Service][GCP KMS] (GCP KMS) to keep information secret. GCP KMS URLs are very
+Service][GCP KMS] (GCP KMS) to keep information secret. `secrets.OpenKeeper`
+will use [Application Default Credentials][GCP credentials]. GCP KMS URLs are
 similar to [key resource IDs][]:
 
 ```go

--- a/internal/website/content/howto/secrets/open-keeper.md
+++ b/internal/website/content/howto/secrets/open-keeper.md
@@ -1,0 +1,242 @@
+---
+title: "Open a Secret Keeper"
+date: 2019-03-21T17:43:54-07:00
+draft: true
+weight: 1
+---
+
+The first step in working with your secrets is establishing your
+secret keeper provider. Every secret keeper provider is a little different, but the Go CDK
+lets you interact with all of them using the [`*secrets.Keeper` type][].
+
+[`*secrets.Keeper` type]: https://godoc.org/gocloud.dev/secrets#Keeper
+
+## Constructors versus URL openers
+
+If you know that your program is always going to use a particular secret
+keeper provider or you need fine-grained control over the connection
+settings, you should call the constructor function in the driver package
+directly (like `awskms.NewKeeper`). However, if you want to change providers
+based on configuration, you can use `secrets.OpenKeeper`, making sure you
+["blank import"][] the driver package to link it in. This guide will show how
+to use both forms for each secret keeper provider.
+
+["blank import"]: https://golang.org/doc/effective_go.html#blank_import
+
+## AWS Key Management Service
+
+The Go CDK can use customer master keys from Amazon Web Service's [Key
+Management Service][AWS KMS] (AWS KMS) to keep information secret. AWS KMS
+URLs can use the key's ID, alias, or Amazon Resource Name (ARN) to identify
+the key. You can specify the `region` query parameter to ensure your
+application connects to the correct region, but otherwise
+`secrets.OpenKeeper` will use the region found in the environment variable
+`AWS_REGION` or your AWS CLI configuration.
+
+```go
+import (
+    "gocloud.dev/secrets"
+    _ "gocloud.dev/secrets/awskms"
+)
+
+// ...
+
+// Use one of the following:
+
+// 1. By ID.
+keeperByID, err := secrets.OpenKeeper(ctx,
+    "awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1")
+if err != nil {
+    return err
+}
+
+// 2. By alias.
+keeperByAlias, err := secrets.OpenKeeper(ctx,
+    "awskms://alias/ExampleAlias?region=us-east-1")
+if err != nil {
+    return err
+}
+
+// 2. By ARN.
+const arn = "arn:aws:kms:us-east-1:111122223333:key/" +
+    "1234abcd-12ab-34bc-56ef-1234567890ab"
+keeperByARN, err := secrets.OpenKeeper(ctx,
+    "awskms://" + arn + "?region=us-east-1")
+if err != nil {
+    return err
+}
+```
+
+[AWS KMS]: https://aws.amazon.com/kms/
+
+## AWS Key Management Service Constructor
+
+The [`awskms.NewKeeper`][] constructor opens a customer master key. You must
+first create an [AWS session][] with the same region as your key and then
+connect to KMS:
+
+```go
+import (
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "gocloud.dev/secrets/awskms"
+)
+
+// ...
+
+// Establish an AWS session.
+// The region must match the region for "master-key-test".
+sess, err := session.NewSession(&aws.Config{
+    Region: aws.String("us-east-1"),
+})
+if err != nil {
+    return err
+}
+
+// Connect to KMS.
+kmsClient, err := awskms.Dial(sess)
+if err != nil {
+    return err
+}
+
+// Create a *secrets.Keeper.
+bucket, err := awskms.NewKeeper(kmsClient, "alias/master-key-test", nil)
+if err != nil {
+    return err
+}
+```
+
+[`awskms.NewKeeper`]: https://godoc.org/gocloud.dev/secrets/awskms#NewKeeper
+[AWS session]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
+
+## Google Cloud Key Management Service
+
+The Go CDK can use keys from Google Cloud Platform's [Key Management
+Service][GCP KMS] (GCP KMS) to keep information secret. GCP KMS URLs are very
+similar to [key resource IDs][]:
+
+```go
+import (
+    "gocloud.dev/secrets"
+    _ "gocloud.dev/secrets/gcpkms"
+)
+
+// ...
+
+keeper, err := secrets.OpenKeeper(ctx,
+    "gcpkms://projects/MYPROJECT/" +
+    "locations/MYLOCATION/" +
+    "keyRings/MYKEYRING/" +
+    "cryptoKeys/MYKEY")
+if err != nil {
+    return err
+}
+```
+
+[GCP KMS]: https://cloud.google.com/kms/
+[key resource IDs]: https://cloud.google.com/kms/docs/object-hierarchy#key
+
+### Google Cloud Key Management Service Constructor
+
+The [`gcpkms.NewKeeper`][] constructor opens a GCP KMS key. You must first
+obtain [GCP credentials][] and then create a gRPC connection to GCP KMS.
+
+```go
+import (
+    "gocloud.dev/gcp"
+    "gocloud.dev/secrets/gcpkms"
+)
+
+// ...
+
+// Your GCP credentials.
+// See https://cloud.google.com/docs/authentication/production
+// for more info on alternatives.
+creds, err := gcp.DefaultCredentials(ctx)
+if err != nil {
+    return err
+}
+
+// Create a KMS client.
+kmsClient, err := gcpkms.Dial(ctx, gcp.CredentialsTokenSource(creds))
+if err != nil {
+    return err
+}
+
+// Create a *blob.Bucket.
+const keyID = gcpkms.KeyResourceID(
+    "MYPROJECT", "MYLOCATION", "MYKEYRING", "MYKEY")
+keeper, err := gcpkms.NewKeeper(client, keyID, nil)
+if err != nil {
+    return err
+}
+```
+
+[GCP credentials]: https://cloud.google.com/docs/authentication/production
+[`gcpkms.NewKeeper`]: https://godoc.org/gocloud.dev/secrets/gcpkms#NewKeeper
+
+## HashiCorp Vault
+
+The Go CDK can use the [transit secrets engine][] in [Vault][] to keep
+information secret. Vault URLs only specify the key ID. The Vault server
+endpoint and authentication token are specified using the environment
+variables `VAULT_SERVER_URL` and `VAULT_SERVER_TOKEN`, respectively.
+
+```go
+import (
+    "gocloud.dev/secrets"
+    _ "gocloud.dev/secrets/vault"
+)
+
+// ...
+
+keeper, err := secrets.OpenKeeper(ctx, "vault://my-key")
+if err != nil {
+    return err
+}
+```
+
+[Vault]: https://www.vaultproject.io/
+[transit secrets engine]: https://www.vaultproject.io/docs/secrets/transit/index.html
+
+### HashiCorp Vault Constructor
+
+The [`vault.NewKeeper`][] constructor opens a transit secrets engine key. You
+must first connect to your Vault instance.
+
+```go
+import (
+    "github.com/hashicorp/vault/api"
+    "gocloud.dev/secrets/vault"
+)
+
+// ...
+
+vaultClient, err := vault.Dial(ctx, &vault.Config{
+    Token: "<Client (Root) Token>",
+    APIConfig: api.Config{
+        Address: "http://127.0.0.1:8200",
+    },
+})
+if err != nil {
+    return err
+}
+keeper := vault.NewKeeper(vaultClient, "my-key", nil)
+```
+
+[`vault.NewKeeper`]: https://godoc.org/gocloud.dev/secrets/vault#NewKeeper
+
+## Local Secrets
+
+**TODO(light):** Document https://godoc.org/gocloud.dev/secrets/localsecrets
+
+**Blocked on https://github.com/google/go-cloud/issues/1664**
+
+## What's Next
+
+Now that you have opened a secrets keeper, you can [encrypt and decrypt
+data][] and [access secret configuration data][] using portable operations.
+
+[access secret configuration data]: {{< ref "./runtimevar.md" >}}
+[encrypt and decrypt data]: {{< ref "./crypt.md" >}}
+

--- a/internal/website/content/howto/secrets/open-keeper.md
+++ b/internal/website/content/howto/secrets/open-keeper.md
@@ -163,7 +163,7 @@ if err != nil {
     return err
 }
 
-// Create a *blob.Bucket.
+// Create a *secrets.Keeper.
 const keyID = gcpkms.KeyResourceID(
     "MYPROJECT", "MYLOCATION", "MYKEYRING", "MYKEY")
 keeper, err := gcpkms.NewKeeper(client, keyID, nil)
@@ -213,7 +213,7 @@ import (
 // ...
 
 vaultClient, err := vault.Dial(ctx, &vault.Config{
-    Token: "<Client (Root) Token>",
+    Token: "CLIENT_TOKEN",
     APIConfig: api.Config{
         Address: "http://127.0.0.1:8200",
     },

--- a/internal/website/content/howto/secrets/runtimevar.md
+++ b/internal/website/content/howto/secrets/runtimevar.md
@@ -1,0 +1,30 @@
+---
+title: "Keep Secrets in Configuration"
+date: 2019-03-21T17:45:27-07:00
+draft: true
+weight: 3
+---
+
+Once you have [opened a secrets keeper][] for the secrets provider you want,
+you can use a secrets keeper to access sensitive configuration stored in an
+encrypted `runtimevar`.
+
+**TODO(light):** This change after https://github.com/google/go-cloud/issues/1667
+
+First, you create a [`*runtimevar.Decoder`][] configured to use your secrets
+keeper using [`runtimevar.DecryptDecode`][]. In this example, we assume the
+data is a plain string, but the configuration could be a more structured
+type. (**TODO(light)**: link to `runtimevar` guide when ready.)
+
+```go
+decodeFunc := runtimevar.DecryptDecode(ctx, keeper, runtimevar.StringDecode)
+decoder := runtimevar.NewDecoder("", decodeFunc)
+```
+
+Then you can pass the decoder to the runtime configuration provider of your
+choice. (**TODO(light)**: Link to opening `runtimevar` guide when ready.)
+
+[opened a secrets keeper]: {{< ref "./open-keeper.md" >}}
+[`*runtimevar.Decoder`]: https://godoc.org/gocloud.dev/runtimevar#Decoder
+[`runtimevar.DecryptDecode`]: https://godoc.org/gocloud.dev/runtimevar#DecryptDecode
+


### PR DESCRIPTION
Like #1630, kept as draft for now to batch how-to guide for publication. This guide has some intentional outstanding TODOs for issues that I found while writing the guide. This will need to be addressed before publishing, but should not change the structure of the guides AFAIK.

Updates #1576

/cc @clausti @shantuo for context on issues I've been opening.