### PR TITLE
blob: return pointer to Attributes structs instead of copying

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -392,8 +392,8 @@ func (r *reader) Read(p []byte) (int, error) {
 func (r *reader) Close() error {
 	return r.body.Close()
 }
-func (r *reader) Attributes() driver.ReaderAttributes {
-	return r.attrs
+func (r *reader) Attributes() *driver.ReaderAttributes {
+	return &r.attrs
 }
 func (r *reader) As(i interface{}) bool {
 	p, ok := i.(*azblob.DownloadResponse)
@@ -489,12 +489,12 @@ func (b *bucket) ErrorCode(err error) gcerrors.ErrorCode {
 }
 
 // Attributes implements driver.Attributes.
-func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes, error) {
+func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes, error) {
 	key = escapeKey(key, false)
 	blockBlobURL := b.containerURL.NewBlockBlobURL(key)
 	blobPropertiesResponse, err := blockBlobURL.GetProperties(ctx, azblob.BlobAccessConditions{})
 	if err != nil {
-		return driver.Attributes{}, err
+		return nil, err
 	}
 
 	azureMD := blobPropertiesResponse.NewMetadata()
@@ -504,7 +504,7 @@ func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes,
 		// keys & values.
 		md[escape.HexUnescape(k)] = escape.URLUnescape(v)
 	}
-	return driver.Attributes{
+	return &driver.Attributes{
 		CacheControl:       blobPropertiesResponse.CacheControl(),
 		ContentDisposition: blobPropertiesResponse.ContentDisposition(),
 		ContentEncoding:    blobPropertiesResponse.ContentEncoding(),

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -563,22 +563,22 @@ func (b *Bucket) Exists(ctx context.Context, key string) (bool, error) {
 //
 // If the blob does not exist, Attributes returns an error for which
 // gcerrors.Code will return gcerrors.NotFound.
-func (b *Bucket) Attributes(ctx context.Context, key string) (_ Attributes, err error) {
+func (b *Bucket) Attributes(ctx context.Context, key string) (_ *Attributes, err error) {
 	if !utf8.ValidString(key) {
-		return Attributes{}, gcerr.Newf(gcerr.InvalidArgument, nil, "blob: Attributes key must be a valid UTF-8 string: %q", key)
+		return nil, gcerr.Newf(gcerr.InvalidArgument, nil, "blob: Attributes key must be a valid UTF-8 string: %q", key)
 	}
 
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	if b.closed {
-		return Attributes{}, errClosed
+		return nil, errClosed
 	}
 	ctx = b.tracer.Start(ctx, "Attributes")
 	defer func() { b.tracer.End(ctx, err) }()
 
 	a, err := b.b.Attributes(ctx, key)
 	if err != nil {
-		return Attributes{}, wrapError(b.b, err)
+		return nil, wrapError(b.b, err)
 	}
 	var md map[string]string
 	if len(a.Metadata) > 0 {
@@ -590,7 +590,7 @@ func (b *Bucket) Attributes(ctx context.Context, key string) (_ Attributes, err 
 			md[strings.ToLower(k)] = v
 		}
 	}
-	return Attributes{
+	return &Attributes{
 		CacheControl:       a.CacheControl,
 		ContentDisposition: a.ContentDisposition,
 		ContentEncoding:    a.ContentEncoding,

--- a/blob/blob_test.go
+++ b/blob/blob_test.go
@@ -84,8 +84,11 @@ type fakeAttributes struct {
 	attributesErr error
 }
 
-func (b *fakeAttributes) Attributes(ctx context.Context, key string) (driver.Attributes, error) {
-	return driver.Attributes{}, b.attributesErr
+func (b *fakeAttributes) Attributes(ctx context.Context, key string) (*driver.Attributes, error) {
+	if b.attributesErr != nil {
+		return nil, b.attributesErr
+	}
+	return &driver.Attributes{}, nil
 }
 
 func (b *fakeAttributes) ErrorCode(err error) gcerrors.ErrorCode {
@@ -178,8 +181,8 @@ func (r *erroringWriter) Close() error {
 	return errFake
 }
 
-func (b *erroringBucket) Attributes(ctx context.Context, key string) (driver.Attributes, error) {
-	return driver.Attributes{}, errFake
+func (b *erroringBucket) Attributes(ctx context.Context, key string) (*driver.Attributes, error) {
+	return nil, errFake
 }
 
 func (b *erroringBucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driver.ListPage, error) {

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -33,6 +33,7 @@ type Reader interface {
 	io.ReadCloser
 
 	// Attributes returns a subset of attributes about the blob.
+	// The portable type will not modify the returned ReaderAttributes.
 	Attributes() *ReaderAttributes
 
 	// As allows providers to expose provider-specific types;
@@ -228,6 +229,7 @@ type Bucket interface {
 	// Attributes returns attributes for the blob. If the specified object does
 	// not exist, Attributes must return an error for which ErrorCode returns
 	// gcerrors.NotFound.
+	// The portable type will not modify the returned Attributes.
 	Attributes(ctx context.Context, key string) (*Attributes, error)
 
 	// ListPaged lists objects in the bucket, in lexicographical order by

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -33,7 +33,7 @@ type Reader interface {
 	io.ReadCloser
 
 	// Attributes returns a subset of attributes about the blob.
-	Attributes() ReaderAttributes
+	Attributes() *ReaderAttributes
 
 	// As allows providers to expose provider-specific types;
 	// see Bucket.As for more details.
@@ -228,7 +228,7 @@ type Bucket interface {
 	// Attributes returns attributes for the blob. If the specified object does
 	// not exist, Attributes must return an error for which ErrorCode returns
 	// gcerrors.NotFound.
-	Attributes(ctx context.Context, key string) (Attributes, error)
+	Attributes(ctx context.Context, key string) (*Attributes, error)
 
 	// ListPaged lists objects in the bucket, in lexicographical order by
 	// UTF-8-encoded key, returning pages of objects at a time.

--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -2018,7 +2018,7 @@ func testAs(t *testing.T, newHarness HarnessMaker, st AsTest) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := st.AttributesCheck(&attrs); err != nil {
+	if err := st.AttributesCheck(attrs); err != nil {
 		t.Error(err)
 	}
 

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -352,12 +352,12 @@ func (b *bucket) ErrorAs(err error, i interface{}) bool {
 }
 
 // Attributes implements driver.Attributes.
-func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes, error) {
+func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes, error) {
 	_, info, xa, err := b.forKey(key)
 	if err != nil {
-		return driver.Attributes{}, err
+		return nil, err
 	}
-	return driver.Attributes{
+	return &driver.Attributes{
 		CacheControl:       xa.CacheControl,
 		ContentDisposition: xa.ContentDisposition,
 		ContentEncoding:    xa.ContentEncoding,
@@ -420,8 +420,8 @@ func (r *reader) Close() error {
 	return r.c.Close()
 }
 
-func (r *reader) Attributes() driver.ReaderAttributes {
-	return r.attrs
+func (r *reader) Attributes() *driver.ReaderAttributes {
+	return &r.attrs
 }
 
 func (r *reader) As(i interface{}) bool { return false }

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -236,8 +236,8 @@ func (r *reader) Close() error {
 	return r.body.Close()
 }
 
-func (r *reader) Attributes() driver.ReaderAttributes {
-	return r.attrs
+func (r *reader) Attributes() *driver.ReaderAttributes {
+	return &r.attrs
 }
 
 func (r *reader) As(i interface{}) bool {
@@ -355,15 +355,15 @@ func (b *bucket) ErrorAs(err error, i interface{}) bool {
 }
 
 // Attributes implements driver.Attributes.
-func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes, error) {
+func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes, error) {
 	key = escapeKey(key)
 	bkt := b.client.Bucket(b.name)
 	obj := bkt.Object(key)
 	attrs, err := obj.Attrs(ctx)
 	if err != nil {
-		return driver.Attributes{}, err
+		return nil, err
 	}
-	return driver.Attributes{
+	return &driver.Attributes{
 		CacheControl:       attrs.CacheControl,
 		ContentDisposition: attrs.ContentDisposition,
 		ContentEncoding:    attrs.ContentEncoding,

--- a/blob/memblob/memblob.go
+++ b/blob/memblob/memblob.go
@@ -79,7 +79,7 @@ type Options struct{}
 
 type blobEntry struct {
 	Content    []byte
-	Attributes driver.Attributes
+	Attributes *driver.Attributes
 }
 
 type bucket struct {
@@ -201,13 +201,13 @@ func (b *bucket) As(i interface{}) bool { return false }
 func (b *bucket) ErrorAs(err error, i interface{}) bool { return false }
 
 // Attributes implements driver.Attributes.
-func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes, error) {
+func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	entry, found := b.blobs[key]
 	if !found {
-		return driver.Attributes{}, errNotFound
+		return nil, errNotFound
 	}
 	return entry.Attributes, nil
 }
@@ -255,8 +255,8 @@ func (r *reader) Close() error {
 	return nil
 }
 
-func (r *reader) Attributes() driver.ReaderAttributes {
-	return r.attrs
+func (r *reader) Attributes() *driver.ReaderAttributes {
+	return &r.attrs
 }
 
 func (r *reader) As(i interface{}) bool { return false }
@@ -319,7 +319,7 @@ func (w *writer) Close() error {
 	content := w.buf.Bytes()
 	entry := &blobEntry{
 		Content: content,
-		Attributes: driver.Attributes{
+		Attributes: &driver.Attributes{
 			CacheControl:       w.opts.CacheControl,
 			ContentDisposition: w.opts.ContentDisposition,
 			ContentEncoding:    w.opts.ContentEncoding,

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -211,8 +211,8 @@ func (r *reader) As(i interface{}) bool {
 	return true
 }
 
-func (r *reader) Attributes() driver.ReaderAttributes {
-	return r.attrs
+func (r *reader) Attributes() *driver.ReaderAttributes {
+	return &r.attrs
 }
 
 // writer writes an S3 object, it implements io.WriteCloser.
@@ -464,7 +464,7 @@ func (b *bucket) ErrorAs(err error, i interface{}) bool {
 }
 
 // Attributes implements driver.Attributes.
-func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes, error) {
+func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes, error) {
 	key = escapeKey(key)
 	in := &s3.HeadObjectInput{
 		Bucket: aws.String(b.name),
@@ -472,7 +472,7 @@ func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes,
 	}
 	resp, err := b.client.HeadObjectWithContext(ctx, in)
 	if err != nil {
-		return driver.Attributes{}, err
+		return nil, err
 	}
 
 	md := make(map[string]string, len(resp.Metadata))
@@ -481,7 +481,7 @@ func (b *bucket) Attributes(ctx context.Context, key string) (driver.Attributes,
 		// keys & values.
 		md[escape.HexUnescape(escape.URLUnescape(k))] = escape.URLUnescape(aws.StringValue(v))
 	}
-	return driver.Attributes{
+	return &driver.Attributes{
 		CacheControl:       aws.StringValue(resp.CacheControl),
 		ContentDisposition: aws.StringValue(resp.ContentDisposition),
 		ContentEncoding:    aws.StringValue(resp.ContentEncoding),


### PR DESCRIPTION
Fixes #1849.