### PR TITLE
pubsub: ensure Message.Metadata is consistently nil if empty

### DIFF
--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -110,7 +110,8 @@ type Message struct {
 	// Body contains the content of the message.
 	Body []byte
 
-	// Metadata has key/value metadata for the message.
+	// Metadata has key/value metadata for the message. It will be nil if the
+	// message has no associated metadata.
 	Metadata map[string]string
 
 	// asFunc invokes driver.Message.AsFunc.
@@ -573,9 +574,13 @@ func (s *Subscription) getNextBatch(nMessages int) ([]*Message, error) {
 	var q []*Message
 	for _, m := range msgs {
 		id := m.AckID
+		md := m.Metadata
+		if len(md) == 0 {
+			md = nil
+		}
 		m2 := &Message{
 			Body:     m.Body,
-			Metadata: m.Metadata,
+			Metadata: md,
 			asFunc:   m.AsFunc,
 		}
 		if s.ackFunc == nil {


### PR DESCRIPTION
Before this PR, the behavior is inconsistent (it depends on driver behavior; some return an empty map, others return nil). Consistency is good.

I noticed this when running conformance tests that used a `nil` Metadata when sending and tried to verify that the received message matched; for some drivers, it did, and for others, it didn't (because the latter drivers returned an empty map instead of nil).