### PR TITLE
pubsub/awssnssqs: OpenTopic&OpenSubscription use ConfigProvider

### DIFF
--- a/pubsub/awssnssqs/awssnssqs_test.go
+++ b/pubsub/awssnssqs/awssnssqs_test.go
@@ -41,9 +41,8 @@ func TestOpenTopic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client := sns.New(sess, &aws.Config{})
 	fakeTopicARN := ""
-	topic := OpenTopic(ctx, client, fakeTopicARN, nil)
+	topic := OpenTopic(ctx, sess, fakeTopicARN, nil)
 	if err := topic.Send(ctx, &pubsub.Message{Body: []byte("")}); err == nil {
 		t.Error("got nil, want error from send to nonexistent topic")
 	}
@@ -55,9 +54,8 @@ func TestOpenSubscription(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client := sqs.New(sess, &aws.Config{})
 	fakeQURL := ""
-	sub := OpenSubscription(ctx, client, fakeQURL, nil)
+	sub := OpenSubscription(ctx, sess, fakeQURL, nil)
 	if _, err := sub.Receive(ctx); err == nil {
 		t.Error("got nil, want error from receive from nonexistent subscription")
 	}
@@ -95,7 +93,7 @@ func createTopic(ctx context.Context, topicName string, sess *session.Session) (
 	if err != nil {
 		return nil, nil, fmt.Errorf(`creating topic "%s": %v`, topicName, err)
 	}
-	dt = openTopic(ctx, client, *out.TopicArn, nil)
+	dt = openTopic(ctx, sess, *out.TopicArn, nil)
 	cleanup = func() {
 		client.DeleteTopic(&sns.DeleteTopicInput{TopicArn: out.TopicArn})
 	}
@@ -103,8 +101,7 @@ func createTopic(ctx context.Context, topicName string, sess *session.Session) (
 }
 
 func (h *harness) MakeNonexistentTopic(ctx context.Context) (driver.Topic, error) {
-	client := sns.New(h.sess)
-	dt := openTopic(ctx, client, "nonexistent-topic", nil)
+	dt := openTopic(ctx, h.sess, "nonexistent-topic", nil)
 	return dt, nil
 }
 
@@ -119,7 +116,7 @@ func createSubscription(ctx context.Context, dt driver.Topic, subName string, se
 	if err != nil {
 		return nil, nil, fmt.Errorf(`creating subscription queue "%s": %v`, subName, err)
 	}
-	ds = openSubscription(ctx, sqsClient, *out.QueueUrl)
+	ds = openSubscription(ctx, sess, *out.QueueUrl)
 
 	snsClient := sns.New(sess, &aws.Config{})
 	cleanupSub, err := subscribeQueueToTopic(ctx, sqsClient, snsClient, out.QueueUrl, dt)
@@ -190,8 +187,7 @@ func subscribeQueueToTopic(ctx context.Context, sqsClient *sqs.SQS, snsClient *s
 }
 
 func (h *harness) MakeNonexistentSubscription(ctx context.Context) (driver.Subscription, error) {
-	client := sqs.New(h.sess)
-	ds := openSubscription(ctx, client, "nonexistent-subscription")
+	ds := openSubscription(ctx, h.sess, "nonexistent-subscription")
 	return ds, nil
 }
 

--- a/pubsub/awssnssqs/example_test.go
+++ b/pubsub/awssnssqs/example_test.go
@@ -20,8 +20,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sns"
-	"github.com/aws/aws-sdk-go/service/sqs"
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/awssnssqs"
 )
@@ -36,13 +34,11 @@ func ExampleOpenTopic() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	// Establish an SNS client.
-	client := sns.New(session)
 
 	// Construct a *pubsub.Topic.
 	// https://docs.aws.amazon.com/gettingstarted/latest/deploy/creating-an-sns-topic.html
 	topicARN := "arn:aws:service:region:accountid:resourceType/resourcePath"
-	t := awssnssqs.OpenTopic(ctx, client, topicARN, nil)
+	t := awssnssqs.OpenTopic(ctx, session, topicARN, nil)
 	defer t.Shutdown(ctx)
 
 	// Now we can use t to send messages.
@@ -59,13 +55,11 @@ func ExampleOpenSubscription() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	// Establish an SQS client.
-	client := sqs.New(session)
 
 	// Construct a *pubsub.Subscription.
 	// https://docs.aws.amazon.com/sdk-for-net/v2/developer-guide/QueueURL.html
 	queueURL := "https://region-endpoint/queue/account-number/queue-name"
-	s := awssnssqs.OpenSubscription(ctx, client, queueURL, nil)
+	s := awssnssqs.OpenSubscription(ctx, session, queueURL, nil)
 	defer s.Shutdown(ctx)
 
 	// Now we can use s to receive messages.


### PR DESCRIPTION
Migrated OpenTopic&OpenSubscription functions to use ConfigProvider: 

Fixes #1713.
