### PR TITLE
mongodocstore: extract the ID field with a function

### DIFF
--- a/internal/docstore/driver/document.go
+++ b/internal/docstore/driver/document.go
@@ -27,6 +27,7 @@ var fieldCache = fields.NewCache(nil, nil, nil)
 // A Document is a lightweight wrapper around either a map[string]interface{} or a
 // struct pointer. It provides operations to get and set fields and field paths.
 type Document struct {
+	Origin interface{}            // the argument to NewDocument
 	m      map[string]interface{} // nil if it's a *struct
 	s      reflect.Value          // the struct reflected
 	fields fields.List            // for structs
@@ -41,7 +42,7 @@ func NewDocument(doc interface{}) (Document, error) {
 		if m == nil {
 			return Document{}, gcerr.Newf(gcerr.InvalidArgument, nil, "document map cannot be nil")
 		}
-		return Document{m: m}, nil
+		return Document{Origin: doc, m: m}, nil
 	}
 	v := reflect.ValueOf(doc)
 	t := v.Type()
@@ -56,7 +57,7 @@ func NewDocument(doc interface{}) (Document, error) {
 	if err != nil {
 		return Document{}, err
 	}
-	return Document{s: v.Elem(), fields: fields}, nil
+	return Document{Origin: doc, s: v.Elem(), fields: fields}, nil
 }
 
 // GetField returns the value of the named document field.

--- a/internal/docstore/mongodocstore/mongo.go
+++ b/internal/docstore/mongodocstore/mongo.go
@@ -42,7 +42,7 @@ import (
 
 type collection struct {
 	coll   *mongo.Collection
-	idFunc func(interface{}) interface{}
+	idFunc func(docstore.Document) interface{}
 }
 
 type Options struct {
@@ -55,11 +55,11 @@ type Options struct {
 // OpenCollection opens a MongoDB collection for use with Docstore.
 // idFunc is a function that accepts a document and returns the value to be used for
 // its _id field, or nil if there is none (which is valid for a Create action).
-func OpenCollection(mcoll *mongo.Collection, idFunc func(doc interface{}) interface{}, _ *Options) *docstore.Collection {
+func OpenCollection(mcoll *mongo.Collection, idFunc func(docstore.Document) interface{}, _ *Options) *docstore.Collection {
 	return docstore.NewCollection(newCollection(mcoll, idFunc))
 }
 
-func newCollection(mcoll *mongo.Collection, idFunc func(interface{}) interface{}) *collection {
+func newCollection(mcoll *mongo.Collection, idFunc func(docstore.Document) interface{}) *collection {
 	return &collection{coll: mcoll, idFunc: idFunc}
 }
 

--- a/internal/docstore/mongodocstore/mongo.go
+++ b/internal/docstore/mongodocstore/mongo.go
@@ -78,7 +78,7 @@ func newCollection(mcoll *mongo.Collection, opts Options) *collection {
 // From https://docs.mongodb.com/manual/core/document: "The field name _id is
 // reserved for use as a primary key; its value must be unique in the collection, is
 // immutable, and may be of any type other than an array."
-const mongoIDField = "_id"
+const mongoIDField = "_id "
 
 // TODO(jba): use bulk RPCs.
 func (c *collection) RunActions(ctx context.Context, actions []*driver.Action, unordered bool) driver.ActionListError {

--- a/internal/docstore/mongodocstore/mongo.go
+++ b/internal/docstore/mongodocstore/mongo.go
@@ -78,7 +78,7 @@ func newCollection(mcoll *mongo.Collection, opts Options) *collection {
 // From https://docs.mongodb.com/manual/core/document: "The field name _id is
 // reserved for use as a primary key; its value must be unique in the collection, is
 // immutable, and may be of any type other than an array."
-const mongoIDField = "_id "
+const mongoIDField = "_id"
 
 // TODO(jba): use bulk RPCs.
 func (c *collection) RunActions(ctx context.Context, actions []*driver.Action, unordered bool) driver.ActionListError {

--- a/internal/docstore/mongodocstore/mongo_test.go
+++ b/internal/docstore/mongodocstore/mongo_test.go
@@ -60,13 +60,8 @@ func newClient(ctx context.Context, uri string) (*mongo.Client, error) {
 	return client, nil
 }
 
-func extractID(doc interface{}) interface{} {
-	m := doc.(map[string]interface{})
-	return m[idField]
-}
-
 func (h *harness) MakeCollection(ctx context.Context) (driver.Collection, error) {
-	coll := newCollection(h.db.Collection(collectionName), extractID)
+	coll := newCollection(h.db.Collection(collectionName), Options{IDField: "_id"})
 	// It seems that the client doesn't actually connect until the first RPC, which will
 	// be this one. So time out quickly if there's a problem.
 	tctx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/internal/docstore/mongodocstore/mongo_test.go
+++ b/internal/docstore/mongodocstore/mongo_test.go
@@ -60,8 +60,13 @@ func newClient(ctx context.Context, uri string) (*mongo.Client, error) {
 	return client, nil
 }
 
+func extractID(doc interface{}) interface{} {
+	m := doc.(map[string]interface{})
+	return m[idField]
+}
+
 func (h *harness) MakeCollection(ctx context.Context) (driver.Collection, error) {
-	coll := newCollection(h.db.Collection(collectionName))
+	coll := newCollection(h.db.Collection(collectionName), extractID)
 	// It seems that the client doesn't actually connect until the first RPC, which will
 	// be this one. So time out quickly if there's a problem.
 	tctx, cancel := context.WithTimeout(ctx, 5*time.Second)


### PR DESCRIPTION
Previously, we assumed the key field of every collection was "_id",
the same as MongoDB's key field. That forces every collection that
wants to be portable to use that field name.

Now, have the user provide a function to extract the ID from the
document. This allows any field (or even a combination of fields)
to be used as the MongoDB _id field.