### PR TITLE
pubsub/awssnssqs: Changed UrlOpener scheme to awssns and awssqs

### DIFF
--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -18,7 +18,7 @@
 // URLs
 //
 // For pubsub.OpenTopic and pubsub.OpenSubscription, awssnssqs registers
-// for the scheme "awssnssqs".
+// for the scheme's "awssns" and "awssqs" respectively.
 // The default URL opener will use an AWS session with the default credentials
 // and configuration; see https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
 // for more details.
@@ -105,8 +105,8 @@ var ackBatcherOpts = &batcher.Options{
 
 func init() {
 	lazy := new(lazySessionOpener)
-	pubsub.DefaultURLMux().RegisterTopic(Scheme, lazy)
-	pubsub.DefaultURLMux().RegisterSubscription(Scheme, lazy)
+	pubsub.DefaultURLMux().RegisterTopic(SNSScheme, lazy)
+	pubsub.DefaultURLMux().RegisterSubscription(SQSScheme, lazy)
 }
 
 // Set holds Wire providers for this package.
@@ -156,11 +156,14 @@ func (o *lazySessionOpener) OpenSubscriptionURL(ctx context.Context, u *url.URL)
 	return opener.OpenSubscriptionURL(ctx, u)
 }
 
-// Scheme is the URL scheme awssnssqs registers its URLOpeners under on pubsub.DefaultMux.
-const Scheme = "awssnssqs"
+// SNSScheme is the URL scheme for pubsub.OpenTopic awssnssqs registers its URLOpeners under on pubsub.DefaultMux.
+const SNSScheme = "awssns"
 
-// URLOpener opens AWS SNS/SQS URLs like "awssnssqs://sns-topic-arn" for
-// topics or "awssnssqs://sqs-queue-url" for subscriptions.
+// SQSScheme is the URL scheme for pubsub.OpenSubscription awssnssqs registers its URLOpeners under on pubsub.DefaultMux.
+const SQSScheme = "awssqs"
+
+// URLOpener opens AWS SNS/SQS URLs like "awssns://sns-topic-arn" for
+// topics or "awssqs://sqs-queue-url" for subscriptions.
 //
 // For topics, the URL's host+path is used as the topic Amazon Resource Name
 // (ARN).

--- a/pubsub/awssnssqs/awssnssqs_test.go
+++ b/pubsub/awssnssqs/awssnssqs_test.go
@@ -316,11 +316,11 @@ func TestOpenTopicFromURL(t *testing.T) {
 		WantErr bool
 	}{
 		// OK.
-		{"awssnssqs://arn:aws:service:region:accountid:resourceType/resourcePath", false},
+		{"awssns://arn:aws:service:region:accountid:resourceType/resourcePath", false},
 		// OK, setting region.
-		{"awssnssqs://arn:aws:service:region:accountid:resourceType/resourcePath?region=us-east-2", false},
+		{"awssns://arn:aws:service:region:accountid:resourceType/resourcePath?region=us-east-2", false},
 		// Invalid parameter.
-		{"awssnssqs://arn:aws:service:region:accountid:resourceType/resourcePath?param=value", true},
+		{"awssns://arn:aws:service:region:accountid:resourceType/resourcePath?param=value", true},
 	}
 
 	ctx := context.Background()
@@ -338,11 +338,11 @@ func TestOpenSubscriptionFromURL(t *testing.T) {
 		WantErr bool
 	}{
 		// OK.
-		{"awssnssqs://sqs.us-east-2.amazonaws.com/99999/my-subscription", false},
+		{"awssqs://sqs.us-east-2.amazonaws.com/99999/my-subscription", false},
 		// OK, setting region.
-		{"awssnssqs://sqs.us-east-2.amazonaws.com/99999/my-subscription?region=us-east-2", false},
+		{"awssqs://sqs.us-east-2.amazonaws.com/99999/my-subscription?region=us-east-2", false},
 		// Invalid parameter.
-		{"awssnssqs://sqs.us-east-2.amazonaws.com/99999/my-subscription?param=value", true},
+		{"awssqs://sqs.us-east-2.amazonaws.com/99999/my-subscription?param=value", true},
 	}
 
 	ctx := context.Background()

--- a/pubsub/awssnssqs/example_test.go
+++ b/pubsub/awssnssqs/example_test.go
@@ -82,10 +82,10 @@ func Example_openFromURL() {
 
 	// OpenTopic creates a *pubsub.Topic from a URL.
 	// This URL will open the topic with the topic ARN "arn:aws:service:region:accountid:resourceType/resourcePath".
-	t, err := pubsub.OpenTopic(ctx, "awssnssqs://arn:aws:service:region:accountid:resourceType/resourcePath")
+	t, err := pubsub.OpenTopic(ctx, "awssns://arn:aws:service:region:accountid:resourceType/resourcePath")
 
 	// Similarly, OpenSubscription creates a *pubsub.Subscription from a URL.
 	// This URL will open the subscription with the URL "https://awssnssqs://sqs.us-east-2.amazonaws.com/99999/my-subscription".
-	s, err := pubsub.OpenSubscription(ctx, "awssnssqs://sqs.us-east-2.amazonaws.com/99999/my-subscription")
+	s, err := pubsub.OpenSubscription(ctx, "awssqs://sqs.us-east-2.amazonaws.com/99999/my-subscription")
 	_, _, _ = t, s, err
 }


### PR DESCRIPTION
Changed pubsub/awssnssqs UrlOpener scheme from `awssnssqs` to `sns` and `sqs` respectively.
Fixes #1707 