### PR TITLE
internal/cmd/gocdk: customize flag parsing setup

### DIFF
--- a/internal/cmd/gocdk/build.go
+++ b/internal/cmd/gocdk/build.go
@@ -27,7 +27,7 @@ import (
 )
 
 func build(ctx context.Context, pctx *processContext, args []string) error {
-	f := flag.NewFlagSet("build", flag.ContinueOnError)
+	f := newFlagSet(pctx, "build")
 	list := f.Bool("list", false, "display Docker images of this project")
 	if err := f.Parse(args); xerrors.Is(err, flag.ErrHelp) {
 		return nil

--- a/internal/cmd/gocdk/deploy.go
+++ b/internal/cmd/gocdk/deploy.go
@@ -22,7 +22,7 @@ import (
 )
 
 func deploy(ctx context.Context, pctx *processContext, args []string) error {
-	f := flag.NewFlagSet("deploy", flag.ContinueOnError)
+	f := newFlagSet(pctx, "deploy")
 	if err := f.Parse(args); xerrors.Is(err, flag.ErrHelp) {
 		return nil
 	} else if err != nil {

--- a/internal/cmd/gocdk/flagset.go
+++ b/internal/cmd/gocdk/flagset.go
@@ -1,0 +1,139 @@
+// Copyright 2019 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// flagSet wraps flag.FlagSet to suppress printing errors to the flag set's
+// output and to include a custom help flag.
+type flagSet struct {
+	flag.FlagSet
+	help bool
+}
+
+func newFlagSet(pctx *processContext, name string) *flagSet {
+	set := new(flagSet)
+	set.Init(name, flag.ContinueOnError)
+	set.Usage = func() {}
+	set.SetOutput(ioutil.Discard)
+	helpVar := &helpFlag{
+		name:    name,
+		flagSet: set,
+		output:  pctx.stderr,
+	}
+	set.Var(helpVar, "help", "displays this help message")
+	return set
+}
+
+func (set *flagSet) Parse(args []string) error {
+	err := set.FlagSet.Parse(args)
+	if set.help {
+		// The flag package wraps any error from Value.Set, so we can't check for
+		// error identity. Preserve ErrHelp
+		return flag.ErrHelp
+	}
+	return err
+}
+
+type helpFlag struct {
+	name    string
+	flagSet *flagSet
+	output  io.Writer
+}
+
+func (help helpFlag) String() string {
+	return ""
+}
+
+func (help helpFlag) Set(string) error {
+	help.flagSet.SetOutput(help.output)
+	fmt.Fprintf(help.output, "Usage of %s:\n", help.name)
+	help.flagSet.PrintDefaults()
+	help.flagSet.SetOutput(ioutil.Discard) // Prevent from printing error we return.
+
+	help.flagSet.help = true
+	// Exact error unimportant, but need to stop parsing.
+	return flag.ErrHelp
+}
+
+func (help helpFlag) IsBoolFlag() bool {
+	return true
+}
+
+// usageError indicates an invalid invocation of gocdk.
+type usageError struct {
+	msg    string
+	frame  xerrors.Frame
+	cause  error
+	unwrap bool
+}
+
+// usagef formats an error message string and returns a value of type
+// usageError. The error message will always have "usage: " prepended to it.
+func usagef(format string, args ...interface{}) error {
+	var cause error
+	const wrapSuffix = ": %w"
+	unwrap := strings.HasSuffix(format, wrapSuffix)
+	isValue := strings.HasSuffix(format, ": %v") || strings.HasSuffix(format, ": %s")
+	if len(args) > 0 && (unwrap || isValue) {
+		var ok bool
+		if cause, ok = args[len(args)-1].(error); ok {
+			// Remove everything after and including last colon from
+			// format and arguments.
+			format = format[:len(format)-len(wrapSuffix)]
+			args = args[:len(args)-1]
+		}
+	}
+	return usageError{
+		msg:    fmt.Sprintf(format, args...),
+		frame:  xerrors.Caller(1),
+		cause:  cause,
+		unwrap: unwrap,
+	}
+}
+
+func (ue usageError) Error() string {
+	if ue.cause != nil {
+		return "usage: " + ue.msg + ": " + ue.cause.Error()
+	}
+	return "usage: " + ue.msg
+}
+
+func (ue usageError) Unwrap() error {
+	if !ue.unwrap {
+		return nil
+	}
+	return ue.cause
+}
+
+func (ue usageError) FormatError(p xerrors.Printer) error {
+	p.Printf("usage: %s", ue.msg)
+	if p.Detail() {
+		ue.frame.Format(p)
+	}
+	return ue.cause
+}
+
+func (ue usageError) Format(f fmt.State, c rune) {
+	xerrors.FormatError(ue, f, c)
+}

--- a/internal/cmd/gocdk/flagset_test.go
+++ b/internal/cmd/gocdk/flagset_test.go
@@ -1,0 +1,165 @@
+// Copyright 2019 The Go Cloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"strings"
+	"testing"
+
+	"golang.org/x/xerrors"
+)
+
+func TestFlagSet(t *testing.T) {
+	t.Run("EmptyArgs", func(t *testing.T) {
+		output := new(bytes.Buffer)
+		set := newFlagSet(&processContext{stderr: output}, "foo")
+		err := set.Parse([]string{})
+		if err != nil {
+			t.Errorf("set.Parse returned %v; want <nil>", err)
+		}
+		if output.Len() > 0 {
+			t.Errorf("output = %q; want \"\"", output)
+		}
+	})
+	t.Run("BadFlag", func(t *testing.T) {
+		output := new(bytes.Buffer)
+		set := newFlagSet(&processContext{stderr: output}, "foo")
+		err := set.Parse([]string{"--bar"})
+		if err == nil {
+			t.Error("set.Parse returned nil; want error")
+		} else if xerrors.Is(err, flag.ErrHelp) {
+			t.Error("set.Parse returned flag.ErrHelp; want different error")
+		}
+		if output.Len() > 0 {
+			t.Errorf("output = %q; want \"\"", output)
+		}
+	})
+	t.Run("Help", func(t *testing.T) {
+		output := new(bytes.Buffer)
+		set := newFlagSet(&processContext{stderr: output}, "foo")
+		err := set.Parse([]string{"--help"})
+		if !xerrors.Is(err, flag.ErrHelp) {
+			t.Errorf("set.Parse returned %v; want %v", err, flag.ErrHelp)
+		}
+		if output.Len() == 0 || strings.Contains(output.String(), flag.ErrHelp.Error()) {
+			t.Errorf("output = %q; want non-empty and not to include %q", output, flag.ErrHelp.Error())
+		}
+	})
+}
+
+func TestUsagef(t *testing.T) {
+	cause := xerrors.New("bork")
+	tests := []struct {
+		name string
+		err  error
+
+		wantMessage       string
+		wantUnwrap        error
+		wantFormatMessage string
+		wantFormatError   error
+	}{
+		{
+			name: "StringOnly",
+			err:  usagef("hello %s", "world"),
+
+			wantMessage:       "usage: hello world",
+			wantUnwrap:        nil,
+			wantFormatMessage: "usage: hello world",
+			wantFormatError:   nil,
+		},
+		{
+			name: "Wrap",
+			err:  usagef("hello: %w", cause),
+
+			wantMessage:       "usage: hello: bork",
+			wantUnwrap:        cause,
+			wantFormatMessage: "usage: hello",
+			wantFormatError:   cause,
+		},
+		{
+			name: "Opaque",
+			err:  usagef("hello: %v", cause),
+
+			wantMessage:       "usage: hello: bork",
+			wantUnwrap:        nil,
+			wantFormatMessage: "usage: hello",
+			wantFormatError:   cause,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !xerrors.As(test.err, new(usageError)) {
+				t.Errorf("usagef returned a non-usageError: %#v", test.err)
+			}
+			if got := test.err.Error(); got != test.wantMessage {
+				t.Errorf("err.Error() = %q; want %q", got, test.wantMessage)
+			}
+			if got := xerrors.Unwrap(test.err); !xerrors.Is(got, test.wantUnwrap) {
+				t.Errorf("xerrors.Unwrap(err) = %v; want <nil>", got)
+			}
+
+			formatMsg, next := formatError(test.err)
+			if formatMsg != test.wantFormatMessage {
+				t.Errorf("after err.FormatError(p), message = %q; want %q", formatMsg, test.wantFormatMessage)
+			}
+			if !xerrors.Is(next, test.wantFormatError) {
+				t.Errorf("err.FormatError(p) = %v; want %v", next, test.wantFormatError)
+			}
+		})
+	}
+}
+
+// Ensure that usageError implements fmt.Formatter for Go 1.12 and below.
+var _ fmt.Formatter = usageError{}
+
+func formatError(err error) (message string, next error) {
+	f, ok := err.(xerrors.Formatter)
+	if !ok {
+		return err.Error(), nil
+	}
+	p := new(testErrorPrinter)
+	next = f.FormatError(p)
+	return strings.TrimSuffix(p.message.String(), "\n"), next
+}
+
+type testErrorPrinter struct {
+	message  strings.Builder
+	inDetail bool
+}
+
+func (p *testErrorPrinter) Print(args ...interface{}) {
+	if p.inDetail {
+		return
+	}
+	fmt.Fprintln(&p.message, args...)
+}
+
+func (p *testErrorPrinter) Printf(format string, args ...interface{}) {
+	if p.inDetail {
+		return
+	}
+	fmt.Fprintf(&p.message, format, args...)
+	if s := p.message.String(); len(s) == 0 || s[len(s)-1] != '\n' {
+		p.message.WriteByte('\n')
+	}
+}
+
+func (p *testErrorPrinter) Detail() bool {
+	p.inDetail = true
+	return true
+}


### PR DESCRIPTION
Otherwise, the control flow of when the flag parsing error is shown is unclear and buried inside the flag package.

@clausti This is the result of my yak-shaving: a large pile of hair worthy of its own PR. Keeping as draft until #1796 is merged in.
