### PR TITLE
dynamodocstore: use Scan if we can't use Query

### DIFF
--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Create.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Create.yaml
@@ -12,9 +12,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190925Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:25 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - S3CU9VJD41CV3S0IG4F49Q9C0JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - N3M9EQCQ5GC741NSH68BC5GKHBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -50,9 +50,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190925Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:25 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3419709330"
       X-Amzn-Requestid:
-      - ER6Q75UN6AVF7QV7R13TLCU08BVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 80M7RJR2ES2JMP6D2P92EAQPKBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -88,9 +88,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190926Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -106,13 +106,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:26 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - QE9KA4RE964REK9H2PE6A28O2FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - EEVQV1GJMPCSAD9108VG8VRNKRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -127,9 +127,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190926Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -144,13 +144,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:26 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - QVK61JQ4LRFOSA5DB9LTH3S58JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - SLV3OMFQGC9LBAOKKBN0ME1VFVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Data.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Data.yaml
@@ -12,9 +12,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190929Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:29 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - SIESPOMVERJQ23VTPF1L6GV3O3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - MD3UPNUG1N8A2P9T7LG3857LSFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -50,9 +50,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190929Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:29 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3397496571"
       X-Amzn-Requestid:
-      - OSL95O1U06PMSL0OAJHQF4KGGNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - MFABPO1DUAIE75V2CGLTDDB2BFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -88,9 +88,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190930Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -105,13 +105,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:30 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - VP3LT5L30A0ORRMR9R5HVV3AHFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - KQVM9BNM9K5746IKJ5K0JMK6LNVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -126,9 +126,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190930Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -143,13 +143,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:30 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "813349402"
       X-Amzn-Requestid:
-      - BONO2QE55KCV9IGJS6AFBMC67NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 8HAVQ6HQNTBF8CE1V9JJ6DV04NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -164,9 +164,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190930Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -181,13 +181,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:30 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - TSFTHSRFPCFQ7TK8J13I6FNPSFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 79M3VHDJS6R6DDDR7712UNOU8BVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -202,9 +202,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190930Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -219,13 +219,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:30 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1231822837"
       X-Amzn-Requestid:
-      - HO5ABQAAPL67B76R4SIPU1QNB7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NB783F06SQUER6K6EMILOK4K8RVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -240,9 +240,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190930Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -257,13 +257,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:30 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - MTQB5M4ORU3S0FPMR2RJDS057FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - N74301BCF0C4D6OKCT0T5VQSIJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -278,9 +278,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190930Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -295,13 +295,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:30 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2384824988"
       X-Amzn-Requestid:
-      - L86F8AFRT68UOI4L8P0H7DNEFFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - RM7LA05LSATVAJ4E1RPPTE84N3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -316,9 +316,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190930Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -333,13 +333,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:30 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 30DCCALQLKMQK4VU9TP2GKTN5NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - BO26RT6P97JJ786IVG5FQT0PEBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -354,9 +354,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190930Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -371,13 +371,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:30 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1613526028"
       X-Amzn-Requestid:
-      - KTR6JERVKQ1GQN44F67GLO1G3FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - AEQ1B5KIIAPQE2KU23HD0GQJDBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -392,9 +392,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190930Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -409,13 +409,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:30 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 7SJQ6TQ0VLMFICC81R2ORP0817VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 70C85BN1QGIO37IFH4ER060IO7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -430,9 +430,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190930Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -447,13 +447,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:30 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3327167908"
       X-Amzn-Requestid:
-      - E36161VO10R86PTL45ABMAQ003VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - C1TFJQ95590GGSO3L2BMG34GSFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -468,9 +468,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190931Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -485,13 +485,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:31 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 7GU78R5SKQ50B34B15KKP5BTQ3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 0VSOCM4AOTAN865SEU4B5VRD6NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -506,9 +506,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190931Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -523,13 +523,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:31 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "482119110"
       X-Amzn-Requestid:
-      - GQET5MNNB5D1JE4GOCNS6B6URVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - CCHC8EM85VC9TQ4TVLQOGNI90FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -544,9 +544,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190931Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -561,13 +561,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:31 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - NB9G1VMNMOPO7AQV5R5V4D9C87VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 690PH13L16U64VKPNVR9QFPHSBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -582,9 +582,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190931Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -599,13 +599,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:31 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3856178417"
       X-Amzn-Requestid:
