### PR TITLE
internal/testing: don't break if upstream changes during test execution

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -885,6 +885,7 @@ golang.org/x/tools v0.0.0-20181221154417-3ad2d988d5e2/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c h1:vamGzbGri8IKo20MQncCuljcQ5uAO6kaCeawQPVblAI=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+golang.org/x/tools v0.0.0-20190312170243-e65039ee4138 h1:H3uGjxCR/6Ds0Mjgyp7LMK81+LvmbvWWEnJhzk1Pi9E=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/xerrors v0.0.0-20190129162528-20feca13ea86 h1:kMgZCSynBSIN3PHpvuFeMExQwPWtUZ/xfnt2Yr2cp20=
 golang.org/x/xerrors v0.0.0-20190129162528-20feca13ea86/go.mod h1:/lyp46tcDBI65C0XC8F4d0/XVb7MT7RScVRech7dX/4=

--- a/internal/testing/check_api_change.sh
+++ b/internal/testing/check_api_change.sh
@@ -14,13 +14,22 @@
 # limitations under the License.
 
 # This script checks to see if there are any incompatible API changes on the
-# current branch relative to master@HEAD.
+# current branch relative to the upstream branch.
 # It fails if it finds any, unless there is a commit with BREAKING_CHANGE_OK
 # in the first line of the commit message.
 
+# This script expects:
+# a) to be run at the root of the repository
+# b) HEAD is pointing to a commit that merges between the pull request and the
+#    upstream branch (TRAVIS_BRANCH). This is what Travis does (see
+#    https://docs.travis-ci.com/user/pull-requests/ for details), but if you
+#    are testing this script manually, you may need to manually create a merge
+#    commit.
+
 set -euo pipefail
 
-echo "Checking for incompatible API changes relative to master@HEAD..."
+UPSTREAM_BRANCH="${TRAVIS_BRANCH:-master}"
+echo "Checking for incompatible API changes relative to ${UPSTREAM_BRANCH}..."
 echo
 
 go install -mod=readonly golang.org/x/exp/cmd/apidiff
@@ -36,11 +45,7 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-# We compare against master@HEAD. This is unfortunate in some cases: if you're
-# working on an out-of-date branch, and master gets some new feature (that has
-# nothing to do with your work on your branch), you'll get an error message.
-# Thankfully the fix is quite simple: rebase your branch.
-git clone https://github.com/google/go-cloud "$MASTER_CLONE_DIR"
+git clone -b "$UPSTREAM_BRANCH" . "$MASTER_CLONE_DIR"
 echo
 
 incompatible_change_pkgs=()


### PR DESCRIPTION
I also made changes suggested by [shellcheck](https://www.shellcheck.net/) to avoid escaping issues. They're made as separate commits if you want to isolate the changes for review.

Fixes #1802