### PR TITLE
firedocstore: support multiple filters in queries

### DIFF
--- a/internal/docstore/firedocstore/doc.go
+++ b/internal/docstore/firedocstore/doc.go
@@ -28,12 +28,17 @@
 //
 // Queries
 //
-// Firestore allows only one field in a query to be compared with an inequality operator (one other than "=").
-// This driver passes the first Where clause with an inequality to Firestore and handles the rest locally.
+// Firestore allows only one field in a query to be compared with an inequality
+// operator (one other than "="). This driver selects the first field in a Where
+// clause with an inequality to pass to Firestore and handles the rest locally. For
+// example, if the query specifies the three clauses A > 1, B > 2 and A < 3, then
+// A > 1 and A < 3 will be sent to Firestore, and the results will be filtered by
+// B > 2 in this driver.
 //
-// Firestore requires a composite index if a query contains both an equality and an inequality comparison.
-// This driver returns an error if the necessary index does not exist. You must create the index manually.
-// See https://cloud.google.com/firestore/docs/query-data/indexing for details.
+// Firestore requires a composite index if a query contains both an equality and an
+// inequality comparison. This driver returns an error if the necessary index does
+// not exist. You must create the index manually. See
+// https://cloud.google.com/firestore/docs/query-data/indexing for details.
 //
 // See https://cloud.google.com/firestore/docs/query-data/queries for more information on Firestore queries.
 package firedocstore // import "gocloud.dev/internal/docstore/firedocstore"

--- a/internal/docstore/firedocstore/doc.go
+++ b/internal/docstore/firedocstore/doc.go
@@ -15,6 +15,7 @@
 // Package firedocstore provides an implementation of the docstore API for Google
 // Cloud Firestore.
 //
+//
 // Docstore types not supported by the Go firestore client, cloud.google.com/go/firestore:
 // - unsigned integers: encoded is int64s
 // - complex64/128: encoded as an array of two float32/64s.
@@ -23,4 +24,16 @@
 // Firestore types not supported by Docstore:
 // - Document reference (a pointer to another Firestore document)
 // TODO(jba): figure out how to support this
+//
+//
+// Queries
+//
+// Firestore allows only one field in a query to be compared with an inequality operator (one other than "=").
+// This driver passes the first Where clause with an inequality to Firestore and handles the rest locally.
+//
+// Firestore requires a composite index if a query contains both an equality and an inequality comparison.
+// This driver returns an error if the necessary index does not exist. You must create the index manually.
+// See https://cloud.google.com/firestore/docs/query-data/indexing for details.
+//
+// See https://cloud.google.com/firestore/docs/query-data/queries for more information on Firestore queries.
 package firedocstore // import "gocloud.dev/internal/docstore/firedocstore"


### PR DESCRIPTION
Add support for locally evaluating some filters.

TODO: add multi-filter conformance tests (after the dynamo gets basic query support)

Updates #1338.