-      - HK9K38IRNP2EOJCM2T3CUR7OKNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 2M4D8MT7L739GJ7T6RS0UBSC3FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -620,9 +620,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190931Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -637,13 +637,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:31 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 191T8CP78VJ0TCKE4CLDUKGOIRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - KO7MUN034ORRDKE4QCL00MKEIBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -658,9 +658,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190931Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -675,13 +675,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:31 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1401218618"
       X-Amzn-Requestid:
-      - B634KHUQ6AK9VQOEK2TJCUN0J7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - BSP4AQ1FN3HR1DD5CCTFKR326BVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -696,9 +696,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190931Z
+      - 20190416T125020Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -713,13 +713,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:31 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - OCTH6EM1JIKE8NNB3SNTFMUKT7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - B5390SK1306V7LQ1026J93LE9FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -734,9 +734,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190931Z
+      - 20190416T125020Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -751,13 +751,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:31 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "482425442"
       X-Amzn-Requestid:
-      - V2QD0FI0F9KVOIAVEGF0QN44HJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - IBEF0655QQ2E05EE01HB5I2U5NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -772,9 +772,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190931Z
+      - 20190416T125020Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -789,13 +789,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:31 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - MBCO5LMD49A50O33T8U4Q6LE2JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 2UI21F29FT3RUDORPQEAG2CBAFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -810,9 +810,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190931Z
+      - 20190416T125020Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -827,13 +827,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:32 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1468195875"
       X-Amzn-Requestid:
-      - EBU0UMQOQNM7FEVC3K75KAKH6NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - R1N0I3U6EM493RFOF8S3THMOT3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -848,9 +848,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190932Z
+      - 20190416T125020Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -865,13 +865,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:32 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - JNT14CKIPJB3E4MSQ97NCBCTUJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - GBA5Q25MIS5QP2HV209GD17S93VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -886,9 +886,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190932Z
+      - 20190416T125020Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -903,13 +903,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:32 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "928465577"
       X-Amzn-Requestid:
-      - T46TQ47M9D5SN1F5129SEA6PBFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - MT6JB805QBC3ETQD498C7AHP0RVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Delete.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Delete.yaml
@@ -12,9 +12,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190928Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:28 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - TLKRPO3PHC0HNTB9PEV96N71B7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - J5O9RQ3MA2CCQ525NJC6PN7TR7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -50,9 +50,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190928Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:28 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - EOTALQTQ552GTHBP96UIE2GTLJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - LKC9PGITHI53RNK9QDESU99THRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -88,9 +88,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190928Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -105,13 +105,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:28 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 4K02VPH9GGOF1TTGQQPQP8MTK3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - KUJ4EH5FI7RQNIC9CJS476SMCRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -126,9 +126,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190928Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -143,13 +143,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:28 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 5OHAAP89MR73ABU1E8Q64V1A4FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - M2JNU1NOIQU3881NLHCJF08JHBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -164,9 +164,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190928Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -181,13 +181,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:28 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - VU0AB3M4KV4LM80I1CV90HAPIFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 83R42DQ2V7414DA6RL1GOFGTSRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -202,9 +202,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190928Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -219,13 +219,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:28 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "503600574"
       X-Amzn-Requestid:
-      - JIU4ENGO64TVJDVPA7G0AV162RVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - T0H3HCR23DEE7LSKS091FVIBTNVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -240,9 +240,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190928Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -257,13 +257,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:28 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 6GNBHOOM7MCPQJOR0EFH1SCJ5JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - F2BA12EFTGPD0MUHDIQNHPIHNFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -278,9 +278,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190928Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -296,13 +296,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:28 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - JN1L82S89NKTSH9HRP2HLSRDB7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - AVHS23KDJDB38F24R8KLBUB33BVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Get.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Get.yaml
@@ -13,9 +13,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190927Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -30,13 +30,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:27 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - S6JQKFGDLNOJLM1S8AH4S8JCEVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - TO6MPMES3F1AU231HEAU1QB4K7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -51,9 +51,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190927Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -68,13 +68,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:27 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3456633873"
       X-Amzn-Requestid:
-      - RDKRMU1KBTLGJ1BMTQVN7S72QNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - H3V55PBN5HIALMUC3UN4AT35QVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -90,9 +90,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190928Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -107,13 +107,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:28 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "829082549"
       X-Amzn-Requestid:
