### PR TITLE
blob/all: add a Copy method BREAKING_CHANGE_OK

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -317,7 +317,7 @@ func (b *bucket) Close() error {
 var errUnimplemented = errors.New("not implemented")
 
 // Copy implements driver.Copy.
-func (b *bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *driver.CopyOptions) error {
+func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.CopyOptions) error {
 	// TODO(rvangent): Implement this and delete errUnimplemented.
 	return errUnimplemented
 }

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -309,8 +309,17 @@ func openBucket(ctx context.Context, pipeline pipeline.Pipeline, accountName Acc
 	}, nil
 }
 
+// Close implements driver.Close.
 func (b *bucket) Close() error {
 	return nil
+}
+
+var errUnimplemented = errors.New("not implemented")
+
+// Copy implements driver.Copy.
+func (b *bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *driver.CopyOptions) error {
+	// TODO(rvangent): Implement this and delete errUnimplemented.
+	return errUnimplemented
 }
 
 // Delete implements driver.Delete.
@@ -418,6 +427,9 @@ func (b *bucket) ErrorAs(err error, i interface{}) bool {
 }
 
 func (b *bucket) ErrorCode(err error) gcerrors.ErrorCode {
+	if err == errUnimplemented {
+		return gcerrors.Unimplemented
+	}
 	serr, ok := err.(azblob.StorageError)
 	switch {
 	case !ok:

--- a/blob/azureblob/testdata/TestConformance/TestCopy/Works.yaml
+++ b/blob/azureblob/testdata/TestConformance/TestCopy/Works.yaml
@@ -1,0 +1,117 @@
+---
+version: 1
+interactions:
+- request:
+    body: Hello World
+    form: {}
+    headers:
+      Content-Length:
+      - "11"
+      User-Agent:
+      - go-cloud/blob/0.1.0 Azure-Storage/0.4 (go1.12; linux)
+      X-Ms-Blob-Cache-Control:
+      - no-cache
+      X-Ms-Blob-Content-Disposition:
+      - inline
+      X-Ms-Blob-Content-Encoding:
+      - identity
+      X-Ms-Blob-Content-Language:
+      - en
+      X-Ms-Blob-Content-Type:
+      - text/plain
+      X-Ms-Blob-Type:
+      - BlockBlob
+      X-Ms-Meta-Foo:
+      - bar
+      X-Ms-Version:
+      - "2018-03-28"
+      x-ms-date:
+      - Thu, 04 Apr 2019 16:29:44 GMT
+    url: https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-src
+    method: PUT
+  response:
+    body: ""
+    headers:
+      Content-Length:
+      - "0"
+      Content-Md5:
+      - sQqNsWTgdUEFt6mb5y4/5Q==
+      Date:
+      - Thu, 04 Apr 2019 16:29:44 GMT
+      Etag:
+      - '"0x8D6B91ABF32769A"'
+      Last-Modified:
+      - Thu, 04 Apr 2019 16:29:44 GMT
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - d0dbe0e4-401e-0068-3803-ebcbe5000000
+      X-Ms-Request-Server-Encrypted:
+      - "true"
+      X-Ms-Version:
+      - "2018-03-28"
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - go-cloud/blob/0.1.0 Azure-Storage/0.4 (go1.12; linux)
+      X-Ms-Version:
+      - "2018-03-28"
+      x-ms-date:
+      - Thu, 04 Apr 2019 16:29:44 GMT
+    url: https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-src
+    method: HEAD
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Disposition:
+      - inline
+      Content-Encoding:
+      - identity
+      Content-Language:
+      - en
+      Content-Length:
+      - "11"
+      Content-Md5:
+      - sQqNsWTgdUEFt6mb5y4/5Q==
+      Content-Type:
+      - text/plain
+      Date:
+      - Thu, 04 Apr 2019 16:29:44 GMT
+      Etag:
+      - '"0x8D6B91ABF32769A"'
+      Last-Modified:
+      - Thu, 04 Apr 2019 16:29:44 GMT
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Access-Tier:
+      - Hot
+      X-Ms-Access-Tier-Inferred:
+      - "true"
+      X-Ms-Blob-Type:
+      - BlockBlob
+      X-Ms-Creation-Time:
+      - Thu, 04 Apr 2019 16:29:23 GMT
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Meta-Foo:
+      - bar
+      X-Ms-Request-Id:
+      - d0dbe0f4-401e-0068-4403-ebcbe5000000
+      X-Ms-Server-Encrypted:
+      - "true"
+      X-Ms-Version:
+      - "2018-03-28"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/blob/azureblob/testdata/TestConformance/TestCopy/Works.yaml
+++ b/blob/azureblob/testdata/TestConformance/TestCopy/Works.yaml
@@ -26,7 +26,7 @@ interactions:
       X-Ms-Version:
       - "2018-03-28"
       x-ms-date:
-      - Thu, 04 Apr 2019 16:29:44 GMT
+      - Fri, 05 Apr 2019 17:03:41 GMT
     url: https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-src
     method: PUT
   response:
@@ -37,15 +37,15 @@ interactions:
       Content-Md5:
       - sQqNsWTgdUEFt6mb5y4/5Q==
       Date:
-      - Thu, 04 Apr 2019 16:29:44 GMT
+      - Fri, 05 Apr 2019 17:03:41 GMT
       Etag:
-      - '"0x8D6B91ABF32769A"'
+      - '"0x8D6B9E8A7AB75E1"'
       Last-Modified:
-      - Thu, 04 Apr 2019 16:29:44 GMT
+      - Fri, 05 Apr 2019 17:03:41 GMT
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d0dbe0e4-401e-0068-3803-ebcbe5000000
+      - 9b4fcb5e-001e-0106-72d1-eb2499000000
       X-Ms-Request-Server-Encrypted:
       - "true"
       X-Ms-Version:
@@ -62,7 +62,7 @@ interactions:
       X-Ms-Version:
       - "2018-03-28"
       x-ms-date:
-      - Thu, 04 Apr 2019 16:29:44 GMT
+      - Fri, 05 Apr 2019 17:03:41 GMT
     url: https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-src
     method: HEAD
   response:
@@ -85,11 +85,11 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Thu, 04 Apr 2019 16:29:44 GMT
+      - Fri, 05 Apr 2019 17:03:41 GMT
       Etag:
-      - '"0x8D6B91ABF32769A"'
+      - '"0x8D6B9E8A7AB75E1"'
       Last-Modified:
-      - Thu, 04 Apr 2019 16:29:44 GMT
+      - Fri, 05 Apr 2019 17:03:41 GMT
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Access-Tier:
@@ -107,11 +107,61 @@ interactions:
       X-Ms-Meta-Foo:
       - bar
       X-Ms-Request-Id:
-      - d0dbe0f4-401e-0068-4403-ebcbe5000000
+      - 9b4fcb72-001e-0106-03d1-eb2499000000
       X-Ms-Server-Encrypted:
       - "true"
       X-Ms-Version:
       - "2018-03-28"
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: clobber me
+    form: {}
+    headers:
+      Content-Length:
+      - "10"
+      User-Agent:
+      - go-cloud/blob/0.1.0 Azure-Storage/0.4 (go1.12; linux)
+      X-Ms-Blob-Cache-Control:
+      - ""
+      X-Ms-Blob-Content-Disposition:
+      - ""
+      X-Ms-Blob-Content-Encoding:
+      - ""
+      X-Ms-Blob-Content-Language:
+      - ""
+      X-Ms-Blob-Content-Type:
+      - text/plain; charset=utf-8
+      X-Ms-Blob-Type:
+      - BlockBlob
+      X-Ms-Version:
+      - "2018-03-28"
+      x-ms-date:
+      - Fri, 05 Apr 2019 17:03:41 GMT
+    url: https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-dest-exists
+    method: PUT
+  response:
+    body: ""
+    headers:
+      Content-Length:
+      - "0"
+      Content-Md5:
+      - oPqafXJA1cXuvXCJlDDFlw==
+      Date:
+      - Fri, 05 Apr 2019 17:03:41 GMT
+      Etag:
+      - '"0x8D6B9E8A7C0FF0E"'
+      Last-Modified:
+      - Fri, 05 Apr 2019 17:03:41 GMT
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 9b4fcb89-001e-0106-17d1-eb2499000000
+      X-Ms-Request-Server-Encrypted:
+      - "true"
+      X-Ms-Version:
+      - "2018-03-28"
+    status: 201 Created
+    code: 201
     duration: ""

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -804,10 +804,10 @@ func (b *Bucket) NewWriter(ctx context.Context, key string, opts *WriterOptions)
 // TODO(rvangent): Look into cross-Bucket copies.
 func (b *Bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *CopyOptions) (err error) {
 	if !utf8.ValidString(srcKey) {
-		return fmt.Errorf("blob.Copy: srcKey must be a valid UTF-8 string: %q", srcKey)
+		return gcerr.Newf(gcerr.InvalidArgument, nil, "blob: Copy srcKey must be a valid UTF-8 string: %q", srcKey)
 	}
 	if !utf8.ValidString(dstKey) {
-		return fmt.Errorf("blob.Copy: dstKey must be a valid UTF-8 string: %q", dstKey)
+		return gcerr.Newf(gcerr.InvalidArgument, nil, "blob: Copy dstKey must be a valid UTF-8 string: %q", dstKey)
 	}
 	if opts == nil {
 		opts = &CopyOptions{}

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -799,9 +799,7 @@ func (b *Bucket) NewWriter(ctx context.Context, key string, opts *WriterOptions)
 // If the source blob does not exist, Copy returns an error for which
 // gcerrors.Code will return gcerrors.NotFound.
 //
-// TODO(rvangent): Determine and document semantics if there's already an
-// existing blob at dstKey.
-// TODO(rvangent): Look into cross-Bucket copies.
+// If the destination blob already exists, it is overwritten.
 func (b *Bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *CopyOptions) (err error) {
 	if !utf8.ValidString(srcKey) {
 		return gcerr.Newf(gcerr.InvalidArgument, nil, "blob: Copy srcKey must be a valid UTF-8 string: %q", srcKey)

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -60,6 +60,7 @@
 //
 // This API collects OpenCensus traces and metrics for the following methods:
 //  - Attributes
+//  - Copy
 //  - Delete
 //  - NewRangeReader, from creation until the call to Close. (NewReader and ReadAll
 //    are included because they call NewRangeReader.)
@@ -794,6 +795,37 @@ func (b *Bucket) NewWriter(ctx context.Context, key string, opts *WriterOptions)
 	return w, nil
 }
 
+// Copy the blob stored at srcKey to dstKey.
+// A nil CopyOptions is treated the same as the zero value.
+//
+// If the source blob does not exist, Copy returns an error for which
+// gcerrors.Code will return gcerrors.NotFound.
+//
+// TODO(rvangent): Determine and document semantics if there's already an
+// existing blob at dstKey.
+func (b *Bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *CopyOptions) (err error) {
+	if !utf8.ValidString(srcKey) {
+		return fmt.Errorf("blob.Copy: srcKey must be a valid UTF-8 string: %q", srcKey)
+	}
+	if !utf8.ValidString(dstKey) {
+		return fmt.Errorf("blob.Copy: dstKey must be a valid UTF-8 string: %q", dstKey)
+	}
+	if opts == nil {
+		opts = &CopyOptions{}
+	}
+	dopts := &driver.CopyOptions{
+		BeforeCopy: opts.BeforeCopy,
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if b.closed {
+		return errClosed
+	}
+	ctx = b.tracer.Start(ctx, "Copy")
+	defer func() { b.tracer.End(ctx, err) }()
+	return wrapError(b.b, b.b.Copy(ctx, srcKey, dstKey, dopts))
+}
+
 // Delete deletes the blob stored at key.
 //
 // If the blob does not exist, Delete returns an error for which
@@ -931,6 +963,16 @@ type WriterOptions struct {
 	// asFunc converts its argument to provider-specific types.
 	// See https://godoc.org/gocloud.dev#hdr-As for background information.
 	BeforeWrite func(asFunc func(interface{}) bool) error
+}
+
+// CopyOptions sets options for Copy.
+type CopyOptions struct {
+	// BeforeCopy is a callback that will be called before the copy is
+	// initiated.
+	//
+	// asFunc converts its argument to provider-specific types.
+	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	BeforeCopy func(asFunc func(interface{}) bool) error
 }
 
 // BucketURLOpener represents types that can open buckets based on a URL.

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -800,7 +800,7 @@ func (b *Bucket) NewWriter(ctx context.Context, key string, opts *WriterOptions)
 // gcerrors.Code will return gcerrors.NotFound.
 //
 // If the destination blob already exists, it is overwritten.
-func (b *Bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *CopyOptions) (err error) {
+func (b *Bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *CopyOptions) (err error) {
 	if !utf8.ValidString(srcKey) {
 		return gcerr.Newf(gcerr.InvalidArgument, nil, "blob: Copy srcKey must be a valid UTF-8 string: %q", srcKey)
 	}
@@ -820,7 +820,7 @@ func (b *Bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *CopyOpti
 	}
 	ctx = b.tracer.Start(ctx, "Copy")
 	defer func() { b.tracer.End(ctx, err) }()
-	return wrapError(b.b, b.b.Copy(ctx, srcKey, dstKey, dopts))
+	return wrapError(b.b, b.b.Copy(ctx, dstKey, srcKey, dopts))
 }
 
 // Delete deletes the blob stored at key.

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -803,6 +803,7 @@ func (b *Bucket) NewWriter(ctx context.Context, key string, opts *WriterOptions)
 //
 // TODO(rvangent): Determine and document semantics if there's already an
 // existing blob at dstKey.
+// TODO(rvangent): Look into cross-Bucket copies.
 func (b *Bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *CopyOptions) (err error) {
 	if !utf8.ValidString(srcKey) {
 		return fmt.Errorf("blob.Copy: srcKey must be a valid UTF-8 string: %q", srcKey)

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -265,12 +265,12 @@ type Bucket interface {
 
 	// Copy copies the object associated with srcKey to dstKey.
 	//
-	// If the specified object does not exist, Copy must return an error for which
+	// If the source object does not exist, Copy must return an error for which
 	// ErrorCode returns gcerrors.NotFound.
 	//
+	// If the destination object already exists, it should be overwritten.
+	//
 	// opts is guaranteed to be non-nil.
-	// TODO(rvangent): Determine and document semantics if there's already an
-	// existing blob at dstKey.
 	Copy(ctx context.Context, srcKey, dstKey string, opts *CopyOptions) error
 
 	// Delete deletes the object associated with key. If the specified object does

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -261,7 +261,7 @@ type Bucket interface {
 	//
 	// Implementations should abort an ongoing write if ctx is later canceled,
 	// and do any necessary cleanup in Close. Close should then return ctx.Err().
-	NewTypedWriter(ctx context.Context, key string, contentType string, opts *WriterOptions) (Writer, error)
+	NewTypedWriter(ctx context.Context, key, contentType string, opts *WriterOptions) (Writer, error)
 
 	// Copy copies the object associated with srcKey to dstKey.
 	//

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -271,7 +271,7 @@ type Bucket interface {
 	// If the destination object already exists, it should be overwritten.
 	//
 	// opts is guaranteed to be non-nil.
-	Copy(ctx context.Context, srcKey, dstKey string, opts *CopyOptions) error
+	Copy(ctx context.Context, dstKey, srcKey string, opts *CopyOptions) error
 
 	// Delete deletes the object associated with key. If the specified object does
 	// not exist, Delete must return an error for which ErrorCode returns

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -83,6 +83,14 @@ type WriterOptions struct {
 	BeforeWrite func(asFunc func(interface{}) bool) error
 }
 
+// CopyOptions controls options for Copy.
+type CopyOptions struct {
+	// BeforeCopy is a callback that must be called before initiating the Copy.
+	// asFunc allows providers to expose provider-specific types;
+	// see Bucket.As for more details.
+	BeforeCopy func(asFunc func(interface{}) bool) error
+}
+
 // ReaderAttributes contains a subset of attributes about a blob that are
 // accessible from Reader.
 type ReaderAttributes struct {
@@ -254,6 +262,16 @@ type Bucket interface {
 	// Implementations should abort an ongoing write if ctx is later canceled,
 	// and do any necessary cleanup in Close. Close should then return ctx.Err().
 	NewTypedWriter(ctx context.Context, key string, contentType string, opts *WriterOptions) (Writer, error)
+
+	// Copy copies the object associated with srcKey to dstKey.
+	//
+	// If the specified object does not exist, Copy must return an error for which
+	// ErrorCode returns gcerrors.NotFound.
+	//
+	// opts is guaranteed to be non-nil.
+	// TODO(rvangent): Determine and document semantics if there's already an
+	// existing blob at dstKey.
+	Copy(ctx context.Context, srcKey, dstKey string, opts *CopyOptions) error
 
 	// Delete deletes the object associated with key. If the specified object does
 	// not exist, Delete must return an error for which ErrorCode returns

--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -1697,6 +1697,7 @@ func testCopy(t *testing.T, newHarness HarnessMaker) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		wantAttr.ModTime = time.Time{} // don't compare this field
 
 		// Copy it to the destination.
 		if err := b.Copy(ctx, srcKey, dstKey, nil); err != nil {
@@ -1717,8 +1718,9 @@ func testCopy(t *testing.T, newHarness HarnessMaker) {
 		// Verify attributes of the copy.
 		gotAttr, err := b.Attributes(ctx, dstKey)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
+		gotAttr.ModTime = time.Time{} // don't compare this field
 		if diff := cmp.Diff(gotAttr, wantAttr, cmpopts.IgnoreUnexported(blob.Attributes{})); diff != "" {
 			t.Errorf("got %v want %v diff %s", gotAttr, wantAttr, diff)
 		}

--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -1654,7 +1654,7 @@ func testCopy(t *testing.T, newHarness HarnessMaker) {
 		b := blob.NewBucket(drv)
 		defer b.Close()
 
-		err = b.Copy(ctx, "does-not-exist", dstKey, nil)
+		err = b.Copy(ctx, dstKey, "does-not-exist", nil)
 		// TODO(rvangent): Remove when implemented for all providers.
 		if gcerrors.Code(err) == gcerrors.Unimplemented {
 			t.Skip("Copy not yet implemented")
@@ -1705,7 +1705,7 @@ func testCopy(t *testing.T, newHarness HarnessMaker) {
 		}
 
 		// Copy the source to the destination.
-		if err := b.Copy(ctx, srcKey, dstKey, nil); err != nil {
+		if err := b.Copy(ctx, dstKey, srcKey, nil); err != nil {
 			// TODO(rvangent): Remove when implemented for all providers.
 			if gcerrors.Code(err) == gcerrors.Unimplemented {
 				t.Skip("Copy not yet implemented")
@@ -1732,7 +1732,7 @@ func testCopy(t *testing.T, newHarness HarnessMaker) {
 
 		// Copy the source to the second destination, where there's an existing blob.
 		// It should be overwritten.
-		if err := b.Copy(ctx, srcKey, dstKeyExists, nil); err != nil {
+		if err := b.Copy(ctx, dstKeyExists, srcKey, nil); err != nil {
 			// TODO(rvangent): Remove when implemented for all providers.
 			if gcerrors.Code(err) == gcerrors.Unimplemented {
 				t.Skip("Copy not yet implemented")

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -529,7 +529,6 @@ func (b *bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *driver.C
 		return err
 	}
 	defer f.Close()
-	r := io.Reader(f)
 
 	// We'll write the copy using Writer, to avoid re-implementing making of a
 	// temp file, cleaning up after partial failures, etc.
@@ -549,7 +548,7 @@ func (b *bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *driver.C
 	if err != nil {
 		return err
 	}
-	_, err = io.Copy(w, r)
+	_, err = io.Copy(w, f)
 	if err != nil {
 		cancel() // cancel before Close cancels the write
 		w.Close()

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -516,6 +516,48 @@ func (w *writer) Close() error {
 	return nil
 }
 
+// Copy implements driver.Copy.
+func (b *bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *driver.CopyOptions) error {
+	// Note: we could use NewRangedReader here, but since we need to copy all of
+	// the metadata (from xa), it's more efficient to do it directly.
+	srcPath, _, xa, err := b.forKey(srcKey)
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	r := io.Reader(f)
+
+	// We'll write the copy using Writer, to avoid re-implementing making of a
+	// temp file, cleaning up after partial failures, etc.
+	wopts := driver.WriterOptions{
+		CacheControl:       xa.CacheControl,
+		ContentDisposition: xa.ContentDisposition,
+		ContentEncoding:    xa.ContentEncoding,
+		ContentLanguage:    xa.ContentLanguage,
+		Metadata:           xa.Metadata,
+		BeforeWrite:        opts.BeforeCopy,
+	}
+	// Create a cancelable context so we can cancel the write if there are
+	// problems.
+	writeCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	w, err := b.NewTypedWriter(writeCtx, dstKey, xa.ContentType, &wopts)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(w, r)
+	if err != nil {
+		cancel() // cancel before Close cancels the write
+		w.Close()
+		return err
+	}
+	return w.Close()
+}
+
 // Delete implements driver.Delete.
 func (b *bucket) Delete(ctx context.Context, key string) error {
 	path, err := b.path(key)

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -517,7 +517,7 @@ func (w *writer) Close() error {
 }
 
 // Copy implements driver.Copy.
-func (b *bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *driver.CopyOptions) error {
+func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.CopyOptions) error {
 	// Note: we could use NewRangedReader here, but since we need to copy all of
 	// the metadata (from xa), it's more efficient to do it directly.
 	srcPath, _, xa, err := b.forKey(srcKey)

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -457,7 +457,7 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType str
 var errUnimplemented = errors.New("not implemented")
 
 // Copy implements driver.Copy.
-func (b *bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *driver.CopyOptions) error {
+func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.CopyOptions) error {
 	// TODO(rvangent): Implement this and delete errUnimplemented.
 	return errUnimplemented
 }

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -249,6 +249,9 @@ func (r *reader) As(i interface{}) bool {
 }
 
 func (b *bucket) ErrorCode(err error) gcerrors.ErrorCode {
+	if err == errUnimplemented {
+		return gcerrors.Unimplemented
+	}
 	if err == storage.ErrObjectNotExist {
 		return gcerrors.NotFound
 	}
@@ -449,6 +452,14 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType str
 		}
 	}
 	return w, nil
+}
+
+var errUnimplemented = errors.New("not implemented")
+
+// Copy implements driver.Copy.
+func (b *bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *driver.CopyOptions) error {
+	// TODO(rvangent): Implement this and delete errUnimplemented.
+	return errUnimplemented
 }
 
 // Delete implements driver.Delete.

--- a/blob/gcsblob/testdata/TestConformance/TestCopy/Works.yaml
+++ b/blob/gcsblob/testdata/TestConformance/TestCopy/Works.yaml
@@ -1,0 +1,97 @@
+---
+version: 1
+interactions:
+- request:
+    body: "--9714446b3066376ce1218429c078380cd006a8f7bbac3ed229f502e786a7\r\nContent-Type:
+      application/json\r\n\r\n{\"bucket\":\"go-cloud-blob-test-bucket\",\"cacheControl\":\"no-cache\",\"contentDisposition\":\"inline\",\"contentEncoding\":\"identity\",\"contentLanguage\":\"en\",\"contentType\":\"text/plain\",\"metadata\":{\"foo\":\"bar\"},\"name\":\"blob-for-copying-src\"}\n\r\n--9714446b3066376ce1218429c078380cd006a8f7bbac3ed229f502e786a7\r\nContent-Type:
+      text/plain\r\n\r\nHello World\r\n--9714446b3066376ce1218429c078380cd006a8f7bbac3ed229f502e786a7--\r\n"
+    form: {}
+    headers:
+      Content-Type:
+      - multipart/related; boundary=9714446b3066376ce1218429c078380cd006a8f7bbac3ed229f502e786a7
+      User-Agent:
+      - google-api-go-client/0.5 go-cloud/blob/0.1.0
+      X-Goog-Api-Client:
+      - gl-go/1.12.0 gccl/20180226
+    url: https://www.googleapis.com/upload/storage/v1/b/go-cloud-blob-test-bucket/o?alt=json&prettyPrint=false&projection=full&uploadType=multipart
+    method: POST
+  response:
+    body: '{"kind":"storage#object","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src","name":"blob-for-copying-src","bucket":"go-cloud-blob-test-bucket","generation":"1554395419717648","metageneration":"1","contentType":"text/plain","timeCreated":"2019-04-04T16:30:19.716Z","updated":"2019-04-04T16:30:19.716Z","storageClass":"REGIONAL","timeStorageClassUpdated":"2019-04-04T16:30:19.716Z","size":"11","md5Hash":"sQqNsWTgdUEFt6mb5y4/5Q==","mediaLink":"https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src?generation=1554395419717648&alt=media","contentEncoding":"identity","contentDisposition":"inline","contentLanguage":"en","cacheControl":"no-cache","metadata":{"foo":"bar"},"acl":[{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/project-owners-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-owners-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"project-owners-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"owners"},"etag":"CJDg1JbutuECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/project-editors-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-editors-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"project-editors-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"editors"},"etag":"CJDg1JbutuECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/project-viewers-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-viewers-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"project-viewers-892942638129","role":"READER","projectTeam":{"projectNumber":"892942638129","team":"viewers"},"etag":"CJDg1JbutuECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/user-rvangent@google.com","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/user-rvangent@google.com","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"user-rvangent@google.com","role":"OWNER","email":"rvangent@google.com","etag":"CJDg1JbutuECEAE="}],"owner":{"entity":"user-rvangent@google.com"},"crc32c":"aR2qLw==","etag":"CJDg1JbutuECEAE="}'
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,44,43,39"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "2965"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 04 Apr 2019 16:30:19 GMT
+      Etag:
+      - CJDg1JbutuECEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Guploader-Customer:
+      - apiary_cloudstorage_single_post_uploads
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2UqEFeJdn5yRaG58boj4Plxk2YejzuXgBgG-uVz5J5_jsaG64GhU3kAEUKxiDwAZAramQS8K5rgdghoCpmyWnZD1OYKvVw
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - google-api-go-client/0.5 go-cloud/blob/0.1.0
+      X-Goog-Api-Client:
+      - gl-go/1.12.0 gccl/20180226
+    url: https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src?alt=json&prettyPrint=false&projection=full
+    method: GET
+  response:
+    body: '{"kind":"storage#object","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src","name":"blob-for-copying-src","bucket":"go-cloud-blob-test-bucket","generation":"1554395419717648","metageneration":"1","contentType":"text/plain","timeCreated":"2019-04-04T16:30:19.716Z","updated":"2019-04-04T16:30:19.716Z","storageClass":"REGIONAL","timeStorageClassUpdated":"2019-04-04T16:30:19.716Z","size":"11","md5Hash":"sQqNsWTgdUEFt6mb5y4/5Q==","mediaLink":"https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src?generation=1554395419717648&alt=media","contentEncoding":"identity","contentDisposition":"inline","contentLanguage":"en","cacheControl":"no-cache","metadata":{"foo":"bar"},"acl":[{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/project-owners-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-owners-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"project-owners-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"owners"},"etag":"CJDg1JbutuECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/project-editors-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-editors-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"project-editors-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"editors"},"etag":"CJDg1JbutuECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/project-viewers-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-viewers-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"project-viewers-892942638129","role":"READER","projectTeam":{"projectNumber":"892942638129","team":"viewers"},"etag":"CJDg1JbutuECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/user-rvangent@google.com","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/user-rvangent@google.com","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"user-rvangent@google.com","role":"OWNER","email":"rvangent@google.com","etag":"CJDg1JbutuECEAE="}],"owner":{"entity":"user-rvangent@google.com"},"crc32c":"aR2qLw==","etag":"CJDg1JbutuECEAE="}'
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,44,43,39"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "2965"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 04 Apr 2019 16:30:19 GMT
+      Etag:
+      - CJDg1JbutuECEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Guploader-Customer:
+      - apiary_cloudstorage_metadata
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2Uq2YGPeZV_TRmvYjeoqxWgmfmcX-MSt7qKkzygZc5Z5A37ZawTRdEaZ6l_liTtRqoH9OJy0IqI5rd0XqdqB06E3Mc7u1A
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/blob/gcsblob/testdata/TestConformance/TestCopy/Works.yaml
+++ b/blob/gcsblob/testdata/TestConformance/TestCopy/Works.yaml
@@ -2,13 +2,13 @@
 version: 1
 interactions:
 - request:
-    body: "--9714446b3066376ce1218429c078380cd006a8f7bbac3ed229f502e786a7\r\nContent-Type:
-      application/json\r\n\r\n{\"bucket\":\"go-cloud-blob-test-bucket\",\"cacheControl\":\"no-cache\",\"contentDisposition\":\"inline\",\"contentEncoding\":\"identity\",\"contentLanguage\":\"en\",\"contentType\":\"text/plain\",\"metadata\":{\"foo\":\"bar\"},\"name\":\"blob-for-copying-src\"}\n\r\n--9714446b3066376ce1218429c078380cd006a8f7bbac3ed229f502e786a7\r\nContent-Type:
-      text/plain\r\n\r\nHello World\r\n--9714446b3066376ce1218429c078380cd006a8f7bbac3ed229f502e786a7--\r\n"
+    body: "--edba2fcfa1b544233fca2a13bb2e49deb2b439134c3625c39d9443d893b8\r\nContent-Type:
+      application/json\r\n\r\n{\"bucket\":\"go-cloud-blob-test-bucket\",\"cacheControl\":\"no-cache\",\"contentDisposition\":\"inline\",\"contentEncoding\":\"identity\",\"contentLanguage\":\"en\",\"contentType\":\"text/plain\",\"metadata\":{\"foo\":\"bar\"},\"name\":\"blob-for-copying-src\"}\n\r\n--edba2fcfa1b544233fca2a13bb2e49deb2b439134c3625c39d9443d893b8\r\nContent-Type:
+      text/plain\r\n\r\nHello World\r\n--edba2fcfa1b544233fca2a13bb2e49deb2b439134c3625c39d9443d893b8--\r\n"
     form: {}
     headers:
       Content-Type:
-      - multipart/related; boundary=9714446b3066376ce1218429c078380cd006a8f7bbac3ed229f502e786a7
+      - multipart/related; boundary=edba2fcfa1b544233fca2a13bb2e49deb2b439134c3625c39d9443d893b8
       User-Agent:
       - google-api-go-client/0.5 go-cloud/blob/0.1.0
       X-Goog-Api-Client:
@@ -16,7 +16,7 @@ interactions:
     url: https://www.googleapis.com/upload/storage/v1/b/go-cloud-blob-test-bucket/o?alt=json&prettyPrint=false&projection=full&uploadType=multipart
     method: POST
   response:
-    body: '{"kind":"storage#object","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src","name":"blob-for-copying-src","bucket":"go-cloud-blob-test-bucket","generation":"1554395419717648","metageneration":"1","contentType":"text/plain","timeCreated":"2019-04-04T16:30:19.716Z","updated":"2019-04-04T16:30:19.716Z","storageClass":"REGIONAL","timeStorageClassUpdated":"2019-04-04T16:30:19.716Z","size":"11","md5Hash":"sQqNsWTgdUEFt6mb5y4/5Q==","mediaLink":"https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src?generation=1554395419717648&alt=media","contentEncoding":"identity","contentDisposition":"inline","contentLanguage":"en","cacheControl":"no-cache","metadata":{"foo":"bar"},"acl":[{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/project-owners-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-owners-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"project-owners-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"owners"},"etag":"CJDg1JbutuECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/project-editors-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-editors-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"project-editors-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"editors"},"etag":"CJDg1JbutuECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/project-viewers-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-viewers-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"project-viewers-892942638129","role":"READER","projectTeam":{"projectNumber":"892942638129","team":"viewers"},"etag":"CJDg1JbutuECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/user-rvangent@google.com","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/user-rvangent@google.com","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"user-rvangent@google.com","role":"OWNER","email":"rvangent@google.com","etag":"CJDg1JbutuECEAE="}],"owner":{"entity":"user-rvangent@google.com"},"crc32c":"aR2qLw==","etag":"CJDg1JbutuECEAE="}'
+    body: '{"kind":"storage#object","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554483843920547","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src","name":"blob-for-copying-src","bucket":"go-cloud-blob-test-bucket","generation":"1554483843920547","metageneration":"1","contentType":"text/plain","timeCreated":"2019-04-05T17:04:03.920Z","updated":"2019-04-05T17:04:03.920Z","storageClass":"REGIONAL","timeStorageClassUpdated":"2019-04-05T17:04:03.920Z","size":"11","md5Hash":"sQqNsWTgdUEFt6mb5y4/5Q==","mediaLink":"https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src?generation=1554483843920547&alt=media","contentEncoding":"identity","contentDisposition":"inline","contentLanguage":"en","cacheControl":"no-cache","metadata":{"foo":"bar"},"acl":[{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554483843920547/project-owners-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-owners-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554483843920547","entity":"project-owners-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"owners"},"etag":"CKPlzcq3ueECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554483843920547/project-editors-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-editors-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554483843920547","entity":"project-editors-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"editors"},"etag":"CKPlzcq3ueECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554483843920547/project-viewers-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-viewers-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554483843920547","entity":"project-viewers-892942638129","role":"READER","projectTeam":{"projectNumber":"892942638129","team":"viewers"},"etag":"CKPlzcq3ueECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554483843920547/user-rvangent@google.com","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/user-rvangent@google.com","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554483843920547","entity":"user-rvangent@google.com","role":"OWNER","email":"rvangent@google.com","etag":"CKPlzcq3ueECEAE="}],"owner":{"entity":"user-rvangent@google.com"},"crc32c":"aR2qLw==","etag":"CKPlzcq3ueECEAE="}'
     headers:
       Alt-Svc:
       - quic=":443"; ma=2592000; v="46,44,43,39"
@@ -27,9 +27,9 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 04 Apr 2019 16:30:19 GMT
+      - Fri, 05 Apr 2019 17:04:03 GMT
       Etag:
-      - CJDg1JbutuECEAE=
+      - CKPlzcq3ueECEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -46,7 +46,7 @@ interactions:
       X-Guploader-Upload-Result:
       - success
       X-Guploader-Uploadid:
-      - AEnB2UqEFeJdn5yRaG58boj4Plxk2YejzuXgBgG-uVz5J5_jsaG64GhU3kAEUKxiDwAZAramQS8K5rgdghoCpmyWnZD1OYKvVw
+      - AEnB2UolhZRcF6_Vi1znw3sg7mbQBf_KSO2lhbnT-wVZvpy-TyaYhi2ga3UriQoumU9-7cyBW65AzKrE63AxDbDVJZZhKE-Rjg
     status: 200 OK
     code: 200
     duration: ""
@@ -61,7 +61,7 @@ interactions:
     url: https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src?alt=json&prettyPrint=false&projection=full
     method: GET
   response:
-    body: '{"kind":"storage#object","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src","name":"blob-for-copying-src","bucket":"go-cloud-blob-test-bucket","generation":"1554395419717648","metageneration":"1","contentType":"text/plain","timeCreated":"2019-04-04T16:30:19.716Z","updated":"2019-04-04T16:30:19.716Z","storageClass":"REGIONAL","timeStorageClassUpdated":"2019-04-04T16:30:19.716Z","size":"11","md5Hash":"sQqNsWTgdUEFt6mb5y4/5Q==","mediaLink":"https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src?generation=1554395419717648&alt=media","contentEncoding":"identity","contentDisposition":"inline","contentLanguage":"en","cacheControl":"no-cache","metadata":{"foo":"bar"},"acl":[{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/project-owners-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-owners-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"project-owners-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"owners"},"etag":"CJDg1JbutuECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/project-editors-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-editors-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"project-editors-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"editors"},"etag":"CJDg1JbutuECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/project-viewers-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-viewers-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"project-viewers-892942638129","role":"READER","projectTeam":{"projectNumber":"892942638129","team":"viewers"},"etag":"CJDg1JbutuECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554395419717648/user-rvangent@google.com","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/user-rvangent@google.com","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554395419717648","entity":"user-rvangent@google.com","role":"OWNER","email":"rvangent@google.com","etag":"CJDg1JbutuECEAE="}],"owner":{"entity":"user-rvangent@google.com"},"crc32c":"aR2qLw==","etag":"CJDg1JbutuECEAE="}'
+    body: '{"kind":"storage#object","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554483843920547","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src","name":"blob-for-copying-src","bucket":"go-cloud-blob-test-bucket","generation":"1554483843920547","metageneration":"1","contentType":"text/plain","timeCreated":"2019-04-05T17:04:03.920Z","updated":"2019-04-05T17:04:03.920Z","storageClass":"REGIONAL","timeStorageClassUpdated":"2019-04-05T17:04:03.920Z","size":"11","md5Hash":"sQqNsWTgdUEFt6mb5y4/5Q==","mediaLink":"https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src?generation=1554483843920547&alt=media","contentEncoding":"identity","contentDisposition":"inline","contentLanguage":"en","cacheControl":"no-cache","metadata":{"foo":"bar"},"acl":[{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554483843920547/project-owners-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-owners-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554483843920547","entity":"project-owners-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"owners"},"etag":"CKPlzcq3ueECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554483843920547/project-editors-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-editors-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554483843920547","entity":"project-editors-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"editors"},"etag":"CKPlzcq3ueECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554483843920547/project-viewers-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/project-viewers-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554483843920547","entity":"project-viewers-892942638129","role":"READER","projectTeam":{"projectNumber":"892942638129","team":"viewers"},"etag":"CKPlzcq3ueECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-src/1554483843920547/user-rvangent@google.com","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-src/acl/user-rvangent@google.com","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-src","generation":"1554483843920547","entity":"user-rvangent@google.com","role":"OWNER","email":"rvangent@google.com","etag":"CKPlzcq3ueECEAE="}],"owner":{"entity":"user-rvangent@google.com"},"crc32c":"aR2qLw==","etag":"CKPlzcq3ueECEAE="}'
     headers:
       Alt-Svc:
       - quic=":443"; ma=2592000; v="46,44,43,39"
@@ -72,9 +72,9 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 04 Apr 2019 16:30:19 GMT
+      - Fri, 05 Apr 2019 17:04:04 GMT
       Etag:
-      - CJDg1JbutuECEAE=
+      - CKPlzcq3ueECEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -91,7 +91,58 @@ interactions:
       X-Guploader-Upload-Result:
       - success
       X-Guploader-Uploadid:
-      - AEnB2Uq2YGPeZV_TRmvYjeoqxWgmfmcX-MSt7qKkzygZc5Z5A37ZawTRdEaZ6l_liTtRqoH9OJy0IqI5rd0XqdqB06E3Mc7u1A
+      - AEnB2UqWDgk-vmkrF3of1kDpCnTrPw70w79u_FVAT3vtns-iDlwBgKvok47ViVdlXwzo_qvWcPOmnuQDsEHwHXbAxmZQ8TBQ4Q
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: "--3d3539b35242c7f4018f669e6d19d7ea670ba6a276914e28cab2e3920ae9\r\nContent-Type:
+      application/json\r\n\r\n{\"bucket\":\"go-cloud-blob-test-bucket\",\"contentType\":\"text/plain;
+      charset=utf-8\",\"name\":\"blob-for-copying-dest-exists\"}\n\r\n--3d3539b35242c7f4018f669e6d19d7ea670ba6a276914e28cab2e3920ae9\r\nContent-Type:
+      text/plain; charset=utf-8\r\n\r\nclobber me\r\n--3d3539b35242c7f4018f669e6d19d7ea670ba6a276914e28cab2e3920ae9--\r\n"
+    form: {}
+    headers:
+      Content-Type:
+      - multipart/related; boundary=3d3539b35242c7f4018f669e6d19d7ea670ba6a276914e28cab2e3920ae9
+      User-Agent:
+      - google-api-go-client/0.5 go-cloud/blob/0.1.0
+      X-Goog-Api-Client:
+      - gl-go/1.12.0 gccl/20180226
+    url: https://www.googleapis.com/upload/storage/v1/b/go-cloud-blob-test-bucket/o?alt=json&prettyPrint=false&projection=full&uploadType=multipart
+    method: POST
+  response:
+    body: '{"kind":"storage#object","id":"go-cloud-blob-test-bucket/blob-for-copying-dest-exists/1554483844208157","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-dest-exists","name":"blob-for-copying-dest-exists","bucket":"go-cloud-blob-test-bucket","generation":"1554483844208157","metageneration":"1","contentType":"text/plain;
+      charset=utf-8","timeCreated":"2019-04-05T17:04:04.207Z","updated":"2019-04-05T17:04:04.207Z","storageClass":"REGIONAL","timeStorageClassUpdated":"2019-04-05T17:04:04.207Z","size":"10","md5Hash":"oPqafXJA1cXuvXCJlDDFlw==","mediaLink":"https://www.googleapis.com/download/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-dest-exists?generation=1554483844208157&alt=media","acl":[{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-dest-exists/1554483844208157/project-owners-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-dest-exists/acl/project-owners-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-dest-exists","generation":"1554483844208157","entity":"project-owners-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"owners"},"etag":"CJ2s38q3ueECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-dest-exists/1554483844208157/project-editors-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-dest-exists/acl/project-editors-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-dest-exists","generation":"1554483844208157","entity":"project-editors-892942638129","role":"OWNER","projectTeam":{"projectNumber":"892942638129","team":"editors"},"etag":"CJ2s38q3ueECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-dest-exists/1554483844208157/project-viewers-892942638129","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-dest-exists/acl/project-viewers-892942638129","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-dest-exists","generation":"1554483844208157","entity":"project-viewers-892942638129","role":"READER","projectTeam":{"projectNumber":"892942638129","team":"viewers"},"etag":"CJ2s38q3ueECEAE="},{"kind":"storage#objectAccessControl","id":"go-cloud-blob-test-bucket/blob-for-copying-dest-exists/1554483844208157/user-rvangent@google.com","selfLink":"https://www.googleapis.com/storage/v1/b/go-cloud-blob-test-bucket/o/blob-for-copying-dest-exists/acl/user-rvangent@google.com","bucket":"go-cloud-blob-test-bucket","object":"blob-for-copying-dest-exists","generation":"1554483844208157","entity":"user-rvangent@google.com","role":"OWNER","email":"rvangent@google.com","etag":"CJ2s38q3ueECEAE="}],"owner":{"entity":"user-rvangent@google.com"},"crc32c":"hiBgdA==","etag":"CJ2s38q3ueECEAE="}'
+    headers:
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,44,43,39"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - "2975"
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 05 Apr 2019 17:04:04 GMT
+      Etag:
+      - CJ2s38q3ueECEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-Guploader-Customer:
+      - apiary_cloudstorage_single_post_uploads
+      X-Guploader-Request-Result:
+      - success
+      X-Guploader-Upload-Result:
+      - success
+      X-Guploader-Uploadid:
+      - AEnB2Uq3TiQU-qt03GHXrbAlZESoX_6-Szb_e3a_cNFEhY-p3bmHXL4oMVjd9NX0T0aHZH6o3JjkKX1Q6Oxk9p1C-n0DKThOwA
     status: 200 OK
     code: 200
     duration: ""

--- a/blob/memblob/memblob.go
+++ b/blob/memblob/memblob.go
@@ -338,7 +338,7 @@ func (w *writer) Close() error {
 }
 
 // Copy implements driver.Copy.
-func (b *bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *driver.CopyOptions) error {
+func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.CopyOptions) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/blob/memblob/memblob.go
+++ b/blob/memblob/memblob.go
@@ -337,6 +337,22 @@ func (w *writer) Close() error {
 	return nil
 }
 
+// Copy implements driver.Copy.
+func (b *bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *driver.CopyOptions) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if opts.BeforeCopy != nil {
+		return opts.BeforeCopy(func(interface{}) bool { return false })
+	}
+	v := b.blobs[srcKey]
+	if v == nil {
+		return errNotFound
+	}
+	b.blobs[dstKey] = v
+	return nil
+}
+
 // Delete implements driver.Delete.
 func (b *bucket) Delete(ctx context.Context, key string) error {
 	b.mu.Lock()

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -300,6 +300,9 @@ func (b *bucket) Close() error {
 }
 
 func (b *bucket) ErrorCode(err error) gcerrors.ErrorCode {
+	if err == errUnimplemented {
+		return gcerrors.Unimplemented
+	}
 	e, ok := err.(awserr.Error)
 	if !ok {
 		return gcerrors.Unknown
@@ -665,6 +668,14 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType str
 		req:      req,
 		donec:    make(chan struct{}),
 	}, nil
+}
+
+var errUnimplemented = errors.New("not implemented")
+
+// Copy implements driver.Copy.
+func (b *bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *driver.CopyOptions) error {
+	// TODO(rvangent): Implement this and delete errUnimplemented.
+	return errUnimplemented
 }
 
 // Delete implements driver.Delete.

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -673,7 +673,7 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType str
 var errUnimplemented = errors.New("not implemented")
 
 // Copy implements driver.Copy.
-func (b *bucket) Copy(ctx context.Context, srcKey, dstKey string, opts *driver.CopyOptions) error {
+func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.CopyOptions) error {
 	// TODO(rvangent): Implement this and delete errUnimplemented.
 	return errUnimplemented
 }

--- a/blob/s3blob/testdata/TestConformance/TestCopy/Works.yaml
+++ b/blob/s3blob/testdata/TestConformance/TestCopy/Works.yaml
@@ -1,0 +1,95 @@
+---
+version: 1
+interactions:
+- request:
+    body: Hello World
+    form: {}
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Disposition:
+      - inline
+      Content-Encoding:
+      - identity
+      Content-Language:
+      - en
+      Content-Length:
+      - "11"
+      Content-Md5:
+      - sQqNsWTgdUEFt6mb5y4/5Q==
+      Content-Type:
+      - text/plain
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64) S3Manager
+      X-Amz-Content-Sha256:
+      - a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e
+      X-Amz-Date:
+      - 20190404T163032Z
+      X-Amz-Meta-Foo:
+      - bar
+    url: https://go-cloud-testing.s3.us-west-1.amazonaws.com/blob-for-copying-src
+    method: PUT
+  response:
+    body: ""
+    headers:
+      Content-Length:
+      - "0"
+      Date:
+      - Thu, 04 Apr 2019 16:30:33 GMT
+      Etag:
+      - '"b10a8db164e0754105b7a99be72e3fe5"'
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - Gd3CzFLX2rX7A8BLIE9nxKXcW0sB3y4L8zGDh/yQQXxp63+pyQUohHIRM/uBNAAB/PDs9fHYP3o=
+      X-Amz-Request-Id:
+      - EC318288C32E696D
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20190404T163032Z
+    url: https://go-cloud-testing.s3.us-west-1.amazonaws.com/blob-for-copying-src
+    method: HEAD
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Disposition:
+      - inline
+      Content-Encoding:
+      - identity
+      Content-Language:
+      - en
+      Content-Length:
+      - "11"
+      Content-Type:
+      - text/plain
+      Date:
+      - Thu, 04 Apr 2019 16:30:33 GMT
+      Etag:
+      - '"b10a8db164e0754105b7a99be72e3fe5"'
+      Last-Modified:
+      - Thu, 04 Apr 2019 16:30:33 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - m7ieao+IKoTsRYL4zpre1XVs9Ir/bsOFUZfjWvv8oO0ubAoSrksOnUUOkyB6paprJ0auoqBKcdY=
+      X-Amz-Meta-Foo:
+      - bar
+      X-Amz-Request-Id:
+      - F3D6E7A9E6931522
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/blob/s3blob/testdata/TestConformance/TestCopy/Works.yaml
+++ b/blob/s3blob/testdata/TestConformance/TestCopy/Works.yaml
@@ -24,7 +24,7 @@ interactions:
       X-Amz-Content-Sha256:
       - a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e
       X-Amz-Date:
-      - 20190404T163032Z
+      - 20190405T170351Z
       X-Amz-Meta-Foo:
       - bar
     url: https://go-cloud-testing.s3.us-west-1.amazonaws.com/blob-for-copying-src
@@ -35,15 +35,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 04 Apr 2019 16:30:33 GMT
+      - Fri, 05 Apr 2019 17:03:52 GMT
       Etag:
       - '"b10a8db164e0754105b7a99be72e3fe5"'
       Server:
       - AmazonS3
       X-Amz-Id-2:
-      - Gd3CzFLX2rX7A8BLIE9nxKXcW0sB3y4L8zGDh/yQQXxp63+pyQUohHIRM/uBNAAB/PDs9fHYP3o=
+      - 6fsZc5GmDLnw3mW2/Q6A982PaFp9osO+3ixhXirtB/2dr+EShJzncKD0Gzh5xwIEwByvSHEgXVk=
       X-Amz-Request-Id:
-      - EC318288C32E696D
+      - C73FF44A0E4648EA
     status: 200 OK
     code: 200
     duration: ""
@@ -56,7 +56,7 @@ interactions:
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20190404T163032Z
+      - 20190405T170351Z
     url: https://go-cloud-testing.s3.us-west-1.amazonaws.com/blob-for-copying-src
     method: HEAD
   response:
@@ -77,19 +77,55 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Thu, 04 Apr 2019 16:30:33 GMT
+      - Fri, 05 Apr 2019 17:03:52 GMT
       Etag:
       - '"b10a8db164e0754105b7a99be72e3fe5"'
       Last-Modified:
-      - Thu, 04 Apr 2019 16:30:33 GMT
+      - Fri, 05 Apr 2019 17:03:52 GMT
       Server:
       - AmazonS3
       X-Amz-Id-2:
-      - m7ieao+IKoTsRYL4zpre1XVs9Ir/bsOFUZfjWvv8oO0ubAoSrksOnUUOkyB6paprJ0auoqBKcdY=
+      - Truilq22tJHGRPk/34uEos8GwtIES/OyDtrgC091W4SFCnNdIKyNzYEkOKtAkg6jm7zB93rRYoA=
       X-Amz-Meta-Foo:
       - bar
       X-Amz-Request-Id:
-      - F3D6E7A9E6931522
+      - 5BE8AE59E09F548C
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: clobber me
+    form: {}
+    headers:
+      Content-Length:
+      - "10"
+      Content-Md5:
+      - oPqafXJA1cXuvXCJlDDFlw==
+      Content-Type:
+      - text/plain; charset=utf-8
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64) S3Manager
+      X-Amz-Content-Sha256:
+      - cbaa060c695ffea336ebacf821fd121c12e6cddc83d19baae739412dc80c42d5
+      X-Amz-Date:
+      - 20190405T170351Z
+    url: https://go-cloud-testing.s3.us-west-1.amazonaws.com/blob-for-copying-dest-exists
+    method: PUT
+  response:
+    body: ""
+    headers:
+      Content-Length:
+      - "0"
+      Date:
+      - Fri, 05 Apr 2019 17:03:52 GMT
+      Etag:
+      - '"a0fa9a7d7240d5c5eebd70899430c597"'
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - y/l+RBwcgutGMp2dT52ih8DB1/8L6Q3Ak3v5JfFYX4KVTGMLMGoCI7MpHqOpD+LKkdJyNp2TpNg=
+      X-Amz-Request-Id:
+      - DB7C70CCA2DDFB6E
     status: 200 OK
     code: 200
     duration: ""

--- a/blob/s3blob/testdata/TestConformanceUsingLegacyList/TestCopy/Works.yaml
+++ b/blob/s3blob/testdata/TestConformanceUsingLegacyList/TestCopy/Works.yaml
@@ -1,0 +1,95 @@
+---
+version: 1
+interactions:
+- request:
+    body: Hello World
+    form: {}
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Disposition:
+      - inline
+      Content-Encoding:
+      - identity
+      Content-Language:
+      - en
+      Content-Length:
+      - "11"
+      Content-Md5:
+      - sQqNsWTgdUEFt6mb5y4/5Q==
+      Content-Type:
+      - text/plain
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64) S3Manager
+      X-Amz-Content-Sha256:
+      - a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e
+      X-Amz-Date:
+      - 20190404T163032Z
+      X-Amz-Meta-Foo:
+      - bar
+    url: https://go-cloud-testing.s3.us-west-1.amazonaws.com/blob-for-copying-src
+    method: PUT
+  response:
+    body: ""
+    headers:
+      Content-Length:
+      - "0"
+      Date:
+      - Thu, 04 Apr 2019 16:30:33 GMT
+      Etag:
+      - '"b10a8db164e0754105b7a99be72e3fe5"'
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - 6FgDN6DtVGJa8M4hUPMVye9R+qhRddiSRDEwuw3JKVqYM76sxEthuooAvvt4FSC7RJbsu6OZU70=
+      X-Amz-Request-Id:
+      - EFE895CC2A94DC34
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      X-Amz-Date:
+      - 20190404T163032Z
+    url: https://go-cloud-testing.s3.us-west-1.amazonaws.com/blob-for-copying-src
+    method: HEAD
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Disposition:
+      - inline
+      Content-Encoding:
+      - identity
+      Content-Language:
+      - en
+      Content-Length:
+      - "11"
+      Content-Type:
+      - text/plain
+      Date:
+      - Thu, 04 Apr 2019 16:30:33 GMT
+      Etag:
+      - '"b10a8db164e0754105b7a99be72e3fe5"'
+      Last-Modified:
+      - Thu, 04 Apr 2019 16:30:33 GMT
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - LmtKYgIMlpXX/WyTKv8vTh+UR732+Y+VmRjHgN5mlCDNjN7IDWF0SHKJXjdxS25uU351S6mDTbA=
+      X-Amz-Meta-Foo:
+      - bar
+      X-Amz-Request-Id:
+      - D8AF6B132F184CBF
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/blob/s3blob/testdata/TestConformanceUsingLegacyList/TestCopy/Works.yaml
+++ b/blob/s3blob/testdata/TestConformanceUsingLegacyList/TestCopy/Works.yaml
@@ -24,7 +24,7 @@ interactions:
       X-Amz-Content-Sha256:
       - a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e
       X-Amz-Date:
-      - 20190404T163032Z
+      - 20190405T170351Z
       X-Amz-Meta-Foo:
       - bar
     url: https://go-cloud-testing.s3.us-west-1.amazonaws.com/blob-for-copying-src
@@ -35,15 +35,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Thu, 04 Apr 2019 16:30:33 GMT
+      - Fri, 05 Apr 2019 17:03:52 GMT
       Etag:
       - '"b10a8db164e0754105b7a99be72e3fe5"'
       Server:
       - AmazonS3
       X-Amz-Id-2:
-      - 6FgDN6DtVGJa8M4hUPMVye9R+qhRddiSRDEwuw3JKVqYM76sxEthuooAvvt4FSC7RJbsu6OZU70=
+      - aOYb9fMGxbHKDZxD5R84GGbcgW1qzEuBZAwNm0yWz2ZMdzYFZNzMarkbdv+A07HZONSwzyDpIYE=
       X-Amz-Request-Id:
-      - EFE895CC2A94DC34
+      - 5286F03794773132
     status: 200 OK
     code: 200
     duration: ""
@@ -56,7 +56,7 @@ interactions:
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20190404T163032Z
+      - 20190405T170351Z
     url: https://go-cloud-testing.s3.us-west-1.amazonaws.com/blob-for-copying-src
     method: HEAD
   response:
@@ -77,19 +77,55 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Thu, 04 Apr 2019 16:30:33 GMT
+      - Fri, 05 Apr 2019 17:03:52 GMT
       Etag:
       - '"b10a8db164e0754105b7a99be72e3fe5"'
       Last-Modified:
-      - Thu, 04 Apr 2019 16:30:33 GMT
+      - Fri, 05 Apr 2019 17:03:52 GMT
       Server:
       - AmazonS3
       X-Amz-Id-2:
-      - LmtKYgIMlpXX/WyTKv8vTh+UR732+Y+VmRjHgN5mlCDNjN7IDWF0SHKJXjdxS25uU351S6mDTbA=
+      - E1mqzKiISnXIee16zLcAQ3lK6NQ0XYEPeWUecNLd8WDJH2yhmMGx5lXi3J4YtpXhNMpitItIZp8=
       X-Amz-Meta-Foo:
       - bar
       X-Amz-Request-Id:
-      - D8AF6B132F184CBF
+      - 411CDD36325B36D7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: clobber me
+    form: {}
+    headers:
+      Content-Length:
+      - "10"
+      Content-Md5:
+      - oPqafXJA1cXuvXCJlDDFlw==
+      Content-Type:
+      - text/plain; charset=utf-8
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64) S3Manager
+      X-Amz-Content-Sha256:
+      - cbaa060c695ffea336ebacf821fd121c12e6cddc83d19baae739412dc80c42d5
+      X-Amz-Date:
+      - 20190405T170351Z
+    url: https://go-cloud-testing.s3.us-west-1.amazonaws.com/blob-for-copying-dest-exists
+    method: PUT
+  response:
+    body: ""
+    headers:
+      Content-Length:
+      - "0"
+      Date:
+      - Fri, 05 Apr 2019 17:03:52 GMT
+      Etag:
+      - '"a0fa9a7d7240d5c5eebd70899430c597"'
+      Server:
+      - AmazonS3
+      X-Amz-Id-2:
+      - Cylks6c+5Cu/wN+nIi8e4g8a5DtLDEawosU7aKLwKfx+C4OmlIb51h/ve7V7EeJdK4ZxD6P3wjU=
+      X-Amz-Request-Id:
+      - F41220974A8DA4B8
     status: 200 OK
     code: 200
     duration: ""


### PR DESCRIPTION
cc @Zyqsempai 

This PR adds the portable API method, extends the driver interface, adds conformance tests, and implements `memblob` and `fileblob`.

It is marked as a breaking change due to the new method in the blob driver interface; since all drivers are in this repo this will not be a breaking change for our users.

Left for subsequent PRs (and marked with TODOs):

* Implementation for the 3 cloud provider drivers.
* Extending conformance tests for `As` to include `CopyOptions.BeforeCopy`.
* Verifying and documenting and testing the semantics for what happens if the destination already exists. Both `fileblob` and `memblob` overwrite, but I'm not sure what the cloud providers do yet.

Updates #1696.