### PR TITLE
pubsub/nats: only receive 1 msg at a time to avoid dropping queued messages

### DIFF
--- a/pubsub/natspubsub/nats.go
+++ b/pubsub/natspubsub/nats.go
@@ -53,14 +53,34 @@ import (
 	"os"
 	"path"
 	"sync"
+	"time"
 
 	"github.com/nats-io/go-nats"
 	"gocloud.dev/gcerrors"
+	"gocloud.dev/internal/batcher"
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/driver"
 )
 
 var errNotInitialized = errors.New("natspubsub: topic not initialized")
+
+var recvBatcherOpts = &batcher.Options{
+	// NATS has at-most-once semantics, meaning once it delivers a message, the
+	// message won't be delivered again.
+	// Therefore, we can't allow the portable type to read-ahead and queue any
+	// messages; they might end up undelivered if the user never calls Receive
+	// to get them. Setting both the MaxBatchSize and MaxHandlers to one means
+	// that we'll only return a message at a time, which should be immediately
+	// returned to the user.
+	//
+	// Note: there is a race condition where the original Receive that
+	// triggered a call to ReceiveBatch ends up failing (e.g., due to a
+	// Done context), and ReceiveBatch returns a message that ends up being
+	// queued for the next Receive. That message is at risk of being dropped.
+	// This seems OK.
+	MaxBatchSize: 1,
+	MaxHandlers:  1, // max concurrency for receives
+}
 
 func init() {
 	o := new(defaultDialer)
@@ -295,7 +315,7 @@ func OpenSubscription(nc *nats.Conn, subject string, ackFunc func(), _ *Subscrip
 	if err != nil {
 		return nil, err
 	}
-	return pubsub.NewSubscription(ds, nil, nil), nil
+	return pubsub.NewSubscription(ds, recvBatcherOpts, nil), nil
 }
 
 func openSubscription(nc *nats.Conn, subject string, ackFunc func()) (driver.Subscription, error) {
@@ -323,52 +343,18 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 		return nil, nats.ErrBadSubscription
 	}
 
-	// Return right away if the ctx has an error.
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	var ms []*driver.Message
-
-	// We will assume the desired goal is at least one message since the public API only has Receive().
-	// We will load all the messages that are already queued up first.
-	for {
-		msg, err := s.nsub.NextMsg(0)
-		if err == nil {
-			dm, err := decode(msg)
-			if err != nil {
-				return nil, err
-			}
-			ms = append(ms, dm)
-			if len(ms) >= maxMessages {
-				break
-			}
-		} else if err == nats.ErrTimeout {
-			break
-		} else {
-			return nil, err
-		}
-	}
-
-	// If we have anything go ahead and return here.
-	if len(ms) > 0 {
-		return ms, nil
-	}
-
-	// Here we will assume the ctx has a deadline and will allow it to do its thing. We may
-	// get a burst of messages but we will only wait once here and let the next call grab them.
-	// The reason is so that if deadline is not properly set we will not needlessly wait here
-	// for more messages when the user most likely only wants one.
-	msg, err := s.nsub.NextMsgWithContext(ctx)
+	msg, err := s.nsub.NextMsg(100 * time.Millisecond)
 	if err != nil {
+		if err == nats.ErrTimeout {
+			return nil, nil
+		}
 		return nil, err
 	}
 	dm, err := decode(msg)
 	if err != nil {
 		return nil, err
 	}
-	ms = append(ms, dm)
-	return ms, nil
+	return []*driver.Message{dm}, nil
 }
 
 // Convert NATS msgs to *driver.Message.

--- a/pubsub/natspubsub/nats_test.go
+++ b/pubsub/natspubsub/nats_test.go
@@ -326,7 +326,7 @@ func BenchmarkNatsPubSub(b *testing.B) {
 
 	topic := pubsub.NewTopic(dt, nil)
 	defer topic.Shutdown(ctx)
-	sub := pubsub.NewSubscription(ds, nil, nil)
+	sub := pubsub.NewSubscription(ds, recvBatcherOpts, nil)
 	defer sub.Shutdown(ctx)
 
 	drivertest.RunBenchmarks(b, topic, sub)


### PR DESCRIPTION
Fixes #1829.