-      - EQ8T998PA3L3TEUDJDGRMCOT4RVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - B1H73RFVPNJUNFPNPO767UA037VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Put.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Put.yaml
@@ -12,9 +12,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190926Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:26 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 6KUDP0DPABCSLMJS7RQILM44FJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - SRP3DAU9GTJ2REFMC0Q6330HMJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -50,9 +50,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190926Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:26 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "390688631"
       X-Amzn-Requestid:
-      - VP7HUAS1375FVBTKSBBMBI02IJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - M2UH80R9RP7SP6K0P1JUFVMJ9FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -88,9 +88,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190926Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -105,13 +105,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:26 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - S25CLQDOBSD3221EM8OBEEC28JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - QCDTF0D8P2V725HK6P861PTQBVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -126,9 +126,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190926Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -143,13 +143,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:26 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3322650091"
       X-Amzn-Requestid:
-      - RCOOAR5KBLOB07OI1LP2NJ2027VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - GKGHEROOJLU7AAVS2FULL387EBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -164,9 +164,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190926Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -181,13 +181,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:26 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 9UFN7JFQ39O7229PJ58TLOR43NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - ET2K3SAQFOV3GTHIFUC17RMQMVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -202,9 +202,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190926Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -219,13 +219,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:26 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3518719518"
       X-Amzn-Requestid:
-      - M7MIPVOQPQ1G3DD66VB36GJPSNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - SJNGDU55822IVAOG5GRI0KB82NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -240,9 +240,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190926Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -257,13 +257,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:27 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - GA314M89B5J5S1BUHA54F7IMBVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 9NKKEBALR6QSLIA65SRTM3DC5VVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -278,9 +278,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190927Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -296,13 +296,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:27 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - 8QHIV3KKEDOVHJLUVEHCJLM69JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 11PE2F55K77CHVG794LK2VREB7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Query.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Query.yaml
@@ -2,80 +2,346 @@
 version: 1
 interactions:
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"_kind","#1":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"query"}},"KeyConditionExpression":"#0
-      = :0","ProjectionExpression":"#1","TableName":"docstore-test"}'
+    body: '{"TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "207"
+      - "29"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190932Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
-    body: '{"Count":0,"Items":[],"ScannedCount":0}'
+    body: '{"Count":7,"Items":[{"_id":{"S":"testPut1"},"b":{"BOOL":false},"_kind":{"S":"put"},"DocstoreRevision":{"S":"6694d2c4-22ac-4208-a007-2939487f6999"}},{"_id":{"S":"testData"},"val":{"B":"AAEC"},"_kind":{"S":"data"},"DocstoreRevision":{"S":"ee294b39-f32b-4c78-a2ba-64f84ab43ca0"}},{"_id":{"S":"testRevisionField"},"s":{"S":"c"},"_kind":{"S":"revisionField"},"DocstoreRevision":{"S":"067d89bc-7f01-41f5-b398-1659a44ff17a"}},{"_id":{"S":"testDelete"},"_kind":{"S":"delete"},"DocstoreRevision":{"S":"29b0223b-eea5-44f7-8391-f445d15afd42"},"x":{"S":"y"}},{"s":{"S":"a
+      string"},"_kind":{"S":"get"},"f":{"N":"32.3"},"i":{"N":"95"},"_id":{"S":"testGet1"},"m":{"M":{"a":{"S":"one"},"b":{"S":"two"}}},"DocstoreRevision":{"S":"172ed857-94bb-458b-8c3b-525da1786f9f"}},{"_id":{"S":"testReplace"},"s":{"S":"b"},"_kind":{"S":"replace"},"DocstoreRevision":{"S":"6325253f-ec73-4dd7-a9e2-8bf921119c16"}},{"a":{"S":"X"},"_id":{"S":"testUpdate"},"c":{"S":"C"},"_kind":{"S":"update"},"DocstoreRevision":{"S":"8d019192-c242-44e2-8afc-cae3a61fb586"}}],"ScannedCount":7}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - "39"
+      - "1043"
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:32 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
-      - "3413411624"
+      - "1049590557"
       X-Amzn-Requestid:
