### PR TITLE
docstore/memdocstore: changes to URLOpener

### DIFF
--- a/internal/docstore/memdocstore/mem.go
+++ b/internal/docstore/memdocstore/mem.go
@@ -17,8 +17,8 @@
 //
 // URLs
 //
-// For docstore.OpenCollection, memdocstore registers for the schemes
-// "memdocstore".
+// For docstore.OpenCollection, memdocstore registers for the scheme
+// "mem".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
 // See https://godoc.org/gocloud.dev#hdr-URLs for background information.
@@ -43,9 +43,14 @@ func init() {
 
 // Scheme is the URL scheme memdocstore registers its URLOpener under on
 // docstore.DefaultMux.
-const Scheme = "memdocstore"
+const Scheme = "mem"
 
-// URLOpener opens URLs like "memdocstore://".
+// URLOpener opens URLs like "mem://".
+//
+// The URL's host is used as the keyField.
+// The URL's path is ignored.
+//
+// No query parameters are supported.
 type URLOpener struct{}
 
 // OpenCollectionURL opens a docstore.Collection based on u.

--- a/internal/docstore/memdocstore/mem.go
+++ b/internal/docstore/memdocstore/mem.go
@@ -45,7 +45,7 @@ func init() {
 // docstore.DefaultMux.
 const Scheme = "mem"
 
-// URLOpener opens URLs like "mem://".
+// URLOpener opens URLs like "mem://_id".
 //
 // The URL's host is used as the keyField.
 // The URL's path is ignored.

--- a/internal/docstore/memdocstore/mem_test.go
+++ b/internal/docstore/memdocstore/mem_test.go
@@ -74,8 +74,7 @@ func TestOpenCollectionFromURL(t *testing.T) {
 		WantErr bool
 	}{
 		// OK.
-		{"mem://", false},
-		// OK, non-empty keyField.
+		{"mem://_id", false},
 		{"mem://foo.bar", false},
 		// Invalid parameter.
 		{"mem://?param=value", true},

--- a/internal/docstore/memdocstore/mem_test.go
+++ b/internal/docstore/memdocstore/mem_test.go
@@ -74,9 +74,11 @@ func TestOpenCollectionFromURL(t *testing.T) {
 		WantErr bool
 	}{
 		// OK.
-		{"memdocstore://", false},
+		{"mem://", false},
+		// OK, non-empty keyField.
+		{"mem://foo.bar", false},
 		// Invalid parameter.
-		{"memdocstore://?param=value", true},
+		{"mem://?param=value", true},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
* `mem` is constent with `memblob` and `mempubsub`.
* Documented that the URL host is used as the keyField.
* Updated test to actually do that.
