### PR TITLE
pubsub/nats: BREAKING_CHANGE rename CreateTopic/Subscription->OpenTopic/Subscription; doc improvements

### DIFF
--- a/pubsub/natspubsub/example_test.go
+++ b/pubsub/natspubsub/example_test.go
@@ -90,6 +90,9 @@ func Example_openFromURL() {
 	// This URL will Dial the NATS server at the URL in the environment
 	// variable NATS_SERVER_URL and send messages with subject "mytopic".
 	topic, err := pubsub.OpenTopic(ctx, "nats://mytopic")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Similarly, OpenSubscription creates a *pubsub.Subscription from a URL.
 	// This URL will use the same connection and receive messages with subject
@@ -98,5 +101,8 @@ func Example_openFromURL() {
 	// no-op for NATS. You can disable the panic using "?ackfunc=log" or
 	// "?ackfunc=noop".
 	sub, err := pubsub.OpenSubscription(ctx, "nats://mytopic")
-	_, _, _ = topic, sub, err
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, _ = topic, sub
 }

--- a/pubsub/natspubsub/example_test.go
+++ b/pubsub/natspubsub/example_test.go
@@ -29,7 +29,7 @@ func ExampleOpenTopic() {
 	// Create a connection to NATS.
 	natsConn, err := nats.Connect("nats://demo.nats.io")
 	// To use NGS with credentials (https://synadia.com/ngs):
-	// natsConn, err := nats.Connect("connect.ngs/global", nats.UserCredentials("path_to_creds_file")
+	// natsConn, err := nats.Connect("connect.ngs/global", nats.UserCredentials("path_to_creds_file"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pubsub/natspubsub/example_test.go
+++ b/pubsub/natspubsub/example_test.go
@@ -23,37 +23,38 @@ import (
 	"gocloud.dev/pubsub/natspubsub"
 )
 
-func ExampleCreateTopic() {
+func ExampleOpenTopic() {
 	ctx := context.Background()
 
-	// Create a connection to NATS
-	// For use with NGS and credentials.
-	// nc, err := nats.Connect("connect.ngs/global", nats.UserCredentials("path_to_creds_file")
-	nc, err := nats.Connect("nats://demo.nats.io")
+	// Create a connection to NATS.
+	natsConn, err := nats.Connect("nats://demo.nats.io")
+	// To use NGS with credentials (https://synadia.com/ngs):
+	// natsConn, err := nats.Connect("connect.ngs/global", nats.UserCredentials("path_to_creds_file")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer nc.Close()
+	defer natsConn.Close()
 
-	pt, err := natspubsub.CreateTopic(nc, "go-cloud.example.send", nil)
+	// Open a pubsub.Topic that publishes message with subject "go-cloud.example.send".
+	topic, err := natspubsub.OpenTopic(natsConn, "go-cloud.example.send", nil)
 	if err != nil {
 		// Handle error....
 	}
 
-	err = pt.Send(ctx, &pubsub.Message{Body: []byte("example message")})
+	err = topic.Send(ctx, &pubsub.Message{Body: []byte("example message")})
 }
 
-func ExampleCreateSubscription() {
+func ExampleOpenSubscription() {
 	ctx := context.Background()
 
-	// Create a connection to NATS
-	// For use with NGS and credentials.
-	// nc, err := nats.Connect("connect.ngs/global", nats.UserCredentials("path_to_creds_file")
-	nc, err := nats.Connect("nats://demo.nats.io")
+	// Create a connection to NATS.
+	natsConn, err := nats.Connect("nats://demo.nats.io")
+	// To use NGS with credentials (https://synadia.com/ngs):
+	// natsConn, err := nats.Connect("connect.ngs/global", nats.UserCredentials("path_to_creds_file")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer nc.Close()
+	defer natsConn.Close()
 
 	ackFunc := func() {
 		// This function will be called when the application calls "Ack" on a
@@ -61,8 +62,11 @@ func ExampleCreateSubscription() {
 		// Since Ack is a meaningless no-op for NATS, you can provide an empty
 		// function to do nothing, or panic/log a warning if your application
 		// is built for at-most-once semantics and should never call Ack.
+		// See https://godoc.org/gocloud.dev/pubsub#hdr-At_most_once_and_At_least_once_Delivery
+		// for more details.
 	}
-	sub, err := natspubsub.CreateSubscription(nc, "go-cloud.example.receive", ackFunc, nil)
+	// Open a pubsub.Subscription that receives messages with subject "go-cloud.example.receive".
+	sub, err := natspubsub.OpenSubscription(natsConn, "go-cloud.example.receive", ackFunc, nil)
 	if err != nil {
 		// Handle error....
 	}
@@ -70,9 +74,9 @@ func ExampleCreateSubscription() {
 	// Now we can use sub to receive messages.
 	msg, err := sub.Receive(ctx)
 	if err != nil {
-		// Handle error....
+		// Handle the error....
 	}
-	// Handle Message
+	// Handle the message....
 
 	// Ack will call ackFunc above. If you're only going to use at-most-once
 	// providers, you can omit it.
@@ -85,7 +89,7 @@ func Example_openFromURL() {
 	// OpenTopic creates a *pubsub.Topic from a URL.
 	// This URL will Dial the NATS server at the URL in the environment
 	// variable NATS_SERVER_URL and send messages with subject "mytopic".
-	t, err := pubsub.OpenTopic(ctx, "nats://mytopic")
+	topic, err := pubsub.OpenTopic(ctx, "nats://mytopic")
 
 	// Similarly, OpenSubscription creates a *pubsub.Subscription from a URL.
 	// This URL will use the same connection and receive messages with subject
@@ -93,6 +97,6 @@ func Example_openFromURL() {
 	// Note that by default, s.Ack will result in a panic, as Ack is a meaningless
 	// no-op for NATS. You can disable the panic using "?ackfunc=log" or
 	// "?ackfunc=noop".
-	s, err := pubsub.OpenSubscription(ctx, "nats://mytopic")
-	_, _, _ = t, s, err
+	sub, err := pubsub.OpenSubscription(ctx, "nats://mytopic")
+	_, _, _ = topic, sub, err
 }

--- a/pubsub/natspubsub/nats_test.go
+++ b/pubsub/natspubsub/nats_test.go
@@ -54,7 +54,7 @@ func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
 
 func (h *harness) CreateTopic(ctx context.Context, testName string) (driver.Topic, func(), error) {
 	cleanup := func() {}
-	dt, err := createTopic(h.nc, testName)
+	dt, err := openTopic(h.nc, testName)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -67,7 +67,7 @@ func (h *harness) MakeNonexistentTopic(ctx context.Context) (driver.Topic, error
 }
 
 func (h *harness) CreateSubscription(ctx context.Context, dt driver.Topic, testName string) (driver.Subscription, func(), error) {
-	ds, err := createSubscription(h.nc, testName, func() {})
+	ds, err := openSubscription(h.nc, testName, func() {})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -170,7 +170,7 @@ func TestInteropWithDirectNATS(t *testing.T) {
 	body := []byte("hello")
 
 	// Send a message using Go CDK and receive it using NATS directly.
-	pt, err := CreateTopic(conn, topic, nil)
+	pt, err := OpenTopic(conn, topic, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +187,7 @@ func TestInteropWithDirectNATS(t *testing.T) {
 	}
 
 	// Send a message using NATS directly and receive it using Go CDK.
-	ps, err := CreateSubscription(conn, topic, func() { t.Fatal("ack called unexpectedly") }, nil)
+	ps, err := OpenSubscription(conn, topic, func() { t.Fatal("ack called unexpectedly") }, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func TestErrorCode(t *testing.T) {
 	h := dh.(*harness)
 
 	// Topics
-	dt, err := createTopic(h.nc, "bar")
+	dt, err := openTopic(h.nc, "bar")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestErrorCode(t *testing.T) {
 	}
 
 	// Subscriptions
-	ds, err := createSubscription(h.nc, "bar", func() { t.Fatal("ack called unexpectedly") })
+	ds, err := openSubscription(h.nc, "bar", func() { t.Fatal("ack called unexpectedly") })
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #1715 by renaming `CreateTopic`/`CreateSubscription` -> `OpenTopic`/`OpenSubscription`.

Fixes #1716:
* Clarified that "topicName" and "subscriptionName" are really NATS subjects by renaming various args and variables to "subject".

* Updated commented-out lines in example about NGS/credentials with a link.

* "Are there ways to set credentials and such in the URLOpener?" --> not currently no.

* Added a link to the centralized documentation for provider semantics to the ackfunc doc in a couple of places. The centralized documentation should probably be improved, but there's no need to repeat it for every driver.

* Lengthened some variable names in examples.