-      - F4QSFB2NM08N9IOFRF3CTLKG6VVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 93FR0KK6DVR9ICOG4TSI9CC43FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"_kind","#1":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"query"}},"KeyConditionExpression":"#0
-      = :0","ProjectionExpression":"#1","TableName":"docstore-test"}'
+    body: '{"TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "207"
+      - "29"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190932Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
-    body: '{"Count":0,"Items":[],"ScannedCount":0}'
+    body: '{"Count":7,"Items":[{"_id":{"S":"testPut1"},"b":{"BOOL":false},"_kind":{"S":"put"},"DocstoreRevision":{"S":"6694d2c4-22ac-4208-a007-2939487f6999"}},{"_id":{"S":"testData"},"val":{"B":"AAEC"},"_kind":{"S":"data"},"DocstoreRevision":{"S":"ee294b39-f32b-4c78-a2ba-64f84ab43ca0"}},{"_id":{"S":"testRevisionField"},"s":{"S":"c"},"_kind":{"S":"revisionField"},"DocstoreRevision":{"S":"067d89bc-7f01-41f5-b398-1659a44ff17a"}},{"_id":{"S":"testDelete"},"_kind":{"S":"delete"},"DocstoreRevision":{"S":"29b0223b-eea5-44f7-8391-f445d15afd42"},"x":{"S":"y"}},{"s":{"S":"a
+      string"},"_kind":{"S":"get"},"f":{"N":"32.3"},"i":{"N":"95"},"_id":{"S":"testGet1"},"m":{"M":{"a":{"S":"one"},"b":{"S":"two"}}},"DocstoreRevision":{"S":"172ed857-94bb-458b-8c3b-525da1786f9f"}},{"_id":{"S":"testReplace"},"s":{"S":"b"},"_kind":{"S":"replace"},"DocstoreRevision":{"S":"6325253f-ec73-4dd7-a9e2-8bf921119c16"}},{"a":{"S":"X"},"_id":{"S":"testUpdate"},"c":{"S":"C"},"_kind":{"S":"update"},"DocstoreRevision":{"S":"8d019192-c242-44e2-8afc-cae3a61fb586"}}],"ScannedCount":7}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - "39"
+      - "1043"
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:32 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
-      - "3413411624"
+      - "1049590557"
       X-Amzn-Requestid:
