### PR TITLE
blob/fileblob: improve ListPaged by adjusting root based on Prefix

### DIFF
--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -243,9 +243,17 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 	// are collapsed to the single directory entry.
 	var lastPrefix string
 
+	// If the Prefix contains a Path Separator, we can set the root of the Walk
+	// to the path specified by the Prefix as any files below the path will not
+	// match the Prefix.
+	root := b.dir
+	if i := strings.LastIndexByte(opts.Prefix, os.PathSeparator); i > -1 {
+		root = filepath.Join(root, opts.Prefix[:i])
+	}
+
 	// Do a full recursive scan of the root directory.
 	var result driver.ListPage
-	err := filepath.Walk(b.dir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			// Couldn't read this file/directory for some reason; just skip it.
 			return nil


### PR DESCRIPTION
This improves the performance of ListPaged for the fileblob store when specifying a Prefix containing a path by modifying the `filepath.Walk`'s root to be based on the Prefix.

e.g. A Prefix of `foo/bar/baz` will start the `filepath.Walk` at `{bucket dir}/foo/bar` as any files in directories below would not match the prefix. This preempts Walking unnecessarily around the directory tree below `foo/bar/baz`.

This performance problem came up in an application with only a couple thousand files but with a deeply nested filesystem-like keying system where the app knows what "directory" to List entries in. 

Let me know if I should write tests -- I figured the existing List tests which included some keys with path separators might suffice, but I'm happy to extend if it is required.