### PR TITLE
docstore: improve codec for ints, uints

### DIFF
--- a/internal/docstore/driver/codec.go
+++ b/internal/docstore/driver/codec.go
@@ -19,7 +19,6 @@ package driver
 
 import (
 	"encoding"
-	"fmt"
 	"reflect"
 	"strconv"
 
@@ -432,11 +431,13 @@ func decode(v reflect.Value, d Decoder) error {
 		i, ok := d.AsInt()
 		if !ok {
 			// Accept a floating-point number with integral value.
-			if f, ok := d.AsFloat(); ok {
-				i = int64(f)
-				if float64(i) != f {
-					return fmt.Errorf("docstore: float %f does not fit into %s", f, v.Type())
-				}
+			f, ok := d.AsFloat()
+			if !ok {
+				return decodingError(v, d)
+			}
+			i = int64(f)
+			if float64(i) != f {
+				return gcerr.Newf(gcerr.InvalidArgument, nil, "float %f does not fit into %s", f, v.Type())
 			}
 		}
 		if v.OverflowInt(i) {
@@ -449,11 +450,13 @@ func decode(v reflect.Value, d Decoder) error {
 		u, ok := d.AsUint()
 		if !ok {
 			// Accept a floating-point number with integral value.
-			if f, ok := d.AsFloat(); ok {
-				u = uint64(f)
-				if float64(u) != f {
-					return fmt.Errorf("docstore: float %f does not fit into %s", f, v.Type())
-				}
+			f, ok := d.AsFloat()
+			if !ok {
+				return decodingError(v, d)
+			}
+			u = uint64(f)
+			if float64(u) != f {
+				return gcerr.Newf(gcerr.InvalidArgument, nil, "float %f does not fit into %s", f, v.Type())
 			}
 		}
 		if v.OverflowUint(u) {

--- a/internal/docstore/driver/codec_test.go
+++ b/internal/docstore/driver/codec_test.go
@@ -387,12 +387,45 @@ func TestDecodeErrors(t *testing.T) {
 			new(MyStruct),
 			map[string]interface{}{"E4": "E4"},
 		},
+		{
+			"int overflow",
+			new(int8),
+			257,
+		},
+		{
+			"uint overflow",
+			new(uint8),
+			uint(257),
+		},
+		{
+			"non-integral float (int)",
+			new(int),
+			1.5,
+		},
+		{
+			"non-integral float (uint)",
+			new(uint),
+			1.5,
+		},
 	} {
 		dec := &testDecoder{test.val}
 		err := Decode(reflect.ValueOf(test.in).Elem(), dec)
 		if e, ok := err.(*gcerr.Error); !ok || err == nil || e.Code != gcerr.InvalidArgument {
 			t.Errorf("%s: got %v, want InvalidArgument Error", test.desc, err)
-			fmt.Printf("%+v\n", test.in)
+		}
+	}
+}
+
+func TestDecodeFail(t *testing.T) {
+	// Verify that failure to decode a value results in an error.
+	for _, in := range []interface{}{
+		new(interface{}), new(bool), new(string), new(int), new(uint), new(float32), new(complex64),
+		new([]byte), new([]int), new(map[string]interface{}),
+	} {
+		dec := &failDecoder{}
+		err := Decode(reflect.ValueOf(in).Elem(), dec)
+		if e, ok := err.(*gcerr.Error); !ok || err == nil || e.Code != gcerr.InvalidArgument {
+			t.Errorf("%T: got %v, want InvalidArgument Error", in, err)
 		}
 	}
 }
@@ -409,10 +442,31 @@ func (d testDecoder) AsNull() bool {
 	return d.val == nil
 }
 
-func (d testDecoder) AsBool() (bool, bool)          { x, ok := d.val.(bool); return x, ok }
-func (d testDecoder) AsString() (string, bool)      { x, ok := d.val.(string); return x, ok }
-func (d testDecoder) AsInt() (int64, bool)          { x, ok := d.val.(int64); return x, ok }
-func (d testDecoder) AsUint() (uint64, bool)        { x, ok := d.val.(uint64); return x, ok }
+func (d testDecoder) AsBool() (bool, bool)     { x, ok := d.val.(bool); return x, ok }
+func (d testDecoder) AsString() (string, bool) { x, ok := d.val.(string); return x, ok }
+
+func (d testDecoder) AsInt() (int64, bool) {
+	switch v := d.val.(type) {
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	default:
+		return 0, false
+	}
+}
+
+func (d testDecoder) AsUint() (uint64, bool) {
+	switch v := d.val.(type) {
+	case uint64:
+		return v, true
+	case uint:
+		return uint64(v), true
+	default:
+		return 0, false
+	}
+}
+
 func (d testDecoder) AsFloat() (float64, bool)      { x, ok := d.val.(float64); return x, ok }
 func (d testDecoder) AsComplex() (complex128, bool) { x, ok := d.val.(complex128); return x, ok }
 func (d testDecoder) AsBytes() ([]byte, bool)       { x, ok := d.val.([]byte); return x, ok }
@@ -456,3 +510,22 @@ func (d testDecoder) AsSpecial(v reflect.Value) (bool, interface{}, error) {
 	}
 	return false, nil, nil
 }
+
+// All of failDecoder's methods return failure.
+type failDecoder struct{}
+
+func (failDecoder) String() string                                       { return "failDecoder" }
+func (failDecoder) AsNull() bool                                         { return false }
+func (failDecoder) AsBool() (bool, bool)                                 { return false, false }
+func (failDecoder) AsString() (string, bool)                             { return "", false }
+func (failDecoder) AsInt() (int64, bool)                                 { return 0, false }
+func (failDecoder) AsUint() (uint64, bool)                               { return 0, false }
+func (failDecoder) AsFloat() (float64, bool)                             { return 0, false }
+func (failDecoder) AsComplex() (complex128, bool)                        { return 0, false }
+func (failDecoder) AsBytes() ([]byte, bool)                              { return nil, false }
+func (failDecoder) ListLen() (int, bool)                                 { return 0, false }
+func (failDecoder) DecodeList(func(i int, vd Decoder) bool)              { panic("impossible") }
+func (failDecoder) MapLen() (int, bool)                                  { return 0, false }
+func (failDecoder) DecodeMap(func(key string, vd Decoder) bool)          { panic("impossible") }
+func (failDecoder) AsSpecial(v reflect.Value) (bool, interface{}, error) { return false, nil, nil }
+func (failDecoder) AsInterface() (interface{}, error)                    { return nil, errors.New("fail") }


### PR DESCRIPTION
- Report an error on failed int and uint decoding. We weren't failing
  property if a value couldn't be decoded as an int or uint.

- Also, test non-integral floats converting to int and uint. Improve
  the returned error.