-      - UASSBAQ2GLOTTOLLV8A5JGOT97VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - JRHST8M0V3T99IVR0IIB7AIUARVV4KQNSO5AEMVJF66Q9ASUAAJG
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ConditionExpression":"#0 = :0","ExpressionAttributeNames":{"#0":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"6694d2c4-22ac-4208-a007-2939487f6999"}},"Key":{"_id":{"S":"testPut1"},"_kind":{"S":"put"}},"TableName":"docstore-test"}'
+    form: {}
+    headers:
+      Accept-Encoding:
+      - identity
+      Content-Length:
+      - "245"
+      Content-Type:
+      - application/x-amz-json-1.0
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
+      X-Amz-Date:
+      - 20190416T125020Z
+      X-Amz-Target:
+      - DynamoDB_20120810.DeleteItem
+    url: https://dynamodb.us-east-2.amazonaws.com/
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/x-amz-json-1.0
+      Date:
+      - Tue, 16 Apr 2019 12:50:20 GMT
+      Server:
+      - Server
+      X-Amz-Crc32:
+      - "2745614147"
+      X-Amzn-Requestid:
+      - JD6D3KIHF2GE6JRK36K06LFRGBVV4KQNSO5AEMVJF66Q9ASUAAJG
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ConditionExpression":"#0 = :0","ExpressionAttributeNames":{"#0":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"ee294b39-f32b-4c78-a2ba-64f84ab43ca0"}},"Key":{"_id":{"S":"testData"},"_kind":{"S":"data"}},"TableName":"docstore-test"}'
+    form: {}
+    headers:
+      Accept-Encoding:
+      - identity
+      Content-Length:
+      - "246"
+      Content-Type:
+      - application/x-amz-json-1.0
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
+      X-Amz-Date:
+      - 20190416T125020Z
+      X-Amz-Target:
+      - DynamoDB_20120810.DeleteItem
+    url: https://dynamodb.us-east-2.amazonaws.com/
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/x-amz-json-1.0
+      Date:
+      - Tue, 16 Apr 2019 12:50:20 GMT
+      Server:
+      - Server
+      X-Amz-Crc32:
+      - "2745614147"
+      X-Amzn-Requestid:
+      - 3V5356PF7KDAN0MRBG49TU9HHVVV4KQNSO5AEMVJF66Q9ASUAAJG
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ConditionExpression":"#0 = :0","ExpressionAttributeNames":{"#0":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"067d89bc-7f01-41f5-b398-1659a44ff17a"}},"Key":{"_id":{"S":"testRevisionField"},"_kind":{"S":"revisionField"}},"TableName":"docstore-test"}'
+    form: {}
+    headers:
+      Accept-Encoding:
+      - identity
+      Content-Length:
+      - "264"
+      Content-Type:
+      - application/x-amz-json-1.0
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
+      X-Amz-Date:
+      - 20190416T125020Z
+      X-Amz-Target:
+      - DynamoDB_20120810.DeleteItem
+    url: https://dynamodb.us-east-2.amazonaws.com/
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/x-amz-json-1.0
+      Date:
+      - Tue, 16 Apr 2019 12:50:20 GMT
+      Server:
+      - Server
+      X-Amz-Crc32:
+      - "2745614147"
+      X-Amzn-Requestid:
+      - V3CBU7QF02SDFMGE5GK8BALV4FVV4KQNSO5AEMVJF66Q9ASUAAJG
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ConditionExpression":"#0 = :0","ExpressionAttributeNames":{"#0":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"29b0223b-eea5-44f7-8391-f445d15afd42"}},"Key":{"_id":{"S":"testDelete"},"_kind":{"S":"delete"}},"TableName":"docstore-test"}'
+    form: {}
+    headers:
+      Accept-Encoding:
+      - identity
+      Content-Length:
+      - "250"
+      Content-Type:
+      - application/x-amz-json-1.0
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
+      X-Amz-Date:
+      - 20190416T125020Z
+      X-Amz-Target:
+      - DynamoDB_20120810.DeleteItem
+    url: https://dynamodb.us-east-2.amazonaws.com/
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/x-amz-json-1.0
+      Date:
+      - Tue, 16 Apr 2019 12:50:20 GMT
+      Server:
+      - Server
+      X-Amz-Crc32:
+      - "2745614147"
+      X-Amzn-Requestid:
+      - 6MHUHNEHL5M4H6CPL4IRP5QRDJVV4KQNSO5AEMVJF66Q9ASUAAJG
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ConditionExpression":"#0 = :0","ExpressionAttributeNames":{"#0":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"172ed857-94bb-458b-8c3b-525da1786f9f"}},"Key":{"_id":{"S":"testGet1"},"_kind":{"S":"get"}},"TableName":"docstore-test"}'
+    form: {}
+    headers:
+      Accept-Encoding:
+      - identity
+      Content-Length:
+      - "245"
+      Content-Type:
+      - application/x-amz-json-1.0
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
+      X-Amz-Date:
+      - 20190416T125020Z
+      X-Amz-Target:
+      - DynamoDB_20120810.DeleteItem
+    url: https://dynamodb.us-east-2.amazonaws.com/
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/x-amz-json-1.0
+      Date:
+      - Tue, 16 Apr 2019 12:50:20 GMT
+      Server:
+      - Server
+      X-Amz-Crc32:
+      - "2745614147"
+      X-Amzn-Requestid:
+      - 1GS8G11HF8K0TFAQRGIUIUJCABVV4KQNSO5AEMVJF66Q9ASUAAJG
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ConditionExpression":"#0 = :0","ExpressionAttributeNames":{"#0":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"6325253f-ec73-4dd7-a9e2-8bf921119c16"}},"Key":{"_id":{"S":"testReplace"},"_kind":{"S":"replace"}},"TableName":"docstore-test"}'
+    form: {}
+    headers:
+      Accept-Encoding:
+      - identity
+      Content-Length:
+      - "252"
+      Content-Type:
+      - application/x-amz-json-1.0
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
+      X-Amz-Date:
+      - 20190416T125020Z
+      X-Amz-Target:
+      - DynamoDB_20120810.DeleteItem
+    url: https://dynamodb.us-east-2.amazonaws.com/
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/x-amz-json-1.0
+      Date:
+      - Tue, 16 Apr 2019 12:50:20 GMT
+      Server:
+      - Server
+      X-Amz-Crc32:
+      - "2745614147"
+      X-Amzn-Requestid:
+      - 0A467ETFBENAFL4G8OJSVPJKGFVV4KQNSO5AEMVJF66Q9ASUAAJG
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ConditionExpression":"#0 = :0","ExpressionAttributeNames":{"#0":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"8d019192-c242-44e2-8afc-cae3a61fb586"}},"Key":{"_id":{"S":"testUpdate"},"_kind":{"S":"update"}},"TableName":"docstore-test"}'
+    form: {}
+    headers:
+      Accept-Encoding:
+      - identity
+      Content-Length:
+      - "250"
+      Content-Type:
+      - application/x-amz-json-1.0
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
+      X-Amz-Date:
+      - 20190416T125020Z
+      X-Amz-Target:
+      - DynamoDB_20120810.DeleteItem
+    url: https://dynamodb.us-east-2.amazonaws.com/
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/x-amz-json-1.0
+      Date:
+      - Tue, 16 Apr 2019 12:50:20 GMT
+      Server:
+      - Server
+      X-Amz-Crc32:
+      - "2745614147"
+      X-Amzn-Requestid:
+      - 74I5SELT9FV89474EBKILQ1TVJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -90,9 +356,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190932Z
+      - 20190416T125020Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -107,13 +373,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:32 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 3TAUHR2N2T1AHJUN7SIB1BQ3MRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - QQUV2K2LE5RNMR0DIG64H7TNEFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -128,9 +394,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190932Z
+      - 20190416T125020Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -145,13 +411,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:32 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - J1SEBJP1OL8IGC48POVIKSC347VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - FDBP2J9S52976I7CLLHL1S9IK3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -166,9 +432,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190932Z
+      - 20190416T125020Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -183,33 +449,33 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:32 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 3MICU3K1S7390DVS6MTFGCC3OVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - SMTJLODB8IAKDII71CU6J87NF3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"_kind","#2":"DocstoreRevision","#3":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"},":1":{"S":"query"}},"FilterExpression":"#0
-      < :0","KeyConditionExpression":"#1 = :1","ProjectionExpression":"#2, #3","TableName":"docstore-test"}'
+    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
+      < :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "275"
+      - "208"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190932Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
@@ -222,33 +488,33 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:32 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2324535421"
       X-Amzn-Requestid:
