### PR TITLE
pubsub/rabbit: give up the lock when we're not receiving anything

### DIFF
--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -592,11 +592,9 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 			}
 
 		case <-maxTime:
-			// Timed out. Return whatever we have, or continue waiting if
-			// we haven't gotten anything yet.
-			if len(ms) > 0 {
-				return ms, nil
-			}
+			// Timed out. Return whatever we have. If we have nothing, we'll get
+			// called again soon, but returning allows us to give up the lock.
+			return ms, nil
 		}
 	}
 }


### PR DESCRIPTION
I found this hang exceedingly hard to reproduce, but I think the problem is that sometimes we'd end up looping forever in `ReceiveBatch`, holding the lock the whole time. Meanwhile, someone else is trying to ack/nack, but they can't get the lock. It's safer to return, give up the lock, and let the portable type call us back.

Fixes #1728.

