### PR TITLE
blob: fix up some comments about errors

### DIFF
--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -218,8 +218,8 @@ type Bucket interface {
 	ErrorAs(error, interface{}) bool
 
 	// Attributes returns attributes for the blob. If the specified object does
-	// not exist, Attributes must return an error for which IsNotExist returns
-	// true.
+	// not exist, Attributes must return an error for which ErrorCode returns
+	// gcerrors.NotFound.
 	Attributes(ctx context.Context, key string) (Attributes, error)
 
 	// ListPaged lists objects in the bucket, in lexicographical order by
@@ -234,8 +234,8 @@ type Bucket interface {
 	// NewRangeReader returns a Reader that reads part of an object, reading at
 	// most length bytes starting at the given offset. If length is negative, it
 	// will read until the end of the object. If the specified object does not
-	// exist, NewRangeReader must return an error for which IsNotExist returns
-	// true.
+	// exist, NewRangeReader must return an error for which ErrorCode returns
+	// gcerrors.NotFound.
 	// opts is guaranteed to be non-nil.
 	NewRangeReader(ctx context.Context, key string, offset, length int64, opts *ReaderOptions) (Reader, error)
 
@@ -256,14 +256,14 @@ type Bucket interface {
 	NewTypedWriter(ctx context.Context, key string, contentType string, opts *WriterOptions) (Writer, error)
 
 	// Delete deletes the object associated with key. If the specified object does
-	// not exist, NewRangeReader must return an error for which IsNotExist returns
-	// true.
+	// not exist, Delete must return an error for which ErrorCode returns
+	// gcerrors.NotFound.
 	Delete(ctx context.Context, key string) error
 
 	// SignedURL returns a URL that can be used to GET the blob for the duration
 	// specified in opts.Expiry. opts is guaranteed to be non-nil.
-	// If not supported, return an error for which IsNotImplemented returns
-	// true.
+	// If not supported, return an error for which ErrorCode returns
+	// gcerrors.Unimplemented.
 	SignedURL(ctx context.Context, key string, opts *SignedURLOptions) (string, error)
 
 	// Close cleans up any resources used by the Bucket. Once Close is called,


### PR DESCRIPTION
I think these were missed when converting to `gcerror`.