### PR TITLE
internal/website: prevent code samples from widening main content region

### DIFF
--- a/internal/website/content/howto/blob/open-bucket.md
+++ b/internal/website/content/howto/blob/open-bucket.md
@@ -61,6 +61,7 @@ import (
     "github.com/aws/aws-sdk-go/aws/session"
     "gocloud.dev/blob/s3blob"
 )
+
 // ...
 
 // Establish an AWS session.
@@ -180,6 +181,7 @@ defer bucket.Close()
 
 [GCP creds]: https://cloud.google.com/docs/authentication/production
 [`gcsblob.OpenBucket`]: https://godoc.org/gocloud.dev/blob/gcsblob#OpenBucket
+[`gocloud.dev/gcp`]: https://godoc.org/gocloud.dev/gcp
 
 ## Azure Storage
 

--- a/internal/website/static/css/style.css
+++ b/internal/website/static/css/style.css
@@ -39,7 +39,10 @@ body {
     'hd hd'
     'sd main'
     'ft ft';
+  margin: 0;
   min-height: 100vh;
+  padding: 0;
+  width: 100vw;
 }
 @media (max-width: 768px) {
   .PageLayout {
@@ -67,6 +70,7 @@ body {
   box-sizing: border-box;
   grid-area: main;
   margin: 0;
+  overflow-x: hidden;  /* creates a new block formatting context for children overflows */
   padding: 2rem 2rem 3rem;
 }
 .MainContent-bounds {
@@ -240,12 +244,10 @@ body {
   display: block;
   font: 0.8rem/1.4 'Source Code Pro', monospace;
   margin: 0 0 1rem;
-  overflow: auto;
+  overflow-x: auto;
   padding: 1rem;
   white-space: pre;
   width: 100%;
-  word-break: break-all;
-  word-wrap: break-word;
 }
 .MainContent pre code {
   font-size: 100%;


### PR DESCRIPTION
(Because I know how much you enjoy reviewing CSS, @eliben.)

The part missing from the CSS before was declaring MainContent to be a new block formatting context. I do this by setting overflow to hidden.

Also includes some small content fixes.