-      - U7RA8S02NK4IM5IQ4P3G1JFAFNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 1NOB4HB77VKH2J761F5I1E0RURVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"_kind","#2":"DocstoreRevision","#3":"_id"},"ExpressionAttributeValues":{":0":{"S":"fog"},":1":{"S":"query"}},"FilterExpression":"#0
-      < :0","KeyConditionExpression":"#1 = :1","ProjectionExpression":"#2, #3","TableName":"docstore-test"}'
+    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"S":"fog"}},"FilterExpression":"#0
+      < :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "277"
+      - "210"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190933Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
@@ -261,33 +527,33 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:33 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2324535421"
       X-Amzn-Requestid:
-      - 1IA25FVUSBTHG2IPBSVBLTIKPFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - DGSHDJJGH68A1PVKUVE56T33KJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"_kind","#2":"DocstoreRevision","#3":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"},":1":{"S":"query"}},"FilterExpression":"#0
-      <= :0","KeyConditionExpression":"#1 = :1","ProjectionExpression":"#2, #3","TableName":"docstore-test"}'
+    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
+      <= :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "276"
+      - "209"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190933Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
@@ -300,33 +566,33 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:33 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3764713186"
       X-Amzn-Requestid:
-      - 4JGALULT3HU86JVRI38AG2AQP7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 9JCAQM7AIAFAUKP4L9APV97V4BVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"_kind","#2":"DocstoreRevision","#3":"_id"},"ExpressionAttributeValues":{":0":{"S":"fog"},":1":{"S":"query"}},"FilterExpression":"#0
-      <= :0","KeyConditionExpression":"#1 = :1","ProjectionExpression":"#2, #3","TableName":"docstore-test"}'
+    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"S":"fog"}},"FilterExpression":"#0
+      <= :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "278"
+      - "211"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190933Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
@@ -339,33 +605,33 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:33 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3420333838"
       X-Amzn-Requestid:
