### PR TITLE
blob/gcsblob: return *storage.Reader from gcsblob escape hatch

### DIFF
--- a/blob/example_test.go
+++ b/blob/example_test.go
@@ -448,7 +448,7 @@ func ExampleReader_As() {
 	defer r.Close()
 
 	// Access storage.Reader via sr here.
-	var sr storage.Reader
+	var sr *storage.Reader
 	if r.As(&sr) {
 		_ = sr.Attrs
 	}

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -40,7 +40,7 @@
 //  - Error: *googleapi.Error
 //  - ListObject: storage.ObjectAttrs
 //  - ListOptions.BeforeList: *storage.Query
-//  - Reader: storage.Reader
+//  - Reader: *storage.Reader
 //  - Attributes: storage.ObjectAttrs
 //  - CopyOptions.BeforeCopy: *storage.Copier
 //  - WriterOptions.BeforeWrite: *storage.Writer
@@ -241,11 +241,11 @@ func (r *reader) Attributes() driver.ReaderAttributes {
 }
 
 func (r *reader) As(i interface{}) bool {
-	p, ok := i.(*storage.Reader)
+	p, ok := i.(**storage.Reader)
 	if !ok {
 		return false
 	}
-	*p = *r.raw
+	*p = r.raw
 	return true
 }
 

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -180,7 +180,7 @@ func (verifyContentLanguage) AttributesCheck(attrs *blob.Attributes) error {
 }
 
 func (verifyContentLanguage) ReaderCheck(r *blob.Reader) error {
-	var rr storage.Reader
+	var rr *storage.Reader
 	if !r.As(&rr) {
 		return errors.New("Reader.As returned false")
 	}


### PR DESCRIPTION
**BREAKING_CHANGE**
    
For consistency with `WriterOptions.BeforeWrite` and to preserve reader identity (don't want to duplicate state).