### PR TITLE
internal/admin: create documentation label in repos

### DIFF
--- a/internal/admin/repository/main.tf
+++ b/internal/admin/repository/main.tf
@@ -117,6 +117,13 @@ resource "github_issue_label" "code_health" {
   description = "Code health task, either refactoring or testing"
 }
 
+resource "github_issue_label" "documentation" {
+  repository  = "${github_repository.repo.name}"
+  name        = "documentation"
+  color       = "edd782"
+  description = "Documentation change"
+}
+
 resource "github_issue_label" "duplicate" {
   repository  = "${github_repository.repo.name}"
   name        = "duplicate"


### PR DESCRIPTION
I'd like to be able to filter on documentation-only changes, since this
seems like a separate enough category.

`terraform plan` output:

```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + module.go_cloud_repo.github_issue_label.documentation
      id:          <computed>
      color:       "edd782"
      description: "Documentation change"
      etag:        <computed>
      name:        "documentation"
      repository:  "go-cloud"
      url:         <computed>

  + module.wire_repo.github_issue_label.documentation
      id:          <computed>
      color:       "edd782"
      description: "Documentation change"
      etag:        <computed>
      name:        "documentation"
      repository:  "wire"
      url:         <computed>


Plan: 2 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------
```