-      - TDLIU5P84FU3QECI47O0778B13VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - G5DFMDC8MGIJ95ICI0P9VE1T1NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"_kind","#2":"DocstoreRevision","#3":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"},":1":{"S":"query"}},"FilterExpression":"#0
-      = :0","KeyConditionExpression":"#1 = :1","ProjectionExpression":"#2, #3","TableName":"docstore-test"}'
+    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
+      = :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "275"
+      - "208"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190933Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
@@ -378,33 +644,33 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:33 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "893020929"
       X-Amzn-Requestid:
-      - 0Q58P17A70ERV780L79SJOOV0VVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 8664Q07R0O4GL9Q2HTKMF0OI2RVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"_kind","#2":"DocstoreRevision","#3":"_id"},"ExpressionAttributeValues":{":0":{"S":"foo"},":1":{"S":"query"}},"FilterExpression":"#0
-      = :0","KeyConditionExpression":"#1 = :1","ProjectionExpression":"#2, #3","TableName":"docstore-test"}'
+    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"S":"foo"}},"FilterExpression":"#0
+      = :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "277"
+      - "210"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190933Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
@@ -417,33 +683,33 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:33 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "893020929"
       X-Amzn-Requestid:
-      - R6JMCUNU32PN8UU7KBTERMB5UNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 1MF1JFQBSP2FFQ4TUN60TVOGLJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"_kind","#2":"DocstoreRevision","#3":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"},":1":{"S":"query"}},"FilterExpression":"#0
-      >= :0","KeyConditionExpression":"#1 = :1","ProjectionExpression":"#2, #3","TableName":"docstore-test"}'
+    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
+      >= :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "276"
+      - "209"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190933Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
@@ -456,33 +722,33 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:33 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3462596048"
       X-Amzn-Requestid:
-      - OJ7GR0SE1DMNHMV5BJASRQNGSVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - RQTJRQ6GS4LOCM6DOJ5NQBAJ6BVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"_kind","#2":"DocstoreRevision","#3":"_id"},"ExpressionAttributeValues":{":0":{"S":"fog"},":1":{"S":"query"}},"FilterExpression":"#0
-      >= :0","KeyConditionExpression":"#1 = :1","ProjectionExpression":"#2, #3","TableName":"docstore-test"}'
+    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"S":"fog"}},"FilterExpression":"#0
+      >= :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "278"
+      - "211"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190933Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
@@ -495,33 +761,33 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:33 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3462596048"
       X-Amzn-Requestid:
-      - J0COA9GF7GGDENGIA89NJ7VDSRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 54BU81FR86DOFH013ACL38NJEJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"_kind","#2":"DocstoreRevision","#3":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"},":1":{"S":"query"}},"FilterExpression":"#0
-      > :0","KeyConditionExpression":"#1 = :1","ProjectionExpression":"#2, #3","TableName":"docstore-test"}'
+    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
+      > :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "275"
+      - "208"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190933Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
@@ -534,33 +800,33 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:33 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "511752941"
       X-Amzn-Requestid:
-      - 3S7I4IUJ7L406NI99B0L2NHD27VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - GDNV1MAK8CHE1FLLT84LU9KPCRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"_kind","#2":"DocstoreRevision","#3":"_id"},"ExpressionAttributeValues":{":0":{"S":"fog"},":1":{"S":"query"}},"FilterExpression":"#0
-      > :0","KeyConditionExpression":"#1 = :1","ProjectionExpression":"#2, #3","TableName":"docstore-test"}'
+    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"S":"fog"}},"FilterExpression":"#0
+      > :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "277"
+      - "210"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190933Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
@@ -573,33 +839,33 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:33 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "893020929"
       X-Amzn-Requestid:
-      - 4715O91SEGPT355KHBJ9KGA1E3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - E05V05R4VHEHE7S37QGAHG4S1RVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"_kind","#2":"DocstoreRevision","#3":"_id"},"ExpressionAttributeValues":{":0":{"N":"-4"},":1":{"S":"query"}},"FilterExpression":"#0
-      >= :0","KeyConditionExpression":"#1 = :1","ProjectionExpression":"#2, #3","TableName":"docstore-test"}'
+    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"N":"-4"}},"FilterExpression":"#0
+      >= :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
       Accept-Encoding:
       - identity
       Content-Length:
-      - "277"
+      - "210"
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190933Z
+      - 20190416T125020Z
       X-Amz-Target:
