### PR TITLE
pubsub: add a finalizer that complains if a message isn't acked/nacked

### DIFF
--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -537,8 +537,10 @@ func (s *Subscription) Receive(ctx context.Context) (_ *Message, err error) {
 			if s.ackFunc == nil {
 				// Add a finalizer that complains if the Message we return isn't
 				// acked or nacked.
-				_, file, lineno, ok := runtime.Caller(1)
+				_, file, lineno, ok := runtime.Caller(1) // the caller of Receive
 				runtime.SetFinalizer(m, func(m *Message) {
+					m.mu.Lock()
+					defer m.mu.Unlock()
 					if !m.isAcked {
 						var caller string
 						if ok {

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -167,6 +167,7 @@ func TestConcurrentReceivesGetAllTheMessages(t *testing.T) {
 					}
 					return
 				}
+				m.Ack()
 				mu.Lock()
 				receivedMsgs[string(m.Body)] = true
 				mu.Unlock()


### PR DESCRIPTION
Fixes #1454.

This is similar to the finalizer we have for blob.Reader/Writer:
https://github.com/google/go-cloud/blob/master/blob/blob.go#L658