### PR TITLE
all: Rename session-->sess in examples to avoid package name shadowing

### DIFF
--- a/blob/s3blob/example_test.go
+++ b/blob/s3blob/example_test.go
@@ -28,14 +28,14 @@ func Example() {
 	// Establish an AWS session.
 	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more info.
 	// The region must match the region for "my_bucket".
-	session, err := session.NewSession(&aws.Config{Region: aws.String("us-west-1")})
+	sess, err := session.NewSession(&aws.Config{Region: aws.String("us-west-1")})
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Create a *blob.Bucket.
 	ctx := context.Background()
-	b, err := s3blob.OpenBucket(ctx, session, "my-bucket", nil)
+	b, err := s3blob.OpenBucket(ctx, sess, "my-bucket", nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pubsub/awssnssqs/example_test.go
+++ b/pubsub/awssnssqs/example_test.go
@@ -30,7 +30,7 @@ func ExampleOpenTopic() {
 	// Establish an AWS session.
 	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more info.
 	// The region must match the region where your topic is provisioned.
-	session, err := session.NewSession(&aws.Config{Region: aws.String("us-west-1")})
+	sess, err := session.NewSession(&aws.Config{Region: aws.String("us-west-1")})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func ExampleOpenTopic() {
 	// Construct a *pubsub.Topic.
 	// https://docs.aws.amazon.com/gettingstarted/latest/deploy/creating-an-sns-topic.html
 	topicARN := "arn:aws:service:region:accountid:resourceType/resourcePath"
-	t := awssnssqs.OpenTopic(ctx, session, topicARN, nil)
+	t := awssnssqs.OpenTopic(ctx, sess, topicARN, nil)
 	defer t.Shutdown(ctx)
 
 	// Now we can use t to send messages.
@@ -51,7 +51,7 @@ func ExampleOpenSubscription() {
 	// Establish an AWS session.
 	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more info.
 	// The region must match the region where your topic is provisioned.
-	session, err := session.NewSession(&aws.Config{Region: aws.String("us-west-1")})
+	sess, err := session.NewSession(&aws.Config{Region: aws.String("us-west-1")})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func ExampleOpenSubscription() {
 	// Construct a *pubsub.Subscription.
 	// https://docs.aws.amazon.com/sdk-for-net/v2/developer-guide/QueueURL.html
 	queueURL := "https://region-endpoint/queue/account-number/queue-name"
-	s := awssnssqs.OpenSubscription(ctx, session, queueURL, nil)
+	s := awssnssqs.OpenSubscription(ctx, sess, queueURL, nil)
 	defer s.Shutdown(ctx)
 
 	// Now we can use s to receive messages.

--- a/runtimevar/awsparamstore/example_test.go
+++ b/runtimevar/awsparamstore/example_test.go
@@ -32,7 +32,7 @@ type MyConfig struct {
 func Example() {
 	// Establish an AWS session.
 	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more info.
-	session, err := session.NewSession(nil)
+	sess, err := session.NewSession(nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func Example() {
 	// Construct a *runtimevar.Variable that watches the variable.
 	// For this example, the Parameter Store variable being referenced
 	// should have a JSON string that decodes into MyConfig.
-	v, err := awsparamstore.NewVariable(session, "cfg-variable-name", decoder, nil)
+	v, err := awsparamstore.NewVariable(sess, "cfg-variable-name", decoder, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/secrets/awskms/example_test.go
+++ b/secrets/awskms/example_test.go
@@ -26,13 +26,13 @@ import (
 func Example() {
 	// Establish an AWS session.
 	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more info.
-	session, err := session.NewSession(nil)
+	sess, err := session.NewSession(nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Get a client to use with the KMS API.
-	client, err := awskms.Dial(session)
+	client, err := awskms.Dial(sess)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #1705