-      - DynamoDB_20120810.Query
+      - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
@@ -612,13 +878,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:33 GMT
+      - Tue, 16 Apr 2019 12:50:20 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3460309551"
       X-Amzn-Requestid:
-      - TU38EAI2OQH11GFQS3OHUB0CTVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - I75K0S3PMGQ5E11A54J9UEV8HBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Replace.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Replace.yaml
@@ -12,9 +12,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190927Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:27 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - T57QHLS6CQJV6U1DSCL90OLA33VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - IT57HE0C8G4IM340V06SQ5C01FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -50,9 +50,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190927Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:27 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 28PKIPVM0UO7Q26QAU4884AHJNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - PATR9OM5Q97RDBKPQ0FKDO3RCVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -88,9 +88,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190927Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -105,13 +105,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:27 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "344366584"
       X-Amzn-Requestid:
-      - RE8QEQFD8A520NK1ARGJVQIO0VVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - CJ9C0HEQ2DJ7M41S45NIB3E1NVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -126,9 +126,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190927Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -144,13 +144,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:27 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - UE4I8ITODURSSSGONKH4BUJO7NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 6MU2TAVO785TEBV33AF74GRP9JVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -165,9 +165,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190927Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -182,13 +182,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:27 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - OGGMMKBPL7IRV9KCCV370O09FJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - FUF49OAVO2VV6UVV2AII5NDPTRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -203,9 +203,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190927Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -220,13 +220,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:27 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3673566516"
       X-Amzn-Requestid:
-      - 1I6FT1OG7N6O4E0U22EPA5K5EFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 6LM23CJ04ECN1LT3CRO36DMAKVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -241,9 +241,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190927Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -258,13 +258,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:27 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - GLAIA965TVM6SGMH1NEO6GAUR7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - H0U0B2GKVMJA9NLL4DP9T9QSI7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -279,9 +279,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190927Z
+      - 20190416T125018Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -297,13 +297,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:27 GMT
+      - Tue, 16 Apr 2019 12:50:18 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - 9567B699SL9T55QL323C73ET5JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 706SPQHRSI3RE1RT8RSM9TVT9JVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Update.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Update.yaml
@@ -12,9 +12,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190929Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:29 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - F1V62IGFP4MT9U7VE1511H2PC7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NH8U42LTT6N9UDN04SRG1M3CVFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -51,9 +51,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190929Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.UpdateItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -68,13 +68,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:29 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 229O9B7FKQS45LONG01INSQTOJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - I9MD1PU6O26MR7NQ2EUGPD7RD7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -89,9 +89,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190929Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -106,13 +106,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:29 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "623689771"
       X-Amzn-Requestid:
-      - H3CPUR1QDFKOJKVGA1ORFHBGTJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - OM07NALFQTC4OE2TQDLU0N4C7JVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -128,9 +128,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190929Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.UpdateItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -146,13 +146,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:29 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - 9Q3NQKKNV7G4OUCCDECU99AN77VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - E690BSGCV00LM0REJ1JNUAL2T7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -167,9 +167,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190929Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -184,13 +184,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:29 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - MB1S72R075CAFJOBC6JN3TRKJRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - JSL10U7TE3HCNA46D32430559NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -205,9 +205,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190929Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -222,13 +222,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:29 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2083191073"
       X-Amzn-Requestid:
-      - QQCC2IRSDT8IT816A14QCN9EVBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - RTLMRR14G0NA095LTOBJ7DDCM3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -244,9 +244,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190929Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.UpdateItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -261,13 +261,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:29 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - O3A2VUI4KGK9Q4LGVG6H1IUU0NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - GVKJK7EH3PTR6SD0PFLHRDLSAFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -283,9 +283,9 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       User-Agent:
-      - aws-sdk-go/1.16.23 (go1.12.3; darwin; amd64)
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190410T190929Z
+      - 20190416T125019Z
       X-Amz-Target:
       - DynamoDB_20120810.UpdateItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -301,13 +301,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 10 Apr 2019 19:09:29 GMT
+      - Tue, 16 Apr 2019 12:50:19 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - B2JTG3QTGOGO7HN88S6RQR04KJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - RF6Q41DM1VD0GN7JLFE4RS9567VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""


### PR DESCRIPTION
Fall back to using the Scan RPC if the conditions for a Query RPC
aren't met.