### PR TITLE
internal/website: rewrite blob how-to guide to use blob godoc examples

### DIFF
--- a/blob/azureblob/example_test.go
+++ b/blob/azureblob/example_test.go
@@ -24,12 +24,17 @@ import (
 )
 
 func Example() {
+	// This example is used in https://gocloud.dev/howto/blob/open-bucket/#azure-ctor
+
+	// Variables set up elsewhere:
+	ctx := context.Background()
+
 	const (
-		// Your Azure Storage Acount and Access Key.
-		accountName = azureblob.AccountName("my-account")
-		accountKey  = azureblob.AccountKey("my-account-key")
-		// The storage container to access.
-		containerName = "mycontainer"
+		// Fill in with your Azure Storage Account and Access Key.
+		accountName azureblob.AccountName = "my-account"
+		accountKey  azureblob.AccountKey  = "my-account-key"
+		// Fill in with the storage container to access.
+		containerName = "my-container"
 	)
 
 	// Create a credentials object.
@@ -43,19 +48,12 @@ func Example() {
 
 	// Create a *blob.Bucket.
 	// The credential Option is required if you're going to use blob.SignedURL.
-	ctx := context.Background()
-	b, err := azureblob.OpenBucket(ctx, pipeline, accountName, containerName, &azureblob.Options{Credential: credential})
+	bucket, err := azureblob.OpenBucket(ctx, pipeline, accountName, containerName,
+		&azureblob.Options{Credential: credential})
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer b.Close()
-
-	// Now we can use b to read or write files to the container.
-	data, err := b.ReadAll(ctx, "my-key")
-	if err != nil {
-		log.Fatal(err)
-	}
-	_ = data
+	defer bucket.Close()
 }
 
 func Example_sasToken() {
@@ -64,7 +62,7 @@ func Example_sasToken() {
 		accountName = azureblob.AccountName("my-account")
 		sasToken    = azureblob.SASToken("my-SAS-token")
 		// The storage container to access.
-		containerName = "mycontainer"
+		containerName = "my-container"
 	)
 
 	// Since we're using a SASToken, we can use anonymous credentials.
@@ -93,14 +91,21 @@ func Example_sasToken() {
 }
 
 func Example_openBucket() {
+	// This example is used in https://gocloud.dev/howto/blob/open-bucket/#azure
+
+	// import _ "gocloud.dev/blob/azureblob"
+
+	// Variables set up elsewhere:
 	ctx := context.Background()
 
 	// OpenBucket creates a *blob.Bucket from a URL.
-	// This URL will open the container "mycontainer" using default
+	// This URL will open the container "my-container" using default
 	// credentials found in the environment variables
 	// AZURE_STORAGE_ACCOUNT plus at least one of AZURE_STORAGE_KEY
 	// and AZURE_STORAGE_SAS_TOKEN.
-	b, err := blob.OpenBucket(ctx, "azblob://mycontainer")
-	defer b.Close()
-	_, _ = b, err
+	bucket, err := blob.OpenBucket(ctx, "azblob://my-container")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer bucket.Close()
 }

--- a/blob/fileblob/example_test.go
+++ b/blob/fileblob/example_test.go
@@ -28,35 +28,20 @@ import (
 )
 
 func Example() {
+	// This example is used in https://gocloud.dev/howto/blob/open-bucket/#local-ctor
 
-	// Create a temporary directory.
-	dir, err := ioutil.TempDir("", "go-cloud-fileblob-example")
-	if err != nil {
+	// The directory you pass to fileblob.OpenBucket must exist first.
+	const myDir = "path/to/local/directory"
+	if err := os.MkdirAll(myDir, 0777); err != nil {
 		log.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
 
 	// Create a file-based bucket.
-	b, err := fileblob.OpenBucket(dir, nil)
+	bucket, err := fileblob.OpenBucket(myDir, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer b.Close()
-
-	// Now we can use b to read or write files to the container.
-	ctx := context.Background()
-	err = b.WriteAll(ctx, "my-key", []byte("hello world"), nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	data, err := b.ReadAll(ctx, "my-key")
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(string(data))
-
-	// Output:
-	// hello world
+	defer bucket.Close()
 }
 
 func Example_openBucket() {

--- a/blob/gcsblob/example_test.go
+++ b/blob/gcsblob/example_test.go
@@ -23,45 +23,51 @@ import (
 	"gocloud.dev/gcp"
 )
 
-func Example_read() {
+func Example() {
+	// This example is used in https://gocloud.dev/howto/blob/open-bucket/#gcs-ctor
+
+	// Variables set up elsewhere:
+	ctx := context.Background()
+
 	// Your GCP credentials.
 	// See https://cloud.google.com/docs/authentication/production
 	// for more info on alternatives.
-	ctx := context.Background()
 	creds, err := gcp.DefaultCredentials(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Create an HTTP client.
-	// This example uses the default HTTP transport and the credentials created
-	// above.
-	client, err := gcp.NewHTTPClient(gcp.DefaultTransport(), gcp.CredentialsTokenSource(creds))
+	// This example uses the default HTTP transport and the credentials
+	// created above.
+	client, err := gcp.NewHTTPClient(
+		gcp.DefaultTransport(),
+		gcp.CredentialsTokenSource(creds))
 	if err != nil {
-		return
+		log.Fatal(err)
 	}
 
 	// Create a *blob.Bucket.
-	b, err := gcsblob.OpenBucket(ctx, client, "my-bucket", nil)
+	bucket, err := gcsblob.OpenBucket(ctx, client, "my-bucket", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer b.Close()
-
-	// Now we can use b to read or write files to the container.
-	data, err := b.ReadAll(ctx, "my-key")
-	if err != nil {
-		log.Fatal(err)
-	}
-	_ = data
+	defer bucket.Close()
 }
 
 func Example_openBucket() {
+	// This example is used in https://gocloud.dev/howto/blob/open-bucket/#gcs
+
+	// import _ "gocloud.dev/blob/gcsblob"
+
+	// Variables set up elsewhere:
 	ctx := context.Background()
 
 	// OpenBucket creates a *blob.Bucket from a URL.
 	// This URL will open the bucket "my-bucket" using default credentials.
-	b, err := blob.OpenBucket(ctx, "gs://my-bucket")
-	defer b.Close()
-	_, _ = b, err
+	bucket, err := blob.OpenBucket(ctx, "gs://my-bucket")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer bucket.Close()
 }

--- a/blob/memblob/example_test.go
+++ b/blob/memblob/example_test.go
@@ -24,18 +24,21 @@ import (
 )
 
 func Example() {
+	// This example is used in https://gocloud.dev/howto/blob/open-bucket/#local-ctor
+
+	// Variables set up elsewhere:
+	ctx := context.Background()
 
 	// Create an in-memory bucket.
-	b := memblob.OpenBucket(nil)
-	defer b.Close()
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
 
-	// Now we can use b to read or write files to the container.
-	ctx := context.Background()
-	err := b.WriteAll(ctx, "my-key", []byte("hello world"), nil)
+	// Now we can use bucket to read or write files to the bucket.
+	err := bucket.WriteAll(ctx, "my-key", []byte("hello world"), nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-	data, err := b.ReadAll(ctx, "my-key")
+	data, err := bucket.ReadAll(ctx, "my-key")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/blob/s3blob/example_test.go
+++ b/blob/s3blob/example_test.go
@@ -25,35 +25,41 @@ import (
 )
 
 func Example() {
+	// This example is used in https://gocloud.dev/howto/blob/open-bucket/#s3-ctor
+
+	// Variables set up elsewhere:
+	ctx := context.Background()
+
 	// Establish an AWS session.
 	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more info.
-	// The region must match the region for "my_bucket".
-	sess, err := session.NewSession(&aws.Config{Region: aws.String("us-west-1")})
+	// The region must match the region for "my-bucket".
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-west-1"),
+	})
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Create a *blob.Bucket.
-	ctx := context.Background()
-	b, err := s3blob.OpenBucket(ctx, sess, "my-bucket", nil)
+	bucket, err := s3blob.OpenBucket(ctx, sess, "my-bucket", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer b.Close()
-
-	// Now we can use b to read or write files to the container.
-	data, err := b.ReadAll(ctx, "my-key")
-	if err != nil {
-		log.Fatal(err)
-	}
-	_ = data
+	defer bucket.Close()
 }
 
 func Example_openBucket() {
+	// This example is used in https://gocloud.dev/howto/blob/open-bucket/#s3
+
+	// import _ "gocloud.dev/blob/s3blob"
+
+	// Variables set up elsewhere:
 	ctx := context.Background()
 
 	// OpenBucket creates a *blob.Bucket from a URL.
-	b, err := blob.OpenBucket(ctx, "s3://my-bucket")
-	defer b.Close()
-	_, _ = b, err
+	bucket, err := blob.OpenBucket(ctx, "s3://my-bucket?region=us-west-1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer bucket.Close()
 }

--- a/internal/website/content/howto/blob/data.md
+++ b/internal/website/content/howto/blob/data.md
@@ -11,7 +11,7 @@ store and access data from it using the standard Go I/O patterns.
 
 <!--more-->
 
-## Writing data to a bucket
+## Writing data to a bucket {#writing}
 
 To write data to a bucket, you create a writer, write data to it, and then
 close the writer. Closing the writer commits the write to the provider,
@@ -21,22 +21,7 @@ must always check the error of `Close`.
 The writer implements [`io.Writer`][], so you can use any functions that take
 an `io.Writer` like `io.Copy` or `fmt.Fprintln`.
 
-```go
-// Open the key "foo.txt" for writing with the default options.
-w, err := bucket.NewWriter(ctx, "foo.txt", nil)
-if err != nil {
-    return w
-}
-_, writeErr := fmt.Fprintln(w, "Hello, World!")
-// Always check the return value of Close when writing.
-closeErr := w.Close()
-if writeErr != nil {
-    return writeErr
-}
-if closeErr != nil {
-    return closeErr
-}
-```
+{{< goexample src="gocloud.dev/blob.ExampleBucket_NewWriter" imports="0" >}}
 
 In some cases, you may want to cancel an in-progress write to avoid the blob
 being created or overwritten. A typical reason for wanting to cancel a write
@@ -45,78 +30,31 @@ a write, you cancel the `Context` you pass to the writer. Again, you must
 always `Close` the writer to release the resources, but in this case you can
 ignore the error because the write's failure is expected.
 
-```go
-// Create a cancelable context from the existing context.
-writeCtx, cancelWrite := context.WithCancel(ctx)
-defer cancelWrite()
-
-// Open the key "foo.txt" for writing with the default options.
-w, err := bucket.NewWriter(ctx, "foo.txt", nil)
-if err != nil {
-    return err
-}
-
-// Assume some writes happened and we encountered an error.
-// Now we want to abort the write.
-
-// First cancel the context.
-cancelWrite()
-// You must still close the writer to avoid leaking resources.
-w.Close()
-```
+{{< goexample src="gocloud.dev/blob.ExampleBucket_NewWriter_cancel" imports="0" >}}
 
 [`io.Writer`]: https://golang.org/pkg/io/#Writer
 
-## Reading data from a bucket
+## Reading data from a bucket {#reading}
 
 Once you have written data to a bucket, you can read it back by creating a
 reader. The reader implements [`io.Reader`][], so you can use any functions
 that take an `io.Reader` like `io.Copy` or `io/ioutil.ReadAll`. You must
 always close a reader after using it to avoid leaking resources.
 
-```go
-// Open the key "foo.txt" for reading with the default options.
-r, err := bucket.NewReader(ctx, "foo.txt", nil)
-if err != nil {
-    return err
-}
-defer r.Close()
-// Readers also have a limited view of the blob's metadata.
-fmt.Println("Content-Type:", r.ContentType())
-fmt.Println()
-// Copy from the reader to stdout.
-if _, err := io.Copy(os.Stdout, r); err != nil {
-    return err
-}
-```
+{{< goexample src="gocloud.dev/blob.ExampleBucket_NewReader" imports="0" >}}
 
 Many storage providers provide efficient random-access to data in buckets. To
 start reading from an arbitrary offset in the blob, use `NewRangeReader`.
 
-```go
-// Open the key "foo.txt" for reading at offset 1024 and read up to 4096 bytes.
-r, err := bucket.NewRangeReader(ctx, "foo.txt", 1024, 4096, nil)
-if err != nil {
-    return err
-}
-defer r.Close()
-// Copy from the read range to stdout.
-if _, err := io.Copy(os.Stdout, r); err != nil {
-    return err
-}
-```
+{{< goexample src="gocloud.dev/blob.ExampleBucket_NewRangeReader" imports="0" >}}
 
 [`io.Reader`]: https://golang.org/pkg/io/#Reader
 
-## Deleting blobs
+## Deleting blobs {#deleting}
 
 You can delete blobs using the `Bucket.Delete` method.
 
-```go
-if err := bucket.Delete(ctx, "foo.txt"); err != nil {
-    return err
-}
-```
+{{< goexample src="gocloud.dev/blob.ExampleBucket_Delete" imports="0" >}}
 
 ## Wrapping up
 

--- a/internal/website/content/howto/blob/open-bucket.md
+++ b/internal/website/content/howto/blob/open-bucket.md
@@ -26,69 +26,32 @@ both forms for each storage provider.
 ["blank import"]: https://golang.org/doc/effective_go.html#blank_import
 [documentation on URLs]: https://godoc.org/gocloud.dev#hdr-URLs
 
-## S3
+## S3 {#s3}
 
 S3 URLs in the Go CDK closely resemble the URLs you would see in the AWS CLI.
 You can specify the `region` query parameter to ensure your application connects
 to the correct region, but otherwise `blob.OpenBucket` will use the region found
 in the environment variables or your AWS CLI configuration.
 
-```go
-import (
-    "gocloud.dev/blob"
-    _ "gocloud.dev/blob/s3blob"
-)
-
-// ...
-
-bucket, err := blob.OpenBucket(ctx, "s3://my-bucket?region=us-west-1")
-if err != nil {
-    return err
-}
-defer bucket.Close()
-```
+{{< goexample "gocloud.dev/blob/s3blob.Example_openBucket" >}}
 
 Full details about acceptable URLs can be found under the API reference for
 [`s3blob.URLOpener`][].
 
 [`s3blob.URLOpener`]: https://godoc.org/gocloud.dev/blob/s3blob#URLOpener
 
-### S3 Constructor
+### S3 Constructor {#s3-ctor}
 
 The [`s3blob.OpenBucket`][] constructor opens an [S3][] bucket. You must first
 create an [AWS session][] with the same region as your bucket:
 
-```go
-import (
-    "github.com/aws/aws-sdk-go/aws"
-    "github.com/aws/aws-sdk-go/aws/session"
-    "gocloud.dev/blob/s3blob"
-)
-
-// ...
-
-// Establish an AWS session.
-// The region must match the region for "my-bucket".
-sess, err := session.NewSession(&aws.Config{
-    Region: aws.String("us-west-1"),
-})
-if err != nil {
-    return err
-}
-
-// Create a *blob.Bucket.
-bucket, err := s3blob.OpenBucket(ctx, sess, "my-bucket", nil)
-if err != nil {
-    return err
-}
-defer bucket.Close()
-```
+{{< goexample "gocloud.dev/blob/s3blob.Example" >}}
 
 [`s3blob.OpenBucket`]: https://godoc.org/gocloud.dev/blob/s3blob
 [AWS session]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
 [S3]: https://aws.amazon.com/s3/
 
-### S3-compatible storage servers
+### S3-compatible storage servers {#s3-compatible}
 
 The Go CDK can also interact with [S3-compatible storage servers][] that
 recognize the same REST HTTP endpoints as S3, like [Minio][], [Ceph][], or
@@ -113,26 +76,13 @@ See [`aws.ConfigFromURLParams`][] for more details on supported URL options for 
 [SeaweedFS]: https://github.com/chrislusf/seaweedfs
 [S3-compatible storage servers]: https://en.wikipedia.org/wiki/Amazon_S3#S3_API_and_competing_services
 
-## Google Cloud Storage
+## Google Cloud Storage {#gcs}
 
 [Google Cloud Storage][] (GCS) URLs in the Go CDK closely resemble the URLs
 you would see in the `gsutil` CLI. `blob.OpenBucket` will use [Application
 Default Credentials][GCP creds].
 
-```go
-import (
-    "gocloud.dev/blob"
-    _ "gocloud.dev/blob/gcsblob"
-)
-
-// ...
-
-bucket, err := blob.OpenBucket(ctx, "gs://my-bucket")
-if err != nil {
-    return err
-}
-defer bucket.Close()
-```
+{{< goexample "gocloud.dev/blob/gcsblob.Example_openBucket" >}}
 
 Full details about acceptable URLs can be found under the API reference for
 [`gcsblob.URLOpener`][].
@@ -140,7 +90,7 @@ Full details about acceptable URLs can be found under the API reference for
 [Google Cloud Storage]: https://cloud.google.com/storage/
 [`gcsblob.URLOpener`]: https://godoc.org/gocloud.dev/blob/gcsblob#URLOpener
 
-### Google Cloud Storage Constructor
+### Google Cloud Storage Constructor {#gcs-ctor}
 
 The [`gcsblob.OpenBucket`][] constructor opens a GCS bucket. You must first
 create a `*net/http.Client` that sends requests authorized by [Google Cloud
@@ -148,45 +98,13 @@ Platform credentials][GCP creds]. (You can reuse the same client for any
 other API that takes in a `*gcp.HTTPClient`.) You can find functions in the
 [`gocloud.dev/gcp`][] package to set this up for you.
 
-```go
-import (
-    "gocloud.dev/blob/gcsblob"
-    "gocloud.dev/gcp"
-)
-
-// ...
-
-// Your GCP credentials.
-// See https://cloud.google.com/docs/authentication/production
-// for more info on alternatives.
-creds, err := gcp.DefaultCredentials(ctx)
-if err != nil {
-    return err
-}
-
-// Create an HTTP client.
-// This example uses the default HTTP transport and the credentials created
-// above.
-client, err := gcp.NewHTTPClient(
-    gcp.DefaultTransport(),
-    gcp.CredentialsTokenSource(creds))
-if err != nil {
-    return err
-}
-
-// Create a *blob.Bucket.
-bucket, err := gcsblob.OpenBucket(ctx, client, "my-bucket", nil)
-if err != nil {
-    return err
-}
-defer bucket.Close()
-```
+{{< goexample "gocloud.dev/blob/gcsblob.Example" >}}
 
 [GCP creds]: https://cloud.google.com/docs/authentication/production
 [`gcsblob.OpenBucket`]: https://godoc.org/gocloud.dev/blob/gcsblob#OpenBucket
 [`gocloud.dev/gcp`]: https://godoc.org/gocloud.dev/gcp
 
-## Azure Storage
+## Azure Storage {#azure}
 
 Azure Storage URLs in the Go CDK allow you to identify [Azure Storage][] containers
 when opening a bucket with `blob.OpenBucket`. Go CDK uses the environment
@@ -194,20 +112,7 @@ variables `AZURE_STORAGE_ACCOUNT`, `AZURE_STORAGE_KEY`, and
 `AZURE_STORAGE_SAS_TOKEN` to configure the credentials. `AZURE_STORAGE_ACCOUNT`
 is required, along with one of the other two.
 
-```go
-import (
-    "gocloud.dev/blob"
-    _ "gocloud.dev/blob/azureblob"
-)
-
-// ...
-
-bucket, err := blob.OpenBucket(ctx, "azblob://my-container")
-if err != nil {
-    return err
-}
-defer bucket.Close()
-```
+{{< goexample "gocloud.dev/blob/azureblob.Example_openBucket" >}}
 
 Full details about acceptable URLs can be found under the API reference for
 [`azureblob.URLOpener`][].
@@ -215,53 +120,19 @@ Full details about acceptable URLs can be found under the API reference for
 [Azure Storage]: https://azure.microsoft.com/en-us/services/storage/
 [`azureblob.URLOpener`]: https://godoc.org/gocloud.dev/blob/azureblob#URLOpener
 
-### Azure Storage Constructor
+### Azure Storage Constructor {#azure-ctor}
 
 The [`azureblob.OpenBucket`][] constructor opens an Azure Storage container.
 `azureblob` operates on [Azure Storage Block Blobs][]. You must first create
 Azure Storage credentials and then create an Azure Storage pipeline before
 you can open a container.
 
-```go
-import (
-    "github.com/Azure/azure-storage-blob-go/azblob"
-    "gocloud.dev/blob/azureblob"
-)
-
-// ...
-
-const (
-    // Fill in with your Azure Storage Acount and Access Key.
-    accountName = azureblob.AccountName("my-account")
-    accountKey  = azureblob.AccountKey("my-account-key")
-    // Fill in with the storage container to access.
-    containerName = "mycontainer"
-)
-
-// Create a credentials object.
-credential, err := azureblob.NewCredential(accountName, accountKey)
-if err != nil {
-    return err
-}
-
-// Create a Pipeline, using whatever PipelineOptions you need.
-pipeline := azureblob.NewPipeline(credential, azblob.PipelineOptions{})
-
-// Create a *blob.Bucket.
-// The credential option is required if you're going to use blob.SignedURL.
-ctx := context.Background()
-bucket, err := azureblob.OpenBucket(ctx, pipeline, accountName, containerName,
-    &azureblob.Options{Credential: credential})
-if err != nil {
-    return err
-}
-defer bucket.Close()
-```
+{{< goexample "gocloud.dev/blob/azureblob.Example" >}}
 
 [Azure Storage Block Blobs]: https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs#about-block-blobs
 [`azureblob.OpenBucket`]: https://godoc.org/gocloud.dev/blob/azureblob#OpenBucket
 
-## Local Storage
+## Local Storage {#local}
 
 The Go CDK provides blob drivers for storing data in memory and on the local
 filesystem. These are primarily intended for testing and local development,
@@ -295,39 +166,15 @@ if err != nil {
 defer bucket2.Close()
 ```
 
-### Local Storage Constructors
+### Local Storage Constructors {#local-ctor}
 
 You can create an in-memory bucket with [`memblob.OpenBucket`][]:
 
-```go
-import "gocloud.dev/blob/memblob"
-
-// ...
-
-bucket := memblob.OpenBucket(nil)
-defer bucket.Close()
-```
+{{< goexample "gocloud.dev/blob/memblob.Example" >}}
 
 You can use a local filesystem directory with [`fileblob.OpenBucket`][]:
 
-```go
-import "gocloud.dev/blob/fileblob"
-
-// ...
-
-// The directory you pass to fileblob.OpenBucket must exist first.
-const myDir = "path/to/local/directory"
-if err := os.MkdirAll(myDir, 0777); err != nil {
-    return err
-}
-
-// Open the directory bucket.
-bucket, err := fileblob.OpenBucket(myDir, nil)
-if err != nil {
-    return err
-}
-defer bucket.Close()
-```
+{{< goexample "gocloud.dev/blob/fileblob.Example" >}}
 
 [`fileblob.OpenBucket`]: https://godoc.org/gocloud.dev/blob/fileblob#OpenBucket
 [`memblob.OpenBucket`]: https://godoc.org/gocloud.dev/blob/memblob#OpenBucket

--- a/internal/website/data/examples.json
+++ b/internal/website/data/examples.json
@@ -1,1 +1,54 @@
-{}
+{
+	"gocloud.dev/blob.ExampleBucket_Delete": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/blob\"\n)",
+		"code": "if err := bucket.Delete(ctx, \"foo.txt\"); err != nil {\n\treturn err\n}"
+	},
+	"gocloud.dev/blob.ExampleBucket_NewRangeReader": {
+		"imports": "import (\n\t\"context\"\n\t\"io\"\n\t\"os\"\n\n\t\"gocloud.dev/blob\"\n)",
+		"code": "// Open the key \"foo.txt\" for reading at offset 1024 and read up to 4096 bytes.\nr, err := bucket.NewRangeReader(ctx, \"foo.txt\", 1024, 4096, nil)\nif err != nil {\n\treturn err\n}\ndefer r.Close()\n// Copy from the read range to stdout.\nif _, err := io.Copy(os.Stdout, r); err != nil {\n\treturn err\n}"
+	},
+	"gocloud.dev/blob.ExampleBucket_NewReader": {
+		"imports": "import (\n\t\"context\"\n\t\"fmt\"\n\t\"io\"\n\t\"os\"\n\n\t\"gocloud.dev/blob\"\n)",
+		"code": "// Open the key \"foo.txt\" for reading with the default options.\nr, err := bucket.NewReader(ctx, \"foo.txt\", nil)\nif err != nil {\n\treturn err\n}\ndefer r.Close()\n// Readers also have a limited view of the blob's metadata.\nfmt.Println(\"Content-Type:\", r.ContentType())\nfmt.Println()\n// Copy from the reader to stdout.\nif _, err := io.Copy(os.Stdout, r); err != nil {\n\treturn err\n}"
+	},
+	"gocloud.dev/blob.ExampleBucket_NewWriter": {
+		"imports": "import (\n\t\"context\"\n\t\"fmt\"\n\n\t\"gocloud.dev/blob\"\n)",
+		"code": "// Open the key \"foo.txt\" for writing with the default options.\nw, err := bucket.NewWriter(ctx, \"foo.txt\", nil)\nif err != nil {\n\treturn err\n}\n_, writeErr := fmt.Fprintln(w, \"Hello, World!\")\n// Always check the return value of Close when writing.\ncloseErr := w.Close()\nif writeErr != nil {\n\tlog.Fatal(writeErr)\n}\nif closeErr != nil {\n\tlog.Fatal(closeErr)\n}"
+	},
+	"gocloud.dev/blob.ExampleBucket_NewWriter_cancel": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/blob\"\n)",
+		"code": "// Create a cancelable context from the existing context.\nwriteCtx, cancelWrite := context.WithCancel(ctx)\ndefer cancelWrite()\n\n// Open the key \"foo.txt\" for writing with the default options.\nw, err := bucket.NewWriter(writeCtx, \"foo.txt\", nil)\nif err != nil {\n\treturn err\n}\n\n// Assume some writes happened and we encountered an error.\n// Now we want to abort the write.\n\nif err != nil {\n\t// First cancel the context.\n\tcancelWrite()\n\t// You must still close the writer to avoid leaking resources.\n\tw.Close()\n}"
+	},
+	"gocloud.dev/blob/azureblob.Example": {
+		"imports": "import (\n\t\"context\"\n\n\t\"github.com/Azure/azure-storage-blob-go/azblob\"\n\t\"gocloud.dev/blob/azureblob\"\n)",
+		"code": "const (\n\t// Fill in with your Azure Storage Account and Access Key.\n\taccountName azureblob.AccountName = \"my-account\"\n\taccountKey  azureblob.AccountKey  = \"my-account-key\"\n\t// Fill in with the storage container to access.\n\tcontainerName = \"my-container\"\n)\n\n// Create a credentials object.\ncredential, err := azureblob.NewCredential(accountName, accountKey)\nif err != nil {\n\treturn err\n}\n\n// Create a Pipeline, using whatever PipelineOptions you need.\npipeline := azureblob.NewPipeline(credential, azblob.PipelineOptions{})\n\n// Create a *blob.Bucket.\n// The credential Option is required if you're going to use blob.SignedURL.\nbucket, err := azureblob.OpenBucket(ctx, pipeline, accountName, containerName,\n\t\u0026azureblob.Options{Credential: credential})\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()"
+	},
+	"gocloud.dev/blob/azureblob.Example_openBucket": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/blob\"\n\t_ \"gocloud.dev/blob/azureblob\"\n)",
+		"code": "// OpenBucket creates a *blob.Bucket from a URL.\n// This URL will open the container \"my-container\" using default\n// credentials found in the environment variables\n// AZURE_STORAGE_ACCOUNT plus at least one of AZURE_STORAGE_KEY\n// and AZURE_STORAGE_SAS_TOKEN.\nbucket, err := blob.OpenBucket(ctx, \"azblob://my-container\")\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()"
+	},
+	"gocloud.dev/blob/fileblob.Example": {
+		"imports": "import (\n\t\"os\"\n\n\t\"gocloud.dev/blob/fileblob\"\n)",
+		"code": "// The directory you pass to fileblob.OpenBucket must exist first.\nconst myDir = \"path/to/local/directory\"\nif err := os.MkdirAll(myDir, 0777); err != nil {\n\treturn err\n}\n\n// Create a file-based bucket.\nbucket, err := fileblob.OpenBucket(myDir, nil)\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()"
+	},
+	"gocloud.dev/blob/gcsblob.Example": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/blob/gcsblob\"\n\t\"gocloud.dev/gcp\"\n)",
+		"code": "// Your GCP credentials.\n// See https://cloud.google.com/docs/authentication/production\n// for more info on alternatives.\ncreds, err := gcp.DefaultCredentials(ctx)\nif err != nil {\n\treturn err\n}\n\n// Create an HTTP client.\n// This example uses the default HTTP transport and the credentials\n// created above.\nclient, err := gcp.NewHTTPClient(\n\tgcp.DefaultTransport(),\n\tgcp.CredentialsTokenSource(creds))\nif err != nil {\n\treturn err\n}\n\n// Create a *blob.Bucket.\nbucket, err := gcsblob.OpenBucket(ctx, client, \"my-bucket\", nil)\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()"
+	},
+	"gocloud.dev/blob/gcsblob.Example_openBucket": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/blob\"\n\t_ \"gocloud.dev/blob/gcsblob\"\n)",
+		"code": "// OpenBucket creates a *blob.Bucket from a URL.\n// This URL will open the bucket \"my-bucket\" using default credentials.\nbucket, err := blob.OpenBucket(ctx, \"gs://my-bucket\")\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()"
+	},
+	"gocloud.dev/blob/memblob.Example": {
+		"imports": "import (\n\t\"context\"\n\t\"fmt\"\n\n\t\"gocloud.dev/blob/memblob\"\n)",
+		"code": "// Create an in-memory bucket.\nbucket := memblob.OpenBucket(nil)\ndefer bucket.Close()\n\n// Now we can use bucket to read or write files to the bucket.\nerr := bucket.WriteAll(ctx, \"my-key\", []byte(\"hello world\"), nil)\nif err != nil {\n\treturn err\n}\ndata, err := bucket.ReadAll(ctx, \"my-key\")\nif err != nil {\n\treturn err\n}\nfmt.Println(string(data))\n\n// Output:\n// hello world"
+	},
+	"gocloud.dev/blob/s3blob.Example": {
+		"imports": "import (\n\t\"context\"\n\n\t\"github.com/aws/aws-sdk-go/aws\"\n\t\"github.com/aws/aws-sdk-go/aws/session\"\n\t\"gocloud.dev/blob/s3blob\"\n)",
+		"code": "// Establish an AWS session.\n// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more info.\n// The region must match the region for \"my-bucket\".\nsess, err := session.NewSession(\u0026aws.Config{\n\tRegion: aws.String(\"us-west-1\"),\n})\nif err != nil {\n\treturn err\n}\n\n// Create a *blob.Bucket.\nbucket, err := s3blob.OpenBucket(ctx, sess, \"my-bucket\", nil)\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()"
+	},
+	"gocloud.dev/blob/s3blob.Example_openBucket": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/blob\"\n\t_ \"gocloud.dev/blob/s3blob\"\n)",
+		"code": "// OpenBucket creates a *blob.Bucket from a URL.\nbucket, err := blob.OpenBucket(ctx, \"s3://my-bucket?region=us-west-1\")\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()"
+	}
+}

--- a/internal/website/layouts/shortcodes/goexample.html
+++ b/internal/website/layouts/shortcodes/goexample.html
@@ -1,0 +1,25 @@
+{{/*
+Usage:
+
+goexample "gocloud.dev/foo.ExampleBar"
+goexample src="gocloud.dev/foo.ExampleBar"
+goexample src="gocloud.dev/foo.ExampleBar" imports="0"
+
+*/ -}}
+{{ if .IsNamedParams -}}
+  {{ with index .Site.Data.examples (.Get "src") -}}
+    {{ if and .imports (ne ($.Get "imports") "0") -}}
+      {{ highlight (printf "%s\n\n%s\n" .imports .code) "go" "" -}}
+    {{ else -}}
+      {{ highlight (printf "%s\n" .code) "go" "" -}}
+    {{ end -}}
+  {{end -}}
+{{ else -}}
+  {{ with index .Site.Data.examples (.Get 0) -}}
+    {{ if .imports -}}
+      {{ highlight (printf "%s\n\n%s\n" .imports .code) "go" "" -}}
+    {{ else -}}
+      {{ highlight (printf "%s\n" .code) "go" "" -}}
+    {{ end -}}
+  {{end -}}
+{{ end -}}


### PR DESCRIPTION
Add Hugo shortcode to read from examples.json.

I rewrote the blob godoc examples to match what was in the how-to guides. The page rendering is slightly different, but no substantive content change.

Updates #1827