### PR TITLE
docstore: add collection name arg to Harness.MakeCollection

### DIFF
--- a/internal/docstore/drivertest/drivertest.go
+++ b/internal/docstore/drivertest/drivertest.go
@@ -35,7 +35,7 @@ import (
 // conformance tests.
 type Harness interface {
 	// MakeCollection makes a driver.Collection for testing.
-	MakeCollection(context.Context) (driver.Collection, error)
+	MakeCollection(_ context.Context, name string) (driver.Collection, error)
 
 	// Close closes resources used by the harness.
 	Close()
@@ -78,22 +78,24 @@ type CodecTester interface {
 	DocstoreDecode(value, dest interface{}) error
 }
 
+const collectionName = "docstore-test"
+
 // RunConformanceTests runs conformance tests for provider implementations of docstore.
 func RunConformanceTests(t *testing.T, newHarness HarnessMaker, ct CodecTester) {
-	t.Run("Create", func(t *testing.T) { withCollection(t, newHarness, testCreate) })
-	t.Run("Put", func(t *testing.T) { withCollection(t, newHarness, testPut) })
-	t.Run("Replace", func(t *testing.T) { withCollection(t, newHarness, testReplace) })
-	t.Run("Get", func(t *testing.T) { withCollection(t, newHarness, testGet) })
-	t.Run("Delete", func(t *testing.T) { withCollection(t, newHarness, testDelete) })
-	t.Run("Update", func(t *testing.T) { withCollection(t, newHarness, testUpdate) })
-	t.Run("Data", func(t *testing.T) { withCollection(t, newHarness, testData) })
+	t.Run("Create", func(t *testing.T) { withCollection(t, newHarness, collectionName, testCreate) })
+	t.Run("Put", func(t *testing.T) { withCollection(t, newHarness, collectionName, testPut) })
+	t.Run("Replace", func(t *testing.T) { withCollection(t, newHarness, collectionName, testReplace) })
+	t.Run("Get", func(t *testing.T) { withCollection(t, newHarness, collectionName, testGet) })
+	t.Run("Delete", func(t *testing.T) { withCollection(t, newHarness, collectionName, testDelete) })
+	t.Run("Update", func(t *testing.T) { withCollection(t, newHarness, collectionName, testUpdate) })
+	t.Run("Data", func(t *testing.T) { withCollection(t, newHarness, collectionName, testData) })
 	t.Run("TypeDrivenCodec", func(t *testing.T) { testTypeDrivenDecode(t, ct) })
 	// t.Run("BlindCodec", func(t *testing.T) { testBlindDecode(t, ct) })
 }
 
 const KeyField = "_id"
 
-func withCollection(t *testing.T, newHarness HarnessMaker, f func(*testing.T, *ds.Collection)) {
+func withCollection(t *testing.T, newHarness HarnessMaker, name string, f func(*testing.T, *ds.Collection)) {
 	ctx := context.Background()
 	h, err := newHarness(ctx, t)
 	if err != nil {
@@ -101,7 +103,7 @@ func withCollection(t *testing.T, newHarness HarnessMaker, f func(*testing.T, *d
 	}
 	defer h.Close()
 
-	dc, err := h.MakeCollection(ctx)
+	dc, err := h.MakeCollection(ctx, name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/docstore/firedocstore/fs_test.go
+++ b/internal/docstore/firedocstore/fs_test.go
@@ -28,10 +28,9 @@ import (
 
 const (
 	// projectID is the project ID that was used during the last test run using --record.
-	projectID      = "go-cloud-test-216917"
-	collectionName = "docstore-test"
-	keyName        = "_id"
-	endPoint       = "firestore.googleapis.com:443"
+	projectID = "go-cloud-test-216917"
+	keyName   = "_id"
+	endPoint  = "firestore.googleapis.com:443"
 )
 
 type harness struct {
@@ -49,8 +48,8 @@ func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
 	return &harness{client, done}, nil
 }
 
-func (h *harness) MakeCollection(context.Context) (driver.Collection, error) {
-	return newCollection(h.client, projectID, collectionName, keyName), nil
+func (h *harness) MakeCollection(_ context.Context, name string) (driver.Collection, error) {
+	return newCollection(h.client, projectID, name, keyName), nil
 }
 
 func (h *harness) Close() {

--- a/internal/docstore/memdocstore/mem_test.go
+++ b/internal/docstore/memdocstore/mem_test.go
@@ -30,7 +30,7 @@ func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
 	return &harness{}, nil
 }
 
-func (h *harness) MakeCollection(context.Context) (driver.Collection, error) {
+func (h *harness) MakeCollection(context.Context, string) (driver.Collection, error) {
 	return newCollection(drivertest.KeyField), nil
 }
 

--- a/internal/docstore/mongodocstore/mongo_test.go
+++ b/internal/docstore/mongodocstore/mongo_test.go
@@ -31,9 +31,8 @@ import (
 )
 
 const (
-	serverURI      = "mongodb://localhost"
-	dbName         = "docstore-test"
-	collectionName = "docstore-test"
+	serverURI = "mongodb://localhost"
+	dbName    = "docstore-test"
 )
 
 type harness struct {
@@ -60,8 +59,8 @@ func newClient(ctx context.Context, uri string) (*mongo.Client, error) {
 	return client, nil
 }
 
-func (h *harness) MakeCollection(ctx context.Context) (driver.Collection, error) {
-	coll := newCollection(h.db.Collection(collectionName))
+func (h *harness) MakeCollection(ctx context.Context, name string) (driver.Collection, error) {
+	coll := newCollection(h.db.Collection(name))
 	// It seems that the client doesn't actually connect until the first RPC, which will
 	// be this one. So time out quickly if there's a problem.
 	tctx, cancel := context.WithTimeout(ctx, 5*time.Second)


### PR DESCRIPTION
We'll want to create a separate collection for testing queries,
for better control over its exact contents.