### PR TITLE
pubsub: convert to Message as late as possible

### DIFF
--- a/pubsub/drivertest/drivertest.go
+++ b/pubsub/drivertest/drivertest.go
@@ -825,6 +825,7 @@ func testAs(t *testing.T, newHarness HarnessMaker, st AsTest) {
 	if err := st.MessageCheck(m); err != nil {
 		t.Error(err)
 	}
+	m.Ack()
 
 	top = pubsub.NewTopic(dt, batchSizeOne)
 	defer func() {

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -132,6 +132,7 @@ func TestSendReceive(t *testing.T) {
 	if string(m2.Body) != string(m.Body) {
 		t.Fatalf("received message has body %q, want %q", m2.Body, m.Body)
 	}
+	m2.Ack()
 }
 
 func TestConcurrentReceivesGetAllTheMessages(t *testing.T) {
@@ -316,10 +317,11 @@ func (*failTopic) ErrorCode(error) gcerrors.ErrorCode { return gcerrors.Unknown 
 func TestRetryReceive(t *testing.T) {
 	fs := &failSub{}
 	sub := pubsub.NewSubscription(fs, nil, nil)
-	_, err := sub.Receive(context.Background())
+	m, err := sub.Receive(context.Background())
 	if err != nil {
-		t.Errorf("Receive: got %v, want nil", err)
+		t.Fatalf("Receive: got %v, want nil", err)
 	}
+	m.Ack()
 	if got, want := fs.calls, nRetryCalls+1; got != want {
 		t.Errorf("calls: got %d, want %d", got, want)
 	}
@@ -338,9 +340,9 @@ func (t *failSub) ReceiveBatch(ctx context.Context, maxMessages int) ([]*driver.
 	return []*driver.Message{{Body: []byte("")}}, nil
 }
 
-func (t *failSub) IsRetryable(err error) bool { return isRetryable(err) }
-
-func (*failSub) AckFunc() func() { return nil }
+func (*failSub) SendAcks(ctx context.Context, ackIDs []driver.AckID) error { return nil }
+func (*failSub) IsRetryable(err error) bool                                { return isRetryable(err) }
+func (*failSub) AckFunc() func()                                           { return nil }
 
 // TODO(jba): add a test for retry of SendAcks.
 

--- a/pubsub/sub_test.go
+++ b/pubsub/sub_test.go
@@ -57,8 +57,9 @@ func TestReceiveWithEmptyBatchReturnedFromDriver(t *testing.T) {
 	}
 	sub := pubsub.NewSubscription(ds, nil, nil)
 	defer sub.Shutdown(ctx)
-	_, err := sub.Receive(ctx)
+	m, err := sub.Receive(ctx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
+	m.Ack()
 }


### PR DESCRIPTION
Fixes #1743.

Recently I changed `pubsub` to convert from `driver.Message` to `Message` when messages arrive from the driver via `ReceiveBatch`, so they are stored in the queue as `*Message`. This interferes with accurate reporting of a `Message` going out of scope without ack/nack being called, because the array holding the queue often holds a reference to a message even after the message has been returned and re-sliced past it.

This PR changes pubsub back to converting to `Message` at the last minute, and holding `driver.Message` in the queue.

This flushed out a few more places in tests where we weren't calling `Ack`.