### PR TITLE
dynamodocstore: query plan with indexes

### DIFF
--- a/internal/docstore/dynamodocstore/dynamo.go
+++ b/internal/docstore/dynamodocstore/dynamo.go
@@ -33,6 +33,7 @@ type collection struct {
 	table        string // DynamoDB table name
 	partitionKey string
 	sortKey      string
+	description  *dyn.TableDescription
 }
 
 // OpenCollection creates a *docstore.Collection representing a DynamoDB collection.

--- a/internal/docstore/dynamodocstore/query.go
+++ b/internal/docstore/dynamodocstore/query.go
@@ -58,60 +58,199 @@ func (c *collection) RunGetQuery(ctx context.Context, q *driver.Query) (driver.D
 	return it, nil
 }
 
-func (c *collection) planQueryOld(q *driver.Query) (*queryRunner, error) {
+func (c *collection) planQuery(q *driver.Query) (*queryRunner, error) {
 	var cb expression.Builder
 	cbUsed := false // It's an error to build an empty Builder.
+	// Set up the projection expression.
 	if len(q.FieldPaths) > 0 {
-		pb := expression.NamesList(expression.Name(docstore.RevisionField))
+		var pb expression.ProjectionBuilder
+		hasRevisionField := false
 		for _, fp := range q.FieldPaths {
+			if fpEqual(fp, docstore.RevisionField) {
+				hasRevisionField = true
+			}
 			pb = pb.AddNames(expression.Name(strings.Join(fp, ".")))
+		}
+		if !hasRevisionField {
+			pb = pb.AddNames(expression.Name(docstore.RevisionField))
+			q.FieldPaths = append(q.FieldPaths, []string{docstore.RevisionField})
 		}
 		cb = cb.WithProjection(pb)
 		cbUsed = true
 	}
-	// If there is an equality filter on the partition key, do a query.
-	// Otherwise, do a scan.
-	doQuery := false
+
+	// Find the best thing to query (table or index).
+	indexName, pkey, skey := c.bestQueryable(q)
+	if indexName == nil && pkey == "" {
+		// No query can be done: fall back to scanning.
+		if len(q.Filters) > 0 {
+			cb = cb.WithFilter(filtersToConditionBuilder(q.Filters))
+			cbUsed = true
+		}
+		in := &dynamodb.ScanInput{TableName: &c.table}
+		if cbUsed {
+			ce, err := cb.Build()
+			if err != nil {
+				return nil, err
+			}
+			in.ExpressionAttributeNames = ce.Names()
+			in.ExpressionAttributeValues = ce.Values()
+			in.FilterExpression = ce.Filter()
+			in.ProjectionExpression = ce.Projection()
+		}
+		return &queryRunner{c: c, scanIn: in}, nil
+	}
+
+	// Do a query.
+	cb = processFilters(cb, q.Filters, pkey, skey)
+	ce, err := cb.Build()
+	if err != nil {
+		return nil, err
+	}
+	return &queryRunner{
+		c: c,
+		queryIn: &dynamodb.QueryInput{
+			TableName:                 &c.table,
+			IndexName:                 indexName,
+			ExpressionAttributeNames:  ce.Names(),
+			ExpressionAttributeValues: ce.Values(),
+			KeyConditionExpression:    ce.KeyCondition(),
+			FilterExpression:          ce.Filter(),
+			ProjectionExpression:      ce.Projection(),
+		},
+	}, nil
+}
+
+// Return the best choice of queryable (table or index) for this query.
+// If indexName is nil but pkey is not empty, then use the table.
+// If all return values are zero, no query will work: do a scan.
+func (c *collection) bestQueryable(q *driver.Query) (indexName *string, pkey, skey string) {
+	// If the query has an "=" filter on the table's partition key, look at the table
+	// and local indexes.
+	if hasEqualityFilter(q, c.partitionKey) {
+		// If the table has a sort key that's in the query, use the table.
+		if hasFilter(q, c.sortKey) {
+			return nil, c.partitionKey, c.sortKey
+		}
+		// Look at local indexes. They all have the same partition key as the base table.
+		// If one has a sort key in the query, use it.
+		for _, li := range c.description.LocalSecondaryIndexes {
+			pkey, skey := keyAttributes(li.KeySchema)
+			if hasFilter(q, skey) {
+				return li.IndexName, pkey, skey
+			}
+		}
+	}
+	// Consider the global indexes: if one has a matching partition and sort key, and
+	// the projected fields of the index include those of the query, use it.
+	for _, gi := range c.description.GlobalSecondaryIndexes {
+		pkey, skey := keyAttributes(gi.KeySchema)
+		if skey == "" {
+			continue // We'll visit global indexes without a sort key later.
+		}
+		if hasEqualityFilter(q, pkey) && hasFilter(q, skey) && c.fieldsIncluded(q, gi) {
+			return gi.IndexName, pkey, skey
+		}
+	}
+	// There are no matches for both partition and sort key. Now consider matches on partition key only.
+	// That will still be better than a scan.
+	// First, check the table itself.
+	if hasEqualityFilter(q, c.partitionKey) {
+		return nil, c.partitionKey, c.sortKey
+	}
+	// No point checking local indexes: they have the same partition key as the table.
+	// Check the global indexes.
+	for _, gi := range c.description.GlobalSecondaryIndexes {
+		pkey, skey := keyAttributes(gi.KeySchema)
+		if hasEqualityFilter(q, pkey) && c.fieldsIncluded(q, gi) {
+			return gi.IndexName, pkey, skey
+		}
+	}
+	// We cannot do a query.
+	// TODO: return the reason why we couldn't. At a minimum, distinguish failure due to keys
+	// from failure due to projection (i.e. a global index had the right partition and sort key,
+	// but didn't project the necessary fields).
+	return nil, "", ""
+}
+
+// Reports whether the fields selected by the query are projected into (that is,
+// contained directly in) the global index. We need this check before using the
+// index, because if a global index doesn't have all the desired fields, then a
+// separate RPC for each returned item would be necessary to retrieve those fields,
+// and we'd rather scan than do that.
+func (c *collection) fieldsIncluded(q *driver.Query, gi *dynamodb.GlobalSecondaryIndexDescription) bool {
+	proj := gi.Projection
+	if *proj.ProjectionType == "ALL" {
+		// The index has all the fields of the table: we're good.
+		return true
+	}
+	if len(q.FieldPaths) == 0 {
+		// The query wants all the fields of the table, but we can't be sure that the
+		// index has them.
+		return false
+	}
+	// The table's keys and the index's keys are always in the index.
+	pkey, skey := keyAttributes(gi.KeySchema)
+	indexFields := map[string]bool{c.partitionKey: true, pkey: true}
+	if c.sortKey != "" {
+		indexFields[c.sortKey] = true
+	}
+	if skey != "" {
+		indexFields[skey] = true
+	}
+	for _, nka := range proj.NonKeyAttributes {
+		indexFields[*nka] = true
+	}
+	// Every field path in the query must be in the index.
+	for _, fp := range q.FieldPaths {
+		if !indexFields[strings.Join(fp, ".")] {
+			return false
+		}
+	}
+	return true
+}
+
+// Extract the names of the partition and sort key attributes from the schema of a
+// table or index.
+func keyAttributes(ks []*dynamodb.KeySchemaElement) (pkey, skey string) {
+	for _, k := range ks {
+		switch *k.KeyType {
+		case "HASH":
+			pkey = *k.AttributeName
+		case "RANGE":
+			skey = *k.AttributeName
+		default:
+			panic("bad key type: " + *k.KeyType)
+		}
+	}
+	return pkey, skey
+}
+
+// Reports whether q has a filter that mentions the top-level field.
+func hasFilter(q *driver.Query, field string) bool {
+	if field == "" {
+		return false
+	}
 	for _, f := range q.Filters {
-		if len(f.FieldPath) == 1 && f.FieldPath[0] == c.partitionKey && f.Op == driver.EqualOp {
-			doQuery = true
-			break
+		if fpEqual(f.FieldPath, field) {
+			return true
 		}
 	}
-	if doQuery {
-		cb = processFilters(cb, q.Filters, c.partitionKey, c.sortKey)
-		ce, err := cb.Build()
-		if err != nil {
-			return nil, err
+	return false
+}
+
+// Reports whether q has a filter that checks if the top-level field is equal to something.
+func hasEqualityFilter(q *driver.Query, field string) bool {
+	for _, f := range q.Filters {
+		if f.Op == driver.EqualOp && fpEqual(f.FieldPath, field) {
+			return true
 		}
-		return &queryRunner{
-			c: c,
-			queryIn: &dynamodb.QueryInput{
-				TableName:                 &c.table,
-				ExpressionAttributeNames:  ce.Names(),
-				ExpressionAttributeValues: ce.Values(),
-				KeyConditionExpression:    ce.KeyCondition(),
-				FilterExpression:          ce.Filter(),
-				ProjectionExpression:      ce.Projection(),
-			},
-		}, nil
 	}
-	if len(q.Filters) > 0 {
-		cb = cb.WithFilter(filtersToConditionBuilder(q.Filters))
-		cbUsed = true
-	}
-	in := &dynamodb.ScanInput{TableName: &c.table}
-	if cbUsed {
-		ce, err := cb.Build()
-		if err != nil {
-			return nil, err
-		}
-		in.ExpressionAttributeNames = ce.Names()
-		in.ExpressionAttributeValues = ce.Values()
-		in.FilterExpression = ce.Filter()
-		in.ProjectionExpression = ce.Projection()
-	}
-	return &queryRunner{c: c, scanIn: in}, nil
+	return false
+}
+
+func fpEqual(fp []string, s string) bool {
+	return len(fp) == 1 && fp[0] == s
 }
 
 type queryRunner struct {
@@ -245,189 +384,4 @@ func (it *documentIterator) Next(ctx context.Context, doc driver.Document) error
 func (it *documentIterator) Stop() {
 	it.items = nil
 	it.last = nil
-}
-
-////////////////////////////////////////////////////////////////
-
-// Return the best choice of queryable (table or index) for this query.
-// If indexName is nil but pkey is not empty, then use the table.
-// If all return values are zero, no query will work: do a scan.
-func (c *collection) bestQueryable(q *driver.Query) (indexName *string, pkey, skey string) {
-	// If the query has an "=" filter on the table's partition key, look at the table
-	// and local indexes.
-	if hasEqualityFilter(q, c.partitionKey) {
-		// If the table has a sort key that's in the query, use the table.
-		if hasFilter(q, c.sortKey) {
-			return nil, c.partitionKey, c.sortKey
-		}
-		// Look at local indexes. They all have the same partition key as the base table.
-		// If one has a sort key in the query, use it.
-		for _, li := range c.description.LocalSecondaryIndexes {
-			pkey, skey := keyAttributes(li.KeySchema)
-			if hasFilter(q, skey) {
-				return li.IndexName, pkey, skey
-			}
-		}
-	}
-	// Consider the global indexes: if one has a matching partition and sort key, and
-	// the projected fields of the index include those of the query, use it.
-	for _, gi := range c.description.GlobalSecondaryIndexes {
-		pkey, skey := keyAttributes(gi.KeySchema)
-		if skey == "" {
-			continue // We'll visit global indexes without a sort key later.
-		}
-		if hasEqualityFilter(q, pkey) && hasFilter(q, skey) && c.fieldsIncluded(q, gi) {
-			return gi.IndexName, pkey, skey
-		}
-	}
-	// There are no matches for both partition and sort key. Now consider matches on partition key only.
-	// That will still be better than a scan.
-	// First, check the table itself.
-	if hasEqualityFilter(q, c.partitionKey) {
-		return nil, c.partitionKey, c.sortKey
-	}
-	// No point checking local indexes: they have the same partition key as the table.
-	// Check the global indexes.
-	for _, gi := range c.description.GlobalSecondaryIndexes {
-		pkey, skey := keyAttributes(gi.KeySchema)
-		if hasEqualityFilter(q, pkey) && c.fieldsIncluded(q, gi) {
-			return gi.IndexName, pkey, skey
-		}
-	}
-	// We cannot do a query.
-	// TODO: return the reason why we couldn't. At a minimum, distinguish failure due to keys
-	// from failure due to projection (i.e. a global index had the right partition and sort key,
-	// but didn't project the necessary fields).
-	return nil, "", ""
-}
-
-// Reports whether the fields selected by the query are projected into (that is,
-// contained directly in) the global index. We need this check before using the
-// index, because if a global index doesn't have all the desired fields, then a
-// separate RPC for each returned item would be necessary to retrieve those fields,
-// and we'd rather scan than do that.
-func (c *collection) fieldsIncluded(q *driver.Query, gi *dynamodb.GlobalSecondaryIndexDescription) bool {
-	proj := gi.Projection
-	if *proj.ProjectionType == "ALL" {
-		// The index has all the fields of the table: we're good.
-		return true
-	}
-	if len(q.FieldPaths) == 0 {
-		// The query wants all the fields of the table, but we can't be sure that the
-		// index has them.
-		return false
-	}
-	// The table's keys and the index's keys are always in the index.
-	pkey, skey := keyAttributes(gi.KeySchema)
-	indexFields := map[string]bool{c.partitionKey: true, pkey: true}
-	if c.sortKey != "" {
-		indexFields[c.sortKey] = true
-	}
-	if skey != "" {
-		indexFields[skey] = true
-	}
-	for _, nka := range proj.NonKeyAttributes {
-		indexFields[*nka] = true
-	}
-	// Every field path in the query must be in the index.
-	for _, fp := range q.FieldPaths {
-		if !indexFields[strings.Join(fp, ".")] {
-			return false
-		}
-	}
-	return true
-}
-
-// Extract the names of the partition and sort key attributes from the schema of a
-// table or index.
-func keyAttributes(ks []*dynamodb.KeySchemaElement) (pkey, skey string) {
-	for _, k := range ks {
-		switch *k.KeyType {
-		case "HASH":
-			pkey = *k.AttributeName
-		case "RANGE":
-			skey = *k.AttributeName
-		default:
-			panic("bad key type: " + *k.KeyType)
-		}
-	}
-	return pkey, skey
-}
-
-// Reports whether q has a filter that mentions the top-level field.
-func hasFilter(q *driver.Query, field string) bool {
-	if field == "" {
-		return false
-	}
-	for _, f := range q.Filters {
-		if len(f.FieldPath) == 1 && f.FieldPath[0] == field {
-			return true
-		}
-	}
-	return false
-}
-
-// Reports whether q has a filter that checks if the top-level field is equal to something.
-func hasEqualityFilter(q *driver.Query, field string) bool {
-	for _, f := range q.Filters {
-		if f.Op == driver.EqualOp && len(f.FieldPath) == 1 && f.FieldPath[0] == field {
-			return true
-		}
-	}
-	return false
-}
-
-func (c *collection) planQuery(q *driver.Query) (*queryRunner, error) {
-	var cb expression.Builder
-	cbUsed := false // It's an error to build an empty Builder.
-	// Set up the projection expression.
-	if len(q.FieldPaths) > 0 {
-		pb := expression.NamesList(expression.Name(docstore.RevisionField))
-		for _, fp := range q.FieldPaths {
-			pb = pb.AddNames(expression.Name(strings.Join(fp, ".")))
-		}
-		cb = cb.WithProjection(pb)
-		cbUsed = true
-	}
-
-	// Find the best thing to query (table or index).
-	indexName, pkey, skey := c.bestQueryable(q)
-	if indexName == nil && pkey == "" {
-		// No query can be done: fall back to scanning.
-		if len(q.Filters) > 0 {
-			cb = cb.WithFilter(filtersToConditionBuilder(q.Filters))
-			cbUsed = true
-		}
-		in := &dynamodb.ScanInput{TableName: &c.table}
-		if cbUsed {
-			ce, err := cb.Build()
-			if err != nil {
-				return nil, err
-			}
-			in.ExpressionAttributeNames = ce.Names()
-			in.ExpressionAttributeValues = ce.Values()
-			in.FilterExpression = ce.Filter()
-			in.ProjectionExpression = ce.Projection()
-		}
-		return &queryRunner{c: c, scanIn: in}, nil
-	}
-
-	// Do a query.
-	cb = processFilters(cb, q.Filters, pkey, skey)
-	ce, err := cb.Build()
-	if err != nil {
-		return nil, err
-	}
-	return &queryRunner{
-		c: c,
-		queryIn: &dynamodb.QueryInput{
-			TableName:                 &c.table,
-			IndexName:                 indexName,
-			ExpressionAttributeNames:  ce.Names(),
-			ExpressionAttributeValues: ce.Values(),
-			KeyConditionExpression:    ce.KeyCondition(),
-			FilterExpression:          ce.Filter(),
-			ProjectionExpression:      ce.Projection(),
-		},
-	}, nil
 }

--- a/internal/docstore/dynamodocstore/query.go
+++ b/internal/docstore/dynamodocstore/query.go
@@ -28,9 +28,20 @@ import (
 
 // TODO: support parallel scans (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan)
 
+// TODO: support an empty item slice returned from an RPC: "A Query operation can
+// return an empty result set and a LastEvaluatedKey if all the items read for the
+// page of results are filtered out."
+
 type avmap = map[string]*dynamodb.AttributeValue
 
 func (c *collection) RunGetQuery(ctx context.Context, q *driver.Query) (driver.DocumentIterator, error) {
+	if c.description == nil {
+		out, err := c.db.DescribeTable(&dynamodb.DescribeTableInput{TableName: &c.table})
+		if err != nil {
+			return nil, err
+		}
+		c.description = out.Table
+	}
 	qr, err := c.planQuery(q)
 	if err != nil {
 		return nil, err
@@ -47,7 +58,7 @@ func (c *collection) RunGetQuery(ctx context.Context, q *driver.Query) (driver.D
 	return it, nil
 }
 
-func (c *collection) planQuery(q *driver.Query) (*queryRunner, error) {
+func (c *collection) planQueryOld(q *driver.Query) (*queryRunner, error) {
 	var cb expression.Builder
 	cbUsed := false // It's an error to build an empty Builder.
 	if len(q.FieldPaths) > 0 {
@@ -138,7 +149,7 @@ func processFilters(cb expression.Builder, fs []driver.Filter, pkey, skey string
 	}
 	keyBuilder := kbs[0]
 	for i := 1; i < len(kbs); i++ {
-		keyBuilder.And(kbs[i])
+		keyBuilder = keyBuilder.And(kbs[i])
 	}
 	cb = cb.WithKeyCondition(keyBuilder)
 	if len(cfs) > 0 {
@@ -234,4 +245,189 @@ func (it *documentIterator) Next(ctx context.Context, doc driver.Document) error
 func (it *documentIterator) Stop() {
 	it.items = nil
 	it.last = nil
+}
+
+////////////////////////////////////////////////////////////////
+
+// Return the best choice of queryable (table or index) for this query.
+// If indexName is nil but pkey is not empty, then use the table.
+// If all return values are zero, no query will work: do a scan.
+func (c *collection) bestQueryable(q *driver.Query) (indexName *string, pkey, skey string) {
+	// If the query has an "=" filter on the table's partition key, look at the table
+	// and local indexes.
+	if hasEqualityFilter(q, c.partitionKey) {
+		// If the table has a sort key that's in the query, use the table.
+		if hasFilter(q, c.sortKey) {
+			return nil, c.partitionKey, c.sortKey
+		}
+		// Look at local indexes. They all have the same partition key as the base table.
+		// If one has a sort key in the query, use it.
+		for _, li := range c.description.LocalSecondaryIndexes {
+			pkey, skey := keyAttributes(li.KeySchema)
+			if hasFilter(q, skey) {
+				return li.IndexName, pkey, skey
+			}
+		}
+	}
+	// Consider the global indexes: if one has a matching partition and sort key, and
+	// the projected fields of the index include those of the query, use it.
+	for _, gi := range c.description.GlobalSecondaryIndexes {
+		pkey, skey := keyAttributes(gi.KeySchema)
+		if skey == "" {
+			continue // We'll visit global indexes without a sort key later.
+		}
+		if hasEqualityFilter(q, pkey) && hasFilter(q, skey) && c.fieldsIncluded(q, gi) {
+			return gi.IndexName, pkey, skey
+		}
+	}
+	// There are no matches for both partition and sort key. Now consider matches on partition key only.
+	// That will still be better than a scan.
+	// First, check the table itself.
+	if hasEqualityFilter(q, c.partitionKey) {
+		return nil, c.partitionKey, c.sortKey
+	}
+	// No point checking local indexes: they have the same partition key as the table.
+	// Check the global indexes.
+	for _, gi := range c.description.GlobalSecondaryIndexes {
+		pkey, skey := keyAttributes(gi.KeySchema)
+		if hasEqualityFilter(q, pkey) && c.fieldsIncluded(q, gi) {
+			return gi.IndexName, pkey, skey
+		}
+	}
+	// We cannot do a query.
+	// TODO: return the reason why we couldn't. At a minimum, distinguish failure due to keys
+	// from failure due to projection (i.e. a global index had the right partition and sort key,
+	// but didn't project the necessary fields).
+	return nil, "", ""
+}
+
+// Reports whether the fields selected by the query are projected into (that is,
+// contained directly in) the global index. We need this check before using the
+// index, because if a global index doesn't have all the desired fields, then a
+// separate RPC for each returned item would be necessary to retrieve those fields,
+// and we'd rather scan than do that.
+func (c *collection) fieldsIncluded(q *driver.Query, gi *dynamodb.GlobalSecondaryIndexDescription) bool {
+	proj := gi.Projection
+	if *proj.ProjectionType == "ALL" {
+		// The index has all the fields of the table: we're good.
+		return true
+	}
+	if len(q.FieldPaths) == 0 {
+		// The query wants all the fields of the table, but we can't be sure that the
+		// index has them.
+		return false
+	}
+	// The table's keys and the index's keys are always in the index.
+	pkey, skey := keyAttributes(gi.KeySchema)
+	indexFields := map[string]bool{c.partitionKey: true, pkey: true}
+	if c.sortKey != "" {
+		indexFields[c.sortKey] = true
+	}
+	if skey != "" {
+		indexFields[skey] = true
+	}
+	for _, nka := range proj.NonKeyAttributes {
+		indexFields[*nka] = true
+	}
+	// Every field path in the query must be in the index.
+	for _, fp := range q.FieldPaths {
+		if !indexFields[strings.Join(fp, ".")] {
+			return false
+		}
+	}
+	return true
+}
+
+// Extract the names of the partition and sort key attributes from the schema of a
+// table or index.
+func keyAttributes(ks []*dynamodb.KeySchemaElement) (pkey, skey string) {
+	for _, k := range ks {
+		switch *k.KeyType {
+		case "HASH":
+			pkey = *k.AttributeName
+		case "RANGE":
+			skey = *k.AttributeName
+		default:
+			panic("bad key type: " + *k.KeyType)
+		}
+	}
+	return pkey, skey
+}
+
+// Reports whether q has a filter that mentions the top-level field.
+func hasFilter(q *driver.Query, field string) bool {
+	if field == "" {
+		return false
+	}
+	for _, f := range q.Filters {
+		if len(f.FieldPath) == 1 && f.FieldPath[0] == field {
+			return true
+		}
+	}
+	return false
+}
+
+// Reports whether q has a filter that checks if the top-level field is equal to something.
+func hasEqualityFilter(q *driver.Query, field string) bool {
+	for _, f := range q.Filters {
+		if f.Op == driver.EqualOp && len(f.FieldPath) == 1 && f.FieldPath[0] == field {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *collection) planQuery(q *driver.Query) (*queryRunner, error) {
+	var cb expression.Builder
+	cbUsed := false // It's an error to build an empty Builder.
+	// Set up the projection expression.
+	if len(q.FieldPaths) > 0 {
+		pb := expression.NamesList(expression.Name(docstore.RevisionField))
+		for _, fp := range q.FieldPaths {
+			pb = pb.AddNames(expression.Name(strings.Join(fp, ".")))
+		}
+		cb = cb.WithProjection(pb)
+		cbUsed = true
+	}
+
+	// Find the best thing to query (table or index).
+	indexName, pkey, skey := c.bestQueryable(q)
+	if indexName == nil && pkey == "" {
+		// No query can be done: fall back to scanning.
+		if len(q.Filters) > 0 {
+			cb = cb.WithFilter(filtersToConditionBuilder(q.Filters))
+			cbUsed = true
+		}
+		in := &dynamodb.ScanInput{TableName: &c.table}
+		if cbUsed {
+			ce, err := cb.Build()
+			if err != nil {
+				return nil, err
+			}
+			in.ExpressionAttributeNames = ce.Names()
+			in.ExpressionAttributeValues = ce.Values()
+			in.FilterExpression = ce.Filter()
+			in.ProjectionExpression = ce.Projection()
+		}
+		return &queryRunner{c: c, scanIn: in}, nil
+	}
+
+	// Do a query.
+	cb = processFilters(cb, q.Filters, pkey, skey)
+	ce, err := cb.Build()
+	if err != nil {
+		return nil, err
+	}
+	return &queryRunner{
+		c: c,
+		queryIn: &dynamodb.QueryInput{
+			TableName:                 &c.table,
+			IndexName:                 indexName,
+			ExpressionAttributeNames:  ce.Names(),
+			ExpressionAttributeValues: ce.Values(),
+			KeyConditionExpression:    ce.KeyCondition(),
+			FilterExpression:          ce.Filter(),
+			ProjectionExpression:      ce.Projection(),
+		},
+	}, nil
 }

--- a/internal/docstore/dynamodocstore/query_test.go
+++ b/internal/docstore/dynamodocstore/query_test.go
@@ -1,0 +1,372 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynamodocstore
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/google/go-cmp/cmp"
+	"gocloud.dev/internal/docstore/driver"
+)
+
+func TestPlanQuery(t *testing.T) {
+	c := &collection{
+		table:        "T",
+		partitionKey: "tableP",
+		description:  &dynamodb.TableDescription{},
+	}
+
+	// Build an ExpressionAttributeNames map with the given names.
+	eans := func(names ...string) map[string]*string {
+		m := map[string]*string{}
+		for i, n := range names {
+			m[fmt.Sprintf("#%d", i)] = aws.String(n)
+		}
+		return m
+	}
+
+	// Build an ExpressionAttributeValues map. Filter values are always the number 1
+	// and the keys are always :0, :1, ..., so we only need to know how many entries.
+	eavs := func(n int) map[string]*dynamodb.AttributeValue {
+		if n == 0 {
+			return nil
+		}
+		one := new(dynamodb.AttributeValue).SetN("1")
+		m := map[string]*dynamodb.AttributeValue{}
+		for i := 0; i < n; i++ {
+			m[fmt.Sprintf(":%d", i)] = one
+		}
+		return m
+	}
+
+	cmpopt := cmp.AllowUnexported(dynamodb.ScanInput{}, dynamodb.QueryInput{}, dynamodb.AttributeValue{})
+
+	for _, test := range []struct {
+		desc                    string
+		tableSortKey            string
+		localIndexSortKey       string   // if non-empty, there is a local index with this sort key
+		globalIndexPartitionKey string   // if non-empty, there is a global index with this partition key
+		globalIndexSortKey      string   // if non-empty, the global index  has this sort key
+		globalIndexFields       []string // the fields projected into the global index
+		query                   *driver.Query
+		want                    interface{} // either a ScanInput or a QueryInput
+	}{
+		{
+			desc: "empty query",
+			// A query with no filters requires a scan.
+			query: &driver.Query{},
+			want:  &dynamodb.ScanInput{TableName: &c.table},
+		},
+		{
+			desc: "equality filter on table partition field",
+			// A filter that compares the table's partition key for equality is the minimum
+			// requirement for querying the table.
+			query: &driver.Query{Filters: []driver.Filter{{[]string{"tableP"}, "=", 1}}},
+			want: &dynamodb.QueryInput{
+				KeyConditionExpression:    aws.String("#0 = :0"),
+				ExpressionAttributeNames:  eans("tableP"),
+				ExpressionAttributeValues: eavs(1),
+			},
+		},
+		{
+			desc: "equality filter on table partition field (sort key)",
+			// Same as above, but the table has a sort key; shouldn't make a difference.
+			tableSortKey: "tableS",
+			query:        &driver.Query{Filters: []driver.Filter{{[]string{"tableP"}, "=", 1}}},
+			want: &dynamodb.QueryInput{
+				KeyConditionExpression:    aws.String("#0 = :0"),
+				ExpressionAttributeNames:  eans("tableP"),
+				ExpressionAttributeValues: eavs(1),
+			},
+		},
+		{
+			desc: "equality filter on other field",
+			// This query has an equality filter, but not on the table's partition key.
+			// Since there are no matching indexes, we must scan.
+			query: &driver.Query{Filters: []driver.Filter{{[]string{"other"}, "=", 1}}},
+			want: &dynamodb.ScanInput{
+				FilterExpression:          aws.String("#0 = :0"),
+				ExpressionAttributeNames:  eans("other"),
+				ExpressionAttributeValues: eavs(1),
+			},
+		},
+		{
+			desc: "non-equality filter on table partition field",
+			// If the query doesn't have an equality filter on the partition key, and there
+			// are no indexes, we must scan. The filter becomes a FilterExpression, evaluated
+			// on the backend.
+			query: &driver.Query{Filters: []driver.Filter{{[]string{"tableP"}, ">", 1}}},
+			want: &dynamodb.ScanInput{
+				FilterExpression:          aws.String("#0 > :0"),
+				ExpressionAttributeNames:  eans("tableP"),
+				ExpressionAttributeValues: eavs(1),
+			},
+		},
+		{
+			desc: "equality filter on partition, filter on other",
+			// The equality filter on the table's partition key lets us query the table.
+			// The other filter is used in the filter expression.
+			query: &driver.Query{Filters: []driver.Filter{
+				{[]string{"tableP"}, "=", 1},
+				{[]string{"other"}, "<=", 1},
+			}},
+			want: &dynamodb.QueryInput{
+				KeyConditionExpression:    aws.String("#1 = :1"),
+				FilterExpression:          aws.String("#0 <= :0"),
+				ExpressionAttributeNames:  eans("other", "tableP"),
+				ExpressionAttributeValues: eavs(2),
+			},
+		},
+		{
+			desc: "equality filter on partition, filter on sort",
+			// If the table has a sort key and the query has a filter on it as well
+			// as an equality filter on the table's partition key, we can query the
+			// table.
+			tableSortKey: "tableS",
+			query: &driver.Query{Filters: []driver.Filter{
+				{[]string{"tableP"}, "=", 1},
+				{[]string{"tableS"}, "<=", 1},
+			}},
+			want: &dynamodb.QueryInput{
+				KeyConditionExpression:    aws.String("(#0 = :0) AND (#1 <= :1)"),
+				ExpressionAttributeNames:  eans("tableP", "tableS"),
+				ExpressionAttributeValues: eavs(2),
+			},
+		},
+		{
+			desc: "equality filter on table partition, filter on local index sort",
+			// The equality filter on the table's partition key allows us to query
+			// the table, but there is a better choice: a local index with a sort key
+			// that is mentioned in the query.
+			localIndexSortKey: "localS",
+			query: &driver.Query{Filters: []driver.Filter{
+				{[]string{"tableP"}, "=", 1},
+				{[]string{"localS"}, "<=", 1},
+			}},
+			want: &dynamodb.QueryInput{
+				IndexName:                aws.String("local"),
+				KeyConditionExpression:   aws.String("(#0 = :0) AND (#1 <= :1)"),
+				ExpressionAttributeNames: eans("tableP", "localS"),
+			},
+		},
+		{
+			desc: "equality filter on table partition, filters on local index and table sort",
+			// Given the choice of querying the table or a local index, prefer the table.
+			tableSortKey:      "tableS",
+			localIndexSortKey: "localS",
+			query: &driver.Query{Filters: []driver.Filter{
+				{[]string{"tableP"}, "=", 1},
+				{[]string{"localS"}, "<=", 1},
+				{[]string{"tableS"}, ">", 1},
+			}},
+			want: &dynamodb.QueryInput{
+				IndexName:                nil,
+				KeyConditionExpression:   aws.String("(#1 = :1) AND (#2 > :2)"),
+				FilterExpression:         aws.String("#0 <= :0"),
+				ExpressionAttributeNames: eans("localS", "tableP", "tableS"),
+			},
+		},
+		{
+			desc: "equality filter on other field with index",
+			// The query is the same as in "equality filter on other field," but now there
+			// is a global index with that field as partition key, so we can query it.
+			globalIndexPartitionKey: "other",
+			query:                   &driver.Query{Filters: []driver.Filter{{[]string{"other"}, "=", 1}}},
+			want: &dynamodb.QueryInput{
+				IndexName:                aws.String("global"),
+				KeyConditionExpression:   aws.String("#0 = :0"),
+				ExpressionAttributeNames: eans("other"),
+			},
+		},
+		{
+			desc: "equality filter on table partition, filter on global index sort",
+			// The equality filter on the table's partition key allows us to query
+			// the table, but there is a better choice: a global index with the same
+			// partition key and a sort key that is mentioned in the query.
+			globalIndexPartitionKey: "tableP",
+			globalIndexSortKey:      "globalS",
+			query: &driver.Query{Filters: []driver.Filter{
+				{[]string{"tableP"}, "=", 1},
+				{[]string{"globalS"}, "<=", 1},
+			}},
+			want: &dynamodb.QueryInput{
+				IndexName:                aws.String("global"),
+				KeyConditionExpression:   aws.String("(#0 = :0) AND (#1 <= :1)"),
+				ExpressionAttributeNames: eans("tableP", "globalS"),
+			},
+		},
+		{
+			desc: "equality filter on table partition, filter on global index sort, bad projection",
+			// Although there is a global index that matches the filters best, it doesn't
+			// have the necessary fields. So we query against the table.
+			globalIndexPartitionKey: "tableP",
+			globalIndexSortKey:      "globalS",
+			globalIndexFields:       []string{"other"},
+			query: &driver.Query{Filters: []driver.Filter{
+				{[]string{"tableP"}, "=", 1},
+				{[]string{"globalS"}, "<=", 1},
+			}},
+			want: &dynamodb.QueryInput{
+				IndexName:                nil,
+				KeyConditionExpression:   aws.String("#1 = :1"),
+				FilterExpression:         aws.String("#0 <= :0"),
+				ExpressionAttributeNames: eans("globalS", "tableP"),
+			},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			c.sortKey = test.tableSortKey
+			if test.localIndexSortKey == "" {
+				c.description.LocalSecondaryIndexes = nil
+			} else {
+				c.description.LocalSecondaryIndexes = []*dynamodb.LocalSecondaryIndexDescription{
+					{
+						IndexName: aws.String("local"),
+						KeySchema: keySchema("tableP", "localS"),
+					},
+				}
+			}
+			if test.globalIndexPartitionKey == "" {
+				c.description.GlobalSecondaryIndexes = nil
+			} else {
+				var proj *dynamodb.Projection
+				if test.globalIndexFields == nil {
+					proj = indexProjection("ALL")
+				} else if len(test.globalIndexFields) == 0 {
+					proj = indexProjection("KEYS_ONLY")
+				} else {
+					proj = indexProjection("INCLUDE", test.globalIndexFields...)
+				}
+				c.description.GlobalSecondaryIndexes = []*dynamodb.GlobalSecondaryIndexDescription{
+					{
+						IndexName:  aws.String("global"),
+						KeySchema:  keySchema(test.globalIndexPartitionKey, test.globalIndexSortKey),
+						Projection: proj,
+					},
+				}
+			}
+			gotRunner, err := c.planQuery(test.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got interface{}
+			switch tw := test.want.(type) {
+			case *dynamodb.ScanInput:
+				got = gotRunner.scanIn
+				tw.TableName = &c.table
+				tw.ExpressionAttributeValues = eavs(len(tw.ExpressionAttributeNames))
+			case *dynamodb.QueryInput:
+				got = gotRunner.queryIn
+				tw.TableName = &c.table
+				tw.ExpressionAttributeValues = eavs(len(tw.ExpressionAttributeNames))
+			default:
+				t.Fatalf("bad type for test.want: %T", test.want)
+			}
+			if diff := cmp.Diff(got, test.want, cmpopt); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+// Make a key schema from the names of the partition and sort keys.
+func keySchema(pkey, skey string) []*dynamodb.KeySchemaElement {
+	return []*dynamodb.KeySchemaElement{
+		{AttributeName: &pkey, KeyType: aws.String("HASH")},
+		{AttributeName: &skey, KeyType: aws.String("RANGE")},
+	}
+}
+
+func indexProjection(ptype string, fields ...string) *dynamodb.Projection {
+	proj := &dynamodb.Projection{ProjectionType: &ptype}
+	for _, f := range fields {
+		f := f
+		proj.NonKeyAttributes = append(proj.NonKeyAttributes, &f)
+	}
+	return proj
+}
+
+func TestFieldsIncluded(t *testing.T) {
+	c := &collection{partitionKey: "tableP", sortKey: "tableS"}
+	gi := &dynamodb.GlobalSecondaryIndexDescription{
+		KeySchema: keySchema("globalP", "globalS"),
+	}
+	for _, test := range []struct {
+		desc         string
+		queryFields  []string
+		wantKeysOnly bool // when the projection includes only table and index keys
+		wantInclude  bool // when the projection includes fields "f" and "g".
+	}{
+		{
+			desc:         "all",
+			queryFields:  nil,
+			wantKeysOnly: false,
+			wantInclude:  false,
+		},
+		{
+			desc:         "key fields",
+			queryFields:  []string{"tableS", "globalP"},
+			wantKeysOnly: true,
+			wantInclude:  true,
+		},
+		{
+			desc:         "included fields",
+			queryFields:  []string{"f", "g"},
+			wantKeysOnly: false,
+			wantInclude:  true,
+		},
+		{
+			desc:         "included and key fields",
+			queryFields:  []string{"f", "g", "tableP", "globalS"},
+			wantKeysOnly: false,
+			wantInclude:  true,
+		},
+		{
+			desc:         "not included field",
+			queryFields:  []string{"f", "g", "h"},
+			wantKeysOnly: false,
+			wantInclude:  false,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			var fps [][]string
+			for _, qf := range test.queryFields {
+				fps = append(fps, strings.Split(qf, "."))
+			}
+			q := &driver.Query{FieldPaths: fps}
+			for _, p := range []struct {
+				name string
+				proj *dynamodb.Projection
+				want bool
+			}{
+				{"ALL", indexProjection("ALL"), true},
+				{"KEYS_ONLY", indexProjection("KEYS_ONLY"), test.wantKeysOnly},
+				{"INCLUDE", indexProjection("INCLUDE", "f", "g"), test.wantInclude},
+			} {
+				t.Run(p.name, func(t *testing.T) {
+					gi.Projection = p.proj
+					got := c.fieldsIncluded(q, gi)
+					if got != p.want {
+						t.Errorf("got %t, want %t", got, p.want)
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Create.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Create.yaml
@@ -14,7 +14,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000431Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:31 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 2OFREOE6VHOQ5BBN3VH001BR37VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - C9O7RO28PFDVNDOCFK3592FI8JVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000431Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:31 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3419709330"
       X-Amzn-Requestid:
-      - NL17MIO7MF4TO9CV3FS10SN567VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - RE6B9A9SQH63BRS4NPQQRUCVBFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -90,7 +90,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000431Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -106,13 +106,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:31 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - F3J4TPD9TNA32J78Q648D0D2PFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NQ2PHRICJHEJ5SPMO7KA5GN1MRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -129,7 +129,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000431Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -144,13 +144,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:31 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - A6FIJPAFQ5K3OH837VI728P1B3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - C6IP74I3CHOCMDVK9EGVK64AUNVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Create.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Create.yaml
@@ -14,7 +14,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193907Z
+      - 20190418T000431Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:07 GMT
+      - Thu, 18 Apr 2019 00:04:31 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - GPRNG1MMAFB8G3DKH5188QQ88FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 2OFREOE6VHOQ5BBN3VH001BR37VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193907Z
+      - 20190418T000431Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:07 GMT
+      - Thu, 18 Apr 2019 00:04:31 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3419709330"
       X-Amzn-Requestid:
-      - QKRE2IGCMLQ7M3S7ILJ7KLUCENVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NL17MIO7MF4TO9CV3FS10SN567VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -90,7 +90,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193907Z
+      - 20190418T000431Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -106,13 +106,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:07 GMT
+      - Thu, 18 Apr 2019 00:04:31 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - 5L43KRL70DTSGGDCAJ0EQCJF07VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - F3J4TPD9TNA32J78Q648D0D2PFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -129,7 +129,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193907Z
+      - 20190418T000431Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -144,13 +144,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:07 GMT
+      - Thu, 18 Apr 2019 00:04:31 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - GFI58TD7C5Q7A7ACKK5PCQNTAFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - A6FIJPAFQ5K3OH837VI728P1B3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Data.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Data.yaml
@@ -14,7 +14,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - JCVRRR1CI1DDBSFBN97NJM5FI3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - PMLO7FVSHE3IPG0T0AA7T0M7ERVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3397496571"
       X-Amzn-Requestid:
-      - 5FAO6EH7KEFFNHF3DLOU6B6ERRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - PTVDHO521G9OE69O9FAT1G1FS7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -90,7 +90,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -105,13 +105,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - E3PRV0VDB44B992FE9VJSLIQINVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 312GTG063QS1QREL65NGMV9NNNVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -128,7 +128,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -143,13 +143,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "813349402"
       X-Amzn-Requestid:
-      - 24U8VQCRCGB4VF34UTI37JR9Q3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - V5H9MDSDEDSOHRCH7J6E9HLGEJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -166,7 +166,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -181,13 +181,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 02995NPLKIMEMTTFD8SKNNOTPRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 61MAGQERCS69VFPAL12L2DML03VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -204,7 +204,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -219,13 +219,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1231822837"
       X-Amzn-Requestid:
-      - DN9BU3H4TSQJFUE322G3G9JTQ7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - APJRN3SA60NU5921FBPAFUT6VFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -242,7 +242,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -257,13 +257,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 9RC86KADCCL9N7HB1LD30JFB4FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NB3N1CBJ722TSEPGE0TI6C5P9BVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -280,7 +280,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -295,13 +295,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2384824988"
       X-Amzn-Requestid:
-      - CBQ95VCN1V6SASDGAQO34T5VV7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - PB9CCJ23K9RHBA9K1015J8IG03VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -318,7 +318,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -333,13 +333,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - QF92VGGQTGJ5K7FDP4JOQJUOSNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - CCULJ3F3CV25STTB2135QLGN57VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -356,7 +356,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -371,13 +371,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1613526028"
       X-Amzn-Requestid:
-      - 87NNIS8KELJKGPEO4K7U1CIB2FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 12KSUMBR2T6VAU6IQ01EKJ613NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -394,7 +394,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -409,13 +409,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 7CJVE3B7LJF0Q8RC2AF9I8IEJVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - CTS17ADFA3LOI29JHCBBIV2DNJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -432,7 +432,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -447,13 +447,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3327167908"
       X-Amzn-Requestid:
-      - LSAFONDMCI8846KC213I1IEN27VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 3Q2G23QJ7BPPS2NIT8NOJE9NABVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -470,7 +470,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -485,13 +485,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - RJB8KV45N3M074PB5MGD9MJOJVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 1DKMA2QAE2JDO6JSPPCMMEIN1FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -508,7 +508,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -523,13 +523,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "482119110"
       X-Amzn-Requestid:
-      - 4M3QRGNRNFNNDTVIQOTEHIUBH7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 5EHS396LSBU7KUC2DCL807MN37VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -546,7 +546,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -561,13 +561,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - HQACPU1TV223H7I1TTM4EVRO9FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - HQG03PPKJLPCKAKGE68OOTVQG7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -584,7 +584,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -599,13 +599,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3856178417"
       X-Amzn-Requestid:
-      - H0U9NINVUENNUFFVD3R72L7883VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - VH07S11HVBLCLDOQ80RJESQ817VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -622,7 +622,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -637,13 +637,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - DV32V6LB3HMF7E7NLVEHL3CJBRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 7V0K8SH3S6CLODD3QP89H28427VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -660,7 +660,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -675,13 +675,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1401218618"
       X-Amzn-Requestid:
-      - MC2TR0T0139498453777C4DR03VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - E2JB7G13E54I0UK26UNKAN57KRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -698,7 +698,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -713,13 +713,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - K7MK8G98FU8IFNU5E63RO7UTMBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - S13ISK46NNU6KL5PSNONOTNAGFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -736,7 +736,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -751,13 +751,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "482425442"
       X-Amzn-Requestid:
-      - R3NU2UPP5HFQFNLQ92JAQFHSDBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - ILK6N40JD0C3SEAN8FSEE6P30BVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -774,7 +774,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -789,13 +789,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - NE2HH6ICSLMAHJIJ123OB3G7E7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - L19KRJ85N8JHN3FM80EM6K435FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -812,7 +812,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -827,13 +827,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1468195875"
       X-Amzn-Requestid:
-      - 0C0AFOMUPATNUECJ25LN0GVAAVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - C6MB1T6JJFE58NQOGRQNN26GNVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -850,7 +850,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -865,13 +865,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - BTIDE7M55BANDO0DJAMA7MDNS3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 8O2542MKKT8E9GSRFBMFSOG9CNVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -888,7 +888,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -903,13 +903,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "928465577"
       X-Amzn-Requestid:
-      - 12IJBSHBU11HO695AAIRB8NLCVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NH1HO5JO0A1PLGMNCHIKUTFVH3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Data.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Data.yaml
@@ -14,7 +14,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - DI96C4I095FMTLH4P5T9BNE2AFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - JCVRRR1CI1DDBSFBN97NJM5FI3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3397496571"
       X-Amzn-Requestid:
-      - HSI3B8J3U5CFH59B4QH2T78RB7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 5FAO6EH7KEFFNHF3DLOU6B6ERRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -90,7 +90,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -105,13 +105,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - CHC2IEPMBO0K0E8QPASTNV3PFFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - E3PRV0VDB44B992FE9VJSLIQINVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -128,7 +128,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -143,13 +143,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "813349402"
       X-Amzn-Requestid:
-      - 9HLFDBH2UU3K4OLS7KD4PLBK9JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 24U8VQCRCGB4VF34UTI37JR9Q3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -166,7 +166,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -181,13 +181,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - MGC5GQUIBRF193MTRVNMSE939NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 02995NPLKIMEMTTFD8SKNNOTPRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -204,7 +204,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -219,13 +219,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1231822837"
       X-Amzn-Requestid:
-      - ABEA0G53HDHL34CIQFHHRS8GOBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - DN9BU3H4TSQJFUE322G3G9JTQ7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -242,7 +242,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -257,13 +257,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - T8R2BDC8QHEIP0GNMJU8D0297FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 9RC86KADCCL9N7HB1LD30JFB4FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -280,7 +280,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -295,13 +295,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2384824988"
       X-Amzn-Requestid:
-      - PV0KLCO1T9KLTEOS6K54BHJB9NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - CBQ95VCN1V6SASDGAQO34T5VV7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -318,7 +318,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -333,13 +333,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - HO91N2EFFGGI890J45S3BJU8Q3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - QF92VGGQTGJ5K7FDP4JOQJUOSNVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -356,7 +356,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -371,13 +371,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1613526028"
       X-Amzn-Requestid:
-      - QVFJGM7AOFBHVT2DBVAC0SE2JBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 87NNIS8KELJKGPEO4K7U1CIB2FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -394,7 +394,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -409,13 +409,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - DO9GD5987BL098Q1QTQMTCT6OJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 7CJVE3B7LJF0Q8RC2AF9I8IEJVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -432,7 +432,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -447,13 +447,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3327167908"
       X-Amzn-Requestid:
-      - U8K4PP5TPSEF6H8AMJ0BKHJ7FBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - LSAFONDMCI8846KC213I1IEN27VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -470,7 +470,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -485,13 +485,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 6BTJB44RK5KJCBCEK54Q8IS2NBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - RJB8KV45N3M074PB5MGD9MJOJVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -508,7 +508,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -523,13 +523,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "482119110"
       X-Amzn-Requestid:
-      - PG2GR6BQEKOCUOLFJRQR937HRRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 4M3QRGNRNFNNDTVIQOTEHIUBH7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -546,7 +546,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -561,13 +561,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - DG9SOP29KGOFV7M06KV6H8OIAFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - HQACPU1TV223H7I1TTM4EVRO9FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -584,7 +584,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -599,13 +599,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3856178417"
       X-Amzn-Requestid:
-      - O0CBN9D6VP5M7DKG0IQGUOB6CFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - H0U9NINVUENNUFFVD3R72L7883VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -622,7 +622,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -637,13 +637,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - B4VQR5URVFMJT4TIGLIUERFH53VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - DV32V6LB3HMF7E7NLVEHL3CJBRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -660,7 +660,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -675,13 +675,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1401218618"
       X-Amzn-Requestid:
-      - 2KLETD3MG83C2NG3AU0TSP6QRVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - MC2TR0T0139498453777C4DR03VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -698,7 +698,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -713,13 +713,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - VTQLUONG87STMBRM9MC6S3BSGFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - K7MK8G98FU8IFNU5E63RO7UTMBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -736,7 +736,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -751,13 +751,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "482425442"
       X-Amzn-Requestid:
-      - 8UKEUD2E38ASIH6GL4QUCQH0M7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - R3NU2UPP5HFQFNLQ92JAQFHSDBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -774,7 +774,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -789,13 +789,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - ULIK4IPPBAPC0VP93DA2JC80SNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NE2HH6ICSLMAHJIJ123OB3G7E7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -812,7 +812,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -827,13 +827,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1468195875"
       X-Amzn-Requestid:
-      - MDA8BRSQCO9OK052JG9BC1QNPFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 0C0AFOMUPATNUECJ25LN0GVAAVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -850,7 +850,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -865,13 +865,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 31ESD4T3LH16DLAOF6TKDSRJ3VVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - BTIDE7M55BANDO0DJAMA7MDNS3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -888,7 +888,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -903,13 +903,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "928465577"
       X-Amzn-Requestid:
-      - FO8MHQBOU9GK1NE7RSJ91QS2G7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 12IJBSHBU11HO695AAIRB8NLCVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Delete.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Delete.yaml
@@ -14,7 +14,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - T2F2TP6FTE3JOGKD12NOGS8IGFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - T96G6DPDUOA9VQAMG6FFF6UQ33VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - MSB1QIEJCQHUKHK23R6UI7L7IVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 3CEB9A58QL8DRLBCQS6I0E5DJFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -90,7 +90,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -105,13 +105,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - EGE6H8GKVQ3L5AV63M8MD1R683VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - IFHU5300AJAK8US4NK3299PO4NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -128,7 +128,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -143,13 +143,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - RDQT341K3VDD9P59K9MGCTNEEFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 102QN6ONDV81O2OI8IH4TDMEA3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -166,7 +166,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -181,13 +181,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - SG1MSJT62K8FVVP336GI6VO51RVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - EAO1M312FE8V8K8454DLJ2UM3NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -204,7 +204,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -219,13 +219,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "503600574"
       X-Amzn-Requestid:
-      - KTUTCRRPOB2FSM6NNB49QL496RVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - PDT6BR72HV8FMN762QH9VO5I07VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -242,7 +242,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -257,13 +257,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - P7RLJRFDVSUJ7FQF1JGJ9KGT03VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NGITUO8J2PF8DS7APS366L58T3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -280,7 +280,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -296,13 +296,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - LG7V673UJMU96L7KU2KU871Q37VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - A62IORND22JB26NKDAK7U4HG5NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Delete.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Delete.yaml
@@ -14,7 +14,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - EEBM0I1LSBHLF4MS2399ASH8NFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - T2F2TP6FTE3JOGKD12NOGS8IGFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - NIQ9NB6UBP95K62G73P9C5MARRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - MSB1QIEJCQHUKHK23R6UI7L7IVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -90,7 +90,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -105,13 +105,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - KMCCSLAS8LEEA35MOS7E5T1QI3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - EGE6H8GKVQ3L5AV63M8MD1R683VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -128,7 +128,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -143,13 +143,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - FHIVDRTOFLR35P03FV1UMF1GF7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - RDQT341K3VDD9P59K9MGCTNEEFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -166,7 +166,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -181,13 +181,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - HPSP1OOH954PM2Q97V7HEFV9INVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - SG1MSJT62K8FVVP336GI6VO51RVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -204,7 +204,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -219,13 +219,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "503600574"
       X-Amzn-Requestid:
-      - UCJV44LJDP846KUQDISJAQI1CFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - KTUTCRRPOB2FSM6NNB49QL496RVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -242,7 +242,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -257,13 +257,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - JHODTF1N0UMSVMJIIGDLQ4R4TNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - P7RLJRFDVSUJ7FQF1JGJ9KGT03VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -280,7 +280,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -296,13 +296,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - ASPSBUM6SRS33G5JRDM0CA8PDFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - LG7V673UJMU96L7KU2KU871Q37VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Get.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Get.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -30,13 +30,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 5AVTC9GQ9UQEBD3H4I1IV9EUSJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 86JG0182V3TU6EC7N3K084G3UJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -53,7 +53,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -68,13 +68,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3456633873"
       X-Amzn-Requestid:
-      - K4RN9HI7PO45MSF2NGTO1CM3HBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - EHEGOAT6GMDE0T8Q6J1HVMMU2BVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -92,7 +92,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -107,13 +107,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "829082549"
       X-Amzn-Requestid:
-      - BPPLOBRT9UP4AFEOOQD5IOCEF3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 5UL2A07SJGDPBV5F30QF3PHBRRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Get.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Get.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -30,13 +30,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 86JG0182V3TU6EC7N3K084G3UJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - F9ORHG7N1C59TDKPC2NIJLEDOBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -53,7 +53,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -68,13 +68,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3456633873"
       X-Amzn-Requestid:
-      - EHEGOAT6GMDE0T8Q6J1HVMMU2BVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - TJGJ8DVFCDR2FSC5DPGS6HBOTVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -92,7 +92,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -107,13 +107,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "829082549"
       X-Amzn-Requestid:
-      - 5UL2A07SJGDPBV5F30QF3PHBRRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NIO93DKO93IJBVROE59QDOFKQNVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Put.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Put.yaml
@@ -14,7 +14,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193907Z
+      - 20190418T000431Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:07 GMT
+      - Thu, 18 Apr 2019 00:04:31 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 7Q85MU07JRCS7M2D005GQVFD63VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - DQ4G7RB22A80VQ6Q707U4KLBQVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193907Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:07 GMT
+      - Thu, 18 Apr 2019 00:04:31 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "390688631"
       X-Amzn-Requestid:
-      - 5TM667GV5UAD1OIEUVBA0ADTD7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - FU2TP9SK9GKA2DR22N78BJ5KPVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -90,7 +90,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193907Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -105,13 +105,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:07 GMT
+      - Thu, 18 Apr 2019 00:04:31 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - H03R3C32UQDVD1VCCJ8M6UV897VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 9SKIQ78ODV0AL1A41PBFULSNGJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -128,7 +128,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -143,13 +143,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:07 GMT
+      - Thu, 18 Apr 2019 00:04:31 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3322650091"
       X-Amzn-Requestid:
-      - EO3FJI69D1M7LC0300L06J4QDBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - GD5I5IU1S8REJO0U20AR9NIQDJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -166,7 +166,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -181,13 +181,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:07 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - NUGR6VFJSQIG264F65NI43TOKBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - J7JPJUVP7G7OI5GD7MS4R87E83VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -204,7 +204,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -219,13 +219,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:07 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3518719518"
       X-Amzn-Requestid:
-      - Q7MTN2H829G577RR88PA59BFVNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 7IQMRU9TN1U0M5OLDD49OTLDG7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -242,7 +242,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -257,13 +257,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - QS25KEI0LIUVFAB10I5RD7AHT7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 6C4NIU4I24M2S2HQ18UT9ETHFVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -280,7 +280,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -296,13 +296,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - UELVKSAI2D86NL6LEJ9QUVH8ARVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - IFF4RVHJ5NKJ4SBFAM2SR4BHH3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Put.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Put.yaml
@@ -14,7 +14,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000431Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:31 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - DQ4G7RB22A80VQ6Q707U4KLBQVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 109JQES7QG63AVR7F52IJPV5NJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:31 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "390688631"
       X-Amzn-Requestid:
-      - FU2TP9SK9GKA2DR22N78BJ5KPVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - I53S4IN9I3LV62ONUTJITJE5D7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -90,7 +90,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -105,13 +105,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:31 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 9SKIQ78ODV0AL1A41PBFULSNGJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - R98KF5E76J6N1JAOF7M8B1T2VRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -128,7 +128,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -143,13 +143,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:31 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3322650091"
       X-Amzn-Requestid:
-      - GD5I5IU1S8REJO0U20AR9NIQDJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - SR1A9LGQL9MEKCQ6O71RM43SP3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -166,7 +166,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -181,13 +181,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - J7JPJUVP7G7OI5GD7MS4R87E83VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - S3QRHDJ7VD6R3CGABTVM20R85RVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -204,7 +204,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -219,13 +219,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3518719518"
       X-Amzn-Requestid:
-      - 7IQMRU9TN1U0M5OLDD49OTLDG7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - B05U6BFVKT5J65H0JCUFGRN7UFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -242,7 +242,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -257,13 +257,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 6C4NIU4I24M2S2HQ18UT9ETHFVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - N82C63TKL5461EM8JPRU1RKUQRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -280,7 +280,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -296,13 +296,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - IFF4RVHJ5NKJ4SBFAM2SR4BHH3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - VN0P1P2T85JI1A56LKQ6ML7BVVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Query.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Query.yaml
@@ -14,28 +14,28 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.DescribeTable
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
-    body: '{"Table":{"AttributeDefinitions":[{"AttributeName":"_id","AttributeType":"S"},{"AttributeName":"_kind","AttributeType":"S"},{"AttributeName":"a/b","AttributeType":"S"},{"AttributeName":"c/d","AttributeType":"S"}],"CreationDateTime":1.55484621416E9,"GlobalSecondaryIndexes":[{"IndexArn":"arn:aws:dynamodb:us-east-2:462380225722:table/docstore-test/index/ab-cd-index","IndexName":"ab-cd-index","IndexSizeBytes":0,"IndexStatus":"ACTIVE","ItemCount":0,"KeySchema":[{"AttributeName":"a/b","KeyType":"HASH"},{"AttributeName":"c/d","KeyType":"RANGE"}],"Projection":{"ProjectionType":"ALL"},"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":5,"WriteCapacityUnits":5}}],"ItemCount":3,"KeySchema":[{"AttributeName":"_kind","KeyType":"HASH"},{"AttributeName":"_id","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":5,"WriteCapacityUnits":5},"TableArn":"arn:aws:dynamodb:us-east-2:462380225722:table/docstore-test","TableId":"d7425873-371c-4f42-8fda-5d54be8e5199","TableName":"docstore-test","TableSizeBytes":248,"TableStatus":"ACTIVE"}}'
+    body: '{"Table":{"AttributeDefinitions":[{"AttributeName":"_id","AttributeType":"S"},{"AttributeName":"_kind","AttributeType":"S"}],"CreationDateTime":1.55484621416E9,"ItemCount":3,"KeySchema":[{"AttributeName":"_kind","KeyType":"HASH"},{"AttributeName":"_id","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":5,"WriteCapacityUnits":5},"TableArn":"arn:aws:dynamodb:us-east-2:462380225722:table/docstore-test","TableId":"d7425873-371c-4f42-8fda-5d54be8e5199","TableName":"docstore-test","TableSizeBytes":248,"TableStatus":"ACTIVE"}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - "1089"
+      - "566"
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
-      - "2610412669"
+      - "3397536754"
       X-Amzn-Requestid:
-      - Q60J21AM2NUKNVHQRJQI7QK0GBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - CFPE17QCONA9JIV8E1PO6T239JVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -68,13 +68,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1049590557"
       X-Amzn-Requestid:
-      - OB0GJJDE12DFL4KT6EGA27QKNBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NN8QJVKNLHJGVQ3VDBDAOCDJFVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -91,7 +91,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -107,13 +107,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1049590557"
       X-Amzn-Requestid:
-      - VTU7LDNH6ET5D2T318N8E2I6URVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - HENAJEATP8639G4ID6FR0IACQRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -130,7 +130,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -145,13 +145,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 95143G0DPMKRRUHHNLMVBE4U4NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - QFJ0L7F5AFMUVRBS74476P0OQBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -168,7 +168,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -183,13 +183,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 94HN00T4CRR5FMAI5LTCHK19RNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 3FL5O2G3AQOQ7FLQQ0SN0LRU3RVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -206,7 +206,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -221,13 +221,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - HH91TBRTPLP85TIK9CS29UL5BNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - BJPRJTFL8TBU05MR09DLHMKQ6RVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -244,7 +244,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -259,13 +259,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - Q88U2HNA7EFO3SAE8E9S1BAVLRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - BLCPPGVVD0IQDL2OHF7DCA97B7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -282,7 +282,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -297,13 +297,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - SBB3D8C6VFGSIO34HC73IPDV93VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 933P0T741KPBFNDFDAU2TOA53JVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -320,7 +320,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -335,13 +335,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 1KMO0P89J4KDSFN2DP4MJTQHMRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - K37AULL7OEJ4C4I3K9RSCOVKQ3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -358,7 +358,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -373,13 +373,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - F4FQ1IP898H2APERPBN8H8L84JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - KGM561EJ6GMM26QRI01D2CSLPNVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -396,7 +396,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -411,13 +411,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 7CLBUKB7EFS7R1R0TPF1LT87NNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 665I2BN93O7GD4BRV6VI73RB2NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -434,7 +434,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -449,13 +449,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 5RKQF2QSHLTRBHEN2DMIC4SPF7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - AL6KP9OI4K4GP1UPS1PO3PD5JVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -472,7 +472,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -487,18 +487,18 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - U18U65UFBOCRSEBJR02LBBB38VVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - AQEGPUBN1GPS368KRRK2FJI2PJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
+    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"_id","#2":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
       < :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
@@ -511,7 +511,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -526,18 +526,18 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2324535421"
       X-Amzn-Requestid:
-      - NKD82RGU01Q9A8PGE4I60ICFFJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - QKUOFQJAF04MGUHFF60RCRDBF7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"S":"fog"}},"FilterExpression":"#0
+    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"_id","#2":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"fog"}},"FilterExpression":"#0
       < :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
@@ -550,7 +550,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -565,18 +565,18 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2324535421"
       X-Amzn-Requestid:
-      - 2KLJDIO3UHO4RNVF92RNF4UOFFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - OL05J09MGG105HDT63MNRICMBRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
+    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"_id","#2":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
       <= :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
@@ -589,7 +589,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -604,18 +604,18 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3764713186"
       X-Amzn-Requestid:
-      - SLO33USFEAH2DV8717SA7GKCJBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 8RUV0AD9R9VFI8Q2CEH56TB1M7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"S":"fog"}},"FilterExpression":"#0
+    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"_id","#2":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"fog"}},"FilterExpression":"#0
       <= :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
@@ -628,7 +628,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000433Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -643,18 +643,18 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3420333838"
       X-Amzn-Requestid:
-      - QST58H7L7O200GUVTSKH5BBDENVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 2GEGH989I4T4114VOQ6T0Q948BVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
+    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"_id","#2":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
       = :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
@@ -667,7 +667,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000434Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -682,18 +682,18 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "893020929"
       X-Amzn-Requestid:
-      - 3TC616SIE8IKG0RKOBBD2P848NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 2KMVVU6BT10JQN64INNE9A7SUJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"S":"foo"}},"FilterExpression":"#0
+    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"_id","#2":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"foo"}},"FilterExpression":"#0
       = :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
@@ -706,7 +706,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000434Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -721,18 +721,18 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "893020929"
       X-Amzn-Requestid:
-      - 7HQ12QKIPJ91C5CAV8KGJJOE87VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - UP99EQA4FIFDPOEGQBA3RE9VLBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
+    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"_id","#2":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
       >= :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
@@ -745,7 +745,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000434Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -760,18 +760,18 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:33 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3462596048"
       X-Amzn-Requestid:
-      - F2G6KCGMOEP1MK6881G8BFMB6VVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - JBIP2IFIR8MP8A86Q0ATUPF3PVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"S":"fog"}},"FilterExpression":"#0
+    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"_id","#2":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"fog"}},"FilterExpression":"#0
       >= :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
@@ -784,7 +784,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000434Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -799,18 +799,18 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:34 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3462596048"
       X-Amzn-Requestid:
-      - GIIHRUUJ04FSICADABEQIKQCJ7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - CNLG0UQRC3CP6B62QQ3I3NCFVFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
+    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"_id","#2":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"N":"1"}},"FilterExpression":"#0
       > :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
@@ -823,7 +823,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000434Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -838,18 +838,18 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:34 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "511752941"
       X-Amzn-Requestid:
-      - BVI7JOGHAM9HJSUKHFDN24D18JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - MQI04HNDC2B9C8UOT0G6AIAS3BVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"S":"fog"}},"FilterExpression":"#0
+    body: '{"ExpressionAttributeNames":{"#0":"s","#1":"_id","#2":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"S":"fog"}},"FilterExpression":"#0
       > :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
@@ -862,7 +862,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000434Z
+      - 20190422T185451Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -877,18 +877,18 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:34 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "893020929"
       X-Amzn-Requestid:
-      - NUU0VF6L9EQBFETCVJ9GUBI3LFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - V9092GPBIRQDHK2EB9V6OJ8INVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"DocstoreRevision","#2":"_id"},"ExpressionAttributeValues":{":0":{"N":"-4"}},"FilterExpression":"#0
+    body: '{"ExpressionAttributeNames":{"#0":"n","#1":"_id","#2":"DocstoreRevision"},"ExpressionAttributeValues":{":0":{"N":"-4"}},"FilterExpression":"#0
       >= :0","ProjectionExpression":"#1, #2","TableName":"docstore-test"}'
     form: {}
     headers:
@@ -901,7 +901,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000434Z
+      - 20190422T185452Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -916,13 +916,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:34 GMT
+      - Mon, 22 Apr 2019 18:54:51 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3460309551"
       X-Amzn-Requestid:
-      - JU29NKL5UI754KLAK4MGL57DC3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - TJ362114QNKA8TK3609HLFN9BVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Query.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Query.yaml
@@ -14,29 +14,28 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
-      - DynamoDB_20120810.Scan
+      - DynamoDB_20120810.DescribeTable
     url: https://dynamodb.us-east-2.amazonaws.com/
     method: POST
   response:
-    body: '{"Count":7,"Items":[{"_id":{"S":"testPut1"},"b":{"BOOL":false},"_kind":{"S":"put"},"DocstoreRevision":{"S":"6694d2c4-22ac-4208-a007-2939487f6999"}},{"_id":{"S":"testData"},"val":{"B":"AAEC"},"_kind":{"S":"data"},"DocstoreRevision":{"S":"ee294b39-f32b-4c78-a2ba-64f84ab43ca0"}},{"_id":{"S":"testRevisionField"},"s":{"S":"c"},"_kind":{"S":"revisionField"},"DocstoreRevision":{"S":"067d89bc-7f01-41f5-b398-1659a44ff17a"}},{"_id":{"S":"testDelete"},"_kind":{"S":"delete"},"DocstoreRevision":{"S":"29b0223b-eea5-44f7-8391-f445d15afd42"},"x":{"S":"y"}},{"s":{"S":"a
-      string"},"_kind":{"S":"get"},"f":{"N":"32.3"},"i":{"N":"95"},"_id":{"S":"testGet1"},"m":{"M":{"a":{"S":"one"},"b":{"S":"two"}}},"DocstoreRevision":{"S":"172ed857-94bb-458b-8c3b-525da1786f9f"}},{"_id":{"S":"testReplace"},"s":{"S":"b"},"_kind":{"S":"replace"},"DocstoreRevision":{"S":"6325253f-ec73-4dd7-a9e2-8bf921119c16"}},{"a":{"S":"X"},"_id":{"S":"testUpdate"},"c":{"S":"C"},"_kind":{"S":"update"},"DocstoreRevision":{"S":"8d019192-c242-44e2-8afc-cae3a61fb586"}}],"ScannedCount":7}'
+    body: '{"Table":{"AttributeDefinitions":[{"AttributeName":"_id","AttributeType":"S"},{"AttributeName":"_kind","AttributeType":"S"},{"AttributeName":"a/b","AttributeType":"S"},{"AttributeName":"c/d","AttributeType":"S"}],"CreationDateTime":1.55484621416E9,"GlobalSecondaryIndexes":[{"IndexArn":"arn:aws:dynamodb:us-east-2:462380225722:table/docstore-test/index/ab-cd-index","IndexName":"ab-cd-index","IndexSizeBytes":0,"IndexStatus":"ACTIVE","ItemCount":0,"KeySchema":[{"AttributeName":"a/b","KeyType":"HASH"},{"AttributeName":"c/d","KeyType":"RANGE"}],"Projection":{"ProjectionType":"ALL"},"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":5,"WriteCapacityUnits":5}}],"ItemCount":3,"KeySchema":[{"AttributeName":"_kind","KeyType":"HASH"},{"AttributeName":"_id","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":5,"WriteCapacityUnits":5},"TableArn":"arn:aws:dynamodb:us-east-2:462380225722:table/docstore-test","TableId":"d7425873-371c-4f42-8fda-5d54be8e5199","TableName":"docstore-test","TableSizeBytes":248,"TableStatus":"ACTIVE"}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - "1043"
+      - "1089"
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
-      - "1049590557"
+      - "2610412669"
       X-Amzn-Requestid:
-      - GFIA8IRL4H7M5VU3IIUTT8BREBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - Q60J21AM2NUKNVHQRJQI7QK0GBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -53,7 +52,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -69,13 +68,52 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "1049590557"
       X-Amzn-Requestid:
-      - 7BO31ENDSLVHVIAODG2I10G2UNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - OB0GJJDE12DFL4KT6EGA27QKNBVV4KQNSO5AEMVJF66Q9ASUAAJG
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"TableName":"docstore-test"}'
+    form: {}
+    headers:
+      Accept-Encoding:
+      - identity
+      Content-Length:
+      - "29"
+      Content-Type:
+      - application/x-amz-json-1.0
+      User-Agent:
+      - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
+      X-Amz-Date:
+      - 20190418T000433Z
+      X-Amz-Target:
+      - DynamoDB_20120810.Scan
+    url: https://dynamodb.us-east-2.amazonaws.com/
+    method: POST
+  response:
+    body: '{"Count":7,"Items":[{"_id":{"S":"testPut1"},"b":{"BOOL":false},"_kind":{"S":"put"},"DocstoreRevision":{"S":"6694d2c4-22ac-4208-a007-2939487f6999"}},{"_id":{"S":"testData"},"val":{"B":"AAEC"},"_kind":{"S":"data"},"DocstoreRevision":{"S":"ee294b39-f32b-4c78-a2ba-64f84ab43ca0"}},{"_id":{"S":"testRevisionField"},"s":{"S":"c"},"_kind":{"S":"revisionField"},"DocstoreRevision":{"S":"067d89bc-7f01-41f5-b398-1659a44ff17a"}},{"_id":{"S":"testDelete"},"_kind":{"S":"delete"},"DocstoreRevision":{"S":"29b0223b-eea5-44f7-8391-f445d15afd42"},"x":{"S":"y"}},{"s":{"S":"a
+      string"},"_kind":{"S":"get"},"f":{"N":"32.3"},"i":{"N":"95"},"_id":{"S":"testGet1"},"m":{"M":{"a":{"S":"one"},"b":{"S":"two"}}},"DocstoreRevision":{"S":"172ed857-94bb-458b-8c3b-525da1786f9f"}},{"_id":{"S":"testReplace"},"s":{"S":"b"},"_kind":{"S":"replace"},"DocstoreRevision":{"S":"6325253f-ec73-4dd7-a9e2-8bf921119c16"}},{"a":{"S":"X"},"_id":{"S":"testUpdate"},"c":{"S":"C"},"_kind":{"S":"update"},"DocstoreRevision":{"S":"8d019192-c242-44e2-8afc-cae3a61fb586"}}],"ScannedCount":7}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "1043"
+      Content-Type:
+      - application/x-amz-json-1.0
+      Date:
+      - Thu, 18 Apr 2019 00:04:33 GMT
+      Server:
+      - Server
+      X-Amz-Crc32:
+      - "1049590557"
+      X-Amzn-Requestid:
+      - VTU7LDNH6ET5D2T318N8E2I6URVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -92,7 +130,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -107,13 +145,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - L14GMLKCJIRPQC5R3N95SQEU5JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 95143G0DPMKRRUHHNLMVBE4U4NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -130,7 +168,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -145,13 +183,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - V5S5QHVIUVP8P7PO5M0A1UOVEBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 94HN00T4CRR5FMAI5LTCHK19RNVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -168,7 +206,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -183,13 +221,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - C424NT4QT2NLQ48DNM4JOC3SEVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - HH91TBRTPLP85TIK9CS29UL5BNVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -206,7 +244,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -221,13 +259,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - RQLF5NEV5F1QD55L5VCVTPTH5BVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - Q88U2HNA7EFO3SAE8E9S1BAVLRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -244,7 +282,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -259,13 +297,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 9MCECEK24033PLJSJOHS0QKTT7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - SBB3D8C6VFGSIO34HC73IPDV93VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -282,7 +320,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -297,13 +335,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - GAGNHVHDPJOBQQ73PGVGF24SJFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 1KMO0P89J4KDSFN2DP4MJTQHMRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -320,7 +358,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.DeleteItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -335,13 +373,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - JEAP5HJ3VS6SB9E2OLVF0VQ16NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - F4FQ1IP898H2APERPBN8H8L84JVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -358,7 +396,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -373,13 +411,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - J6O8ORRU9Q9JGM6AIGOKA38P03VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 7CLBUKB7EFS7R1R0TPF1LT87NNVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -396,7 +434,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -411,13 +449,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - TP4RP24CMU4IAD67AHCR19AH8BVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 5RKQF2QSHLTRBHEN2DMIC4SPF7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -434,7 +472,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -449,13 +487,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 3FKP06KGL6GJUESBKSN37OMLKNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - U18U65UFBOCRSEBJR02LBBB38VVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -473,7 +511,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -488,13 +526,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2324535421"
       X-Amzn-Requestid:
-      - 2TEEU9GVSRER386OAR4CQF90U7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NKD82RGU01Q9A8PGE4I60ICFFJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -512,7 +550,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -527,13 +565,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2324535421"
       X-Amzn-Requestid:
-      - 2LM6J5IGN2TOPLAAQV9OPMVJSRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 2KLJDIO3UHO4RNVF92RNF4UOFFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -551,7 +589,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -566,13 +604,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3764713186"
       X-Amzn-Requestid:
-      - 1PDLULDK9ST80DRGKLN370BEK3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - SLO33USFEAH2DV8717SA7GKCJBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -590,7 +628,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000433Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -605,13 +643,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3420333838"
       X-Amzn-Requestid:
-      - K0D8M4U84HDMC1EJ3KPPHS9JKNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - QST58H7L7O200GUVTSKH5BBDENVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -629,7 +667,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000434Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -644,13 +682,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "893020929"
       X-Amzn-Requestid:
-      - FSA6U9LAAVJ5AIPV4MG73VBMDFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 3TC616SIE8IKG0RKOBBD2P848NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -668,7 +706,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193909Z
+      - 20190418T000434Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -683,13 +721,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:09 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "893020929"
       X-Amzn-Requestid:
-      - DMH58AB533TRB51L86RGQJ6647VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 7HQ12QKIPJ91C5CAV8KGJJOE87VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -707,7 +745,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193910Z
+      - 20190418T000434Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -722,13 +760,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:10 GMT
+      - Thu, 18 Apr 2019 00:04:33 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3462596048"
       X-Amzn-Requestid:
-      - C18HMJ8USLOLOB5KILETR5BQTNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - F2G6KCGMOEP1MK6881G8BFMB6VVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -746,7 +784,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193910Z
+      - 20190418T000434Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -761,13 +799,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:10 GMT
+      - Thu, 18 Apr 2019 00:04:34 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3462596048"
       X-Amzn-Requestid:
-      - VPD7DLHG4EQS1PNL3BTFVO3VBRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - GIIHRUUJ04FSICADABEQIKQCJ7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -785,7 +823,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193910Z
+      - 20190418T000434Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -800,13 +838,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:10 GMT
+      - Thu, 18 Apr 2019 00:04:34 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "511752941"
       X-Amzn-Requestid:
-      - O1E78UEO8IMVHAF687877VJ4UVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - BVI7JOGHAM9HJSUKHFDN24D18JVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -824,7 +862,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193910Z
+      - 20190418T000434Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -839,13 +877,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:10 GMT
+      - Thu, 18 Apr 2019 00:04:34 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "893020929"
       X-Amzn-Requestid:
-      - OLK84SU8O2SR7BIIUV09HAP287VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NUU0VF6L9EQBFETCVJ9GUBI3LFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -863,7 +901,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193910Z
+      - 20190418T000434Z
       X-Amz-Target:
       - DynamoDB_20120810.Scan
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -878,13 +916,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:10 GMT
+      - Thu, 18 Apr 2019 00:04:34 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3460309551"
       X-Amzn-Requestid:
-      - RB58ORU33B0PP9KSA5M4E2I2D3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - JU29NKL5UI754KLAK4MGL57DC3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Replace.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Replace.yaml
@@ -14,7 +14,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185449Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - APT5HAQG0DF4JIQ7UQAB0E9JTJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - PKBCAHAIBR5M5LA4TSLSK7TR3NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - RGNHPOCPDFK5C53T2S5U7V7JH3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - QHPNGLHJNKI57UEA113NQOUI7RVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -90,7 +90,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -105,13 +105,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "344366584"
       X-Amzn-Requestid:
-      - K4QQMOLBHEG4IGAG575JTNT63NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - OM1UBF1NNHMIIVA0R05PML6LONVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -128,7 +128,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -144,13 +144,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - J2UBV8E5P7VANLOI9GHCUQ03TNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - T6MJRR9HH9F4LLJMF1RUPF9UQFVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -167,7 +167,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -182,13 +182,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:49 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - EAVIECU4M1CG9ELUVNNKQNQQ9FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 60JUJ02RA8PF1NDM5369N1C2D3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -205,7 +205,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -220,13 +220,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3673566516"
       X-Amzn-Requestid:
-      - LAJ386KIR78FO3R8QQMTG9GINVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - D1RD4NMDMGOCHRGRL0IANF43V3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -243,7 +243,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -258,13 +258,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - F4Q502K7SLAK0O8UQBNMMU780JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - HMFJRV0DHJ6P3EMPSO8GP57FKBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -281,7 +281,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -297,13 +297,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - 44T72E0OITJSTSNABR2Q9LO7KJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 3G380FOMHI9VEU5JEQASJLN2R3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Replace.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Replace.yaml
@@ -14,7 +14,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 6QPRM5E09GP7FG2BPNOVJ7KRJVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - APT5HAQG0DF4JIQ7UQAB0E9JTJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -67,13 +67,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - U6PJKANPNBMP07O0V12KAS7V7RVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - RGNHPOCPDFK5C53T2S5U7V7JH3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -90,7 +90,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -105,13 +105,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "344366584"
       X-Amzn-Requestid:
-      - SSVP1KH9INV65QHV5Q13R103R3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - K4QQMOLBHEG4IGAG575JTNT63NVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -128,7 +128,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -144,13 +144,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - RB8OVVVULP355GUU0RQTGK0N4VVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - J2UBV8E5P7VANLOI9GHCUQ03TNVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -167,7 +167,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -182,13 +182,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - U3DSU720H7FCHSLRV9IKAG93NJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - EAVIECU4M1CG9ELUVNNKQNQQ9FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -205,7 +205,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -220,13 +220,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "3673566516"
       X-Amzn-Requestid:
-      - 0QN3DFBIA2GK8JQ1MGLLHT0K7RVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - LAJ386KIR78FO3R8QQMTG9GINVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -243,7 +243,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -258,13 +258,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 00A1BLQMRSPP6TNBVFC075S4JBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - F4Q502K7SLAK0O8UQBNMMU780JVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -281,7 +281,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -297,13 +297,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - M5T95FVL8GPOFCASD1TH0GUE5VVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 44T72E0OITJSTSNABR2Q9LO7KJVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Update.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Update.yaml
@@ -14,7 +14,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - U1EKP8C9BL1DU9MCHNH9S4623FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - LJO8I7QBE5G4UIF1I7HU9AK8SRVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -53,7 +53,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.UpdateItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -68,13 +68,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - P5AJRFTIILFGT25L7BAFQNCR6FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 671DOGNRS7VU74CGGEH28EBCM7VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -91,7 +91,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -106,13 +106,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "623689771"
       X-Amzn-Requestid:
-      - IBS7QUGE5FI1P8539B6JK8O6U3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - N5PGUVEV5K0O62IEUKEG0QIDARVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -130,7 +130,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.UpdateItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -146,13 +146,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - LC0E84RUTV71KFS1IQGFL40GOVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - FT41KB4VULF2F4QES7JPRJNTEVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -169,7 +169,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -184,13 +184,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 69H001DUOVTU3EKH64F909G4UBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - NAKPDHUGLQ0P1MENE3E811706VVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -207,7 +207,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -222,13 +222,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2083191073"
       X-Amzn-Requestid:
-      - CUC4V0715CCPELS73M7GRA5G2RVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - PQKP9JD9ILQ5OA2RFR58IVSD47VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -246,7 +246,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.UpdateItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -261,13 +261,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 938GM1K473P2F85CIHJOT8OMRVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - Q4CVC6624JE7E68H9E3J8PH91VVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -285,7 +285,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190418T000432Z
+      - 20190422T185450Z
       X-Amz-Target:
       - DynamoDB_20120810.UpdateItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -301,13 +301,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Thu, 18 Apr 2019 00:04:32 GMT
+      - Mon, 22 Apr 2019 18:54:50 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - IMG9P2S1AHT4D15OLFJ8QK7SLVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 2MLCTJ7PFHAK5HV0HSPOR99EK3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/internal/docstore/dynamodocstore/testdata/TestConformance/Update.yaml
+++ b/internal/docstore/dynamodocstore/testdata/TestConformance/Update.yaml
@@ -14,7 +14,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - O9S2IK8F6HGMK67EFM686NJIV7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - U1EKP8C9BL1DU9MCHNH9S4623FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -53,7 +53,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.UpdateItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -68,13 +68,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - 8RP5EB01RFCCGVEKRJ8598NC8NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - P5AJRFTIILFGT25L7BAFQNCR6FVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -91,7 +91,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -106,13 +106,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "623689771"
       X-Amzn-Requestid:
-      - SVT27B81V8516QIIU9BQKOV7I7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - IBS7QUGE5FI1P8539B6JK8O6U3VV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -130,7 +130,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.UpdateItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -146,13 +146,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - ISTKUHRRR4RIKH48O6DSUJP3HFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - LC0E84RUTV71KFS1IQGFL40GOVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -169,7 +169,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.PutItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -184,13 +184,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - R751M9PSABCNM4V60AKTE5K7IBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 69H001DUOVTU3EKH64F909G4UBVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -207,7 +207,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.GetItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -222,13 +222,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2083191073"
       X-Amzn-Requestid:
-      - VCKTJBRFCA3D0E6NK52JMI8HMFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - CUC4V0715CCPELS73M7GRA5G2RVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -246,7 +246,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.UpdateItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -261,13 +261,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "2745614147"
       X-Amzn-Requestid:
-      - C0NHFDMRI57UPRLEQFQ1EVE6D7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 938GM1K473P2F85CIHJOT8OMRVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 200 OK
     code: 200
     duration: ""
@@ -285,7 +285,7 @@ interactions:
       User-Agent:
       - aws-sdk-go/1.16.23 (go1.12; linux; amd64)
       X-Amz-Date:
-      - 20190417T193908Z
+      - 20190418T000432Z
       X-Amz-Target:
       - DynamoDB_20120810.UpdateItem
     url: https://dynamodb.us-east-2.amazonaws.com/
@@ -301,13 +301,13 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.0
       Date:
-      - Wed, 17 Apr 2019 19:39:08 GMT
+      - Thu, 18 Apr 2019 00:04:32 GMT
       Server:
       - Server
       X-Amz-Crc32:
       - "396270901"
       X-Amzn-Requestid:
-      - UPP8SUUOVPHLK8A9F37TN4QSSVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - IMG9P2S1AHT4D15OLFJ8QK7SLVVV4KQNSO5AEMVJF66Q9ASUAAJG
     status: 400 Bad Request
     code: 400
     duration: ""


### PR DESCRIPTION
Take table indexes into account when deciding how to run a query.

Add tests for query planning.

Updates #1832. This PR builds and runs the RPCs, but we also need to
report the plan to the user.