### PR TITLE
dynamodocstore: reject a partial local index when selecting all fields

### DIFF
--- a/internal/docstore/dynamodocstore/query.go
+++ b/internal/docstore/dynamodocstore/query.go
@@ -171,6 +171,7 @@ func (c *collection) bestQueryable(q *driver.Query) (indexName *string, pkey, sk
 // of a query. Since DynamoDB will read explicitly provided fields from the table if
 // they are not projected into the index, the only case where a local index cannot
 // be used is when the query wants all the fields, and the index projection is not ALL.
+// See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LSI.html#LSI.Projections.
 func localFieldsIncluded(q *driver.Query, li *dynamodb.LocalSecondaryIndexDescription) bool {
 	return len(q.FieldPaths) > 0 || *li.Projection.ProjectionType == "ALL"
 }

--- a/internal/docstore/dynamodocstore/query.go
+++ b/internal/docstore/dynamodocstore/query.go
@@ -115,8 +115,9 @@ func (c *collection) planQuery(q *driver.Query) (*queryRunner, error) {
 }
 
 // Return the best choice of queryable (table or index) for this query.
-// If indexName is nil but pkey is not empty, then use the table.
-// If all return values are zero, no query will work: do a scan.
+// How to interpret the return values:
+// - If indexName is nil but pkey is not empty, then use the table.
+// - If all return values are zero, no query will work: do a scan.
 func (c *collection) bestQueryable(q *driver.Query) (indexName *string, pkey, skey string) {
 	// If the query has an "=" filter on the table's partition key, look at the table
 	// and local indexes.
@@ -129,7 +130,7 @@ func (c *collection) bestQueryable(q *driver.Query) (indexName *string, pkey, sk
 		// If one has a sort key in the query, use it.
 		for _, li := range c.description.LocalSecondaryIndexes {
 			pkey, skey := keyAttributes(li.KeySchema)
-			if hasFilter(q, skey) {
+			if hasFilter(q, skey) && localFieldsIncluded(q, li) {
 				return li.IndexName, pkey, skey
 			}
 		}
@@ -141,7 +142,7 @@ func (c *collection) bestQueryable(q *driver.Query) (indexName *string, pkey, sk
 		if skey == "" {
 			continue // We'll visit global indexes without a sort key later.
 		}
-		if hasEqualityFilter(q, pkey) && hasFilter(q, skey) && c.fieldsIncluded(q, gi) {
+		if hasEqualityFilter(q, pkey) && hasFilter(q, skey) && c.globalFieldsIncluded(q, gi) {
 			return gi.IndexName, pkey, skey
 		}
 	}
@@ -155,7 +156,7 @@ func (c *collection) bestQueryable(q *driver.Query) (indexName *string, pkey, sk
 	// Check the global indexes.
 	for _, gi := range c.description.GlobalSecondaryIndexes {
 		pkey, skey := keyAttributes(gi.KeySchema)
-		if hasEqualityFilter(q, pkey) && c.fieldsIncluded(q, gi) {
+		if hasEqualityFilter(q, pkey) && c.globalFieldsIncluded(q, gi) {
 			return gi.IndexName, pkey, skey
 		}
 	}
@@ -166,12 +167,20 @@ func (c *collection) bestQueryable(q *driver.Query) (indexName *string, pkey, sk
 	return nil, "", ""
 }
 
-// Reports whether the fields selected by the query are projected into (that is,
-// contained directly in) the global index. We need this check before using the
-// index, because if a global index doesn't have all the desired fields, then a
-// separate RPC for each returned item would be necessary to retrieve those fields,
-// and we'd rather scan than do that.
-func (c *collection) fieldsIncluded(q *driver.Query, gi *dynamodb.GlobalSecondaryIndexDescription) bool {
+// localFieldsIncluded reports whether a local index supports all the selected fields
+// of a query. Since DynamoDB will read explicitly provided fields from the table if
+// they are not projected into the index, the only case where a local index cannot
+// be used is when the query wants all the fields, and the index projection is not ALL.
+func localFieldsIncluded(q *driver.Query, li *dynamodb.LocalSecondaryIndexDescription) bool {
+	return len(q.FieldPaths) > 0 || *li.Projection.ProjectionType == "ALL"
+}
+
+// globalFieldsIncluded reports whether the fields selected by the query are
+// projected into (that is, contained directly in) the global index. We need this
+// check before using the index, because if a global index doesn't have all the
+// desired fields, then a separate RPC for each returned item would be necessary to
+// retrieve those fields, and we'd rather scan than do that.
+func (c *collection) globalFieldsIncluded(q *driver.Query, gi *dynamodb.GlobalSecondaryIndexDescription) bool {
 	proj := gi.Projection
 	if *proj.ProjectionType == "ALL" {
 		// The index has all the fields of the table: we're good.

--- a/internal/docstore/dynamodocstore/query_test.go
+++ b/internal/docstore/dynamodocstore/query_test.go
@@ -59,9 +59,11 @@ func TestPlanQuery(t *testing.T) {
 	cmpopt := cmp.AllowUnexported(dynamodb.ScanInput{}, dynamodb.QueryInput{}, dynamodb.AttributeValue{})
 
 	for _, test := range []struct {
-		desc                    string
-		tableSortKey            string
+		desc string
+		// In all cases, the table has a partition key called "tableP".
+		tableSortKey            string   // if non-empty, the table sort key
 		localIndexSortKey       string   // if non-empty, there is a local index with this sort key
+		localIndexFields        []string // the fields projected into the local index
 		globalIndexPartitionKey string   // if non-empty, there is a global index with this partition key
 		globalIndexSortKey      string   // if non-empty, the global index  has this sort key
 		globalIndexFields       []string // the fields projected into the global index
@@ -172,6 +174,48 @@ func TestPlanQuery(t *testing.T) {
 				IndexName:                aws.String("local"),
 				KeyConditionExpression:   aws.String("(#0 = :0) AND (#1 <= :1)"),
 				ExpressionAttributeNames: eans("tableP", "localS"),
+			},
+			wantPlan: `Index: "local"`,
+		},
+		{
+			desc: "equality filter on table partition, filter on local index sort, bad projection",
+			// The equality filter on the table's partition key allows us to query
+			// the table. There seems to be a better choice: a local index with a sort key
+			// that is mentioned in the query. But the query wants the entire document,
+			// and the local index only has some fields.
+			localIndexSortKey: "localS",
+			localIndexFields:  []string{}, // keys only
+			query: &driver.Query{Filters: []driver.Filter{
+				{[]string{"tableP"}, "=", 1},
+				{[]string{"localS"}, "<=", 1},
+			}},
+			want: &dynamodb.QueryInput{
+				KeyConditionExpression:   aws.String("#1 = :1"),
+				FilterExpression:         aws.String("#0 <= :0"),
+				ExpressionAttributeNames: eans("localS", "tableP"),
+			},
+			wantPlan: "Table",
+		},
+		{
+			desc: "equality filter on table partition, filter on local index sort, good projection",
+			// Same as above, but now the query no longer asks for all fields, so
+			// even though the local index's project doesn't appear to cover the
+			// selected fields (because of DocstoreRevision), DynamoDB will read the
+			// other fields from the table.
+			localIndexSortKey: "localS",
+			localIndexFields:  []string{}, // keys only
+			query: &driver.Query{
+				FieldPaths: [][]string{{"tableP"}, {"localS"}},
+				Filters: []driver.Filter{
+					{[]string{"tableP"}, "=", 1},
+					{[]string{"localS"}, "<=", 1},
+				}},
+			want: &dynamodb.QueryInput{
+				IndexName:                 aws.String("local"),
+				KeyConditionExpression:    aws.String("(#0 = :0) AND (#1 <= :1)"),
+				ExpressionAttributeNames:  eans("tableP", "localS", "DocstoreRevision"),
+				ExpressionAttributeValues: eavs(2),
+				ProjectionExpression:      aws.String("#0, #1, #2"),
 			},
 			wantPlan: `Index: "local"`,
 		},
@@ -300,27 +344,20 @@ func TestPlanQuery(t *testing.T) {
 			} else {
 				c.description.LocalSecondaryIndexes = []*dynamodb.LocalSecondaryIndexDescription{
 					{
-						IndexName: aws.String("local"),
-						KeySchema: keySchema("tableP", "localS"),
+						IndexName:  aws.String("local"),
+						KeySchema:  keySchema("tableP", test.localIndexSortKey),
+						Projection: indexProjection(test.localIndexFields),
 					},
 				}
 			}
 			if test.globalIndexPartitionKey == "" {
 				c.description.GlobalSecondaryIndexes = nil
 			} else {
-				var proj *dynamodb.Projection
-				if test.globalIndexFields == nil {
-					proj = indexProjection("ALL")
-				} else if len(test.globalIndexFields) == 0 {
-					proj = indexProjection("KEYS_ONLY")
-				} else {
-					proj = indexProjection("INCLUDE", test.globalIndexFields...)
-				}
 				c.description.GlobalSecondaryIndexes = []*dynamodb.GlobalSecondaryIndexDescription{
 					{
 						IndexName:  aws.String("global"),
 						KeySchema:  keySchema(test.globalIndexPartitionKey, test.globalIndexSortKey),
-						Projection: proj,
+						Projection: indexProjection(test.globalIndexFields),
 					},
 				}
 			}
@@ -364,7 +401,16 @@ func keySchema(pkey, skey string) []*dynamodb.KeySchemaElement {
 	}
 }
 
-func indexProjection(ptype string, fields ...string) *dynamodb.Projection {
+func indexProjection(fields []string) *dynamodb.Projection {
+	var ptype string
+	switch {
+	case fields == nil:
+		ptype = "ALL"
+	case len(fields) == 0:
+		ptype = "KEYS_ONLY"
+	default:
+		ptype = "INCLUDE"
+	}
 	proj := &dynamodb.Projection{ProjectionType: &ptype}
 	for _, f := range fields {
 		f := f
@@ -373,7 +419,7 @@ func indexProjection(ptype string, fields ...string) *dynamodb.Projection {
 	return proj
 }
 
-func TestFieldsIncluded(t *testing.T) {
+func TestGlobalFieldsIncluded(t *testing.T) {
 	c := &collection{partitionKey: "tableP", sortKey: "tableS"}
 	gi := &dynamodb.GlobalSecondaryIndexDescription{
 		KeySchema: keySchema("globalP", "globalS"),
@@ -426,13 +472,13 @@ func TestFieldsIncluded(t *testing.T) {
 				proj *dynamodb.Projection
 				want bool
 			}{
-				{"ALL", indexProjection("ALL"), true},
-				{"KEYS_ONLY", indexProjection("KEYS_ONLY"), test.wantKeysOnly},
-				{"INCLUDE", indexProjection("INCLUDE", "f", "g"), test.wantInclude},
+				{"ALL", indexProjection(nil), true},
+				{"KEYS_ONLY", indexProjection([]string{}), test.wantKeysOnly},
+				{"INCLUDE", indexProjection([]string{"f", "g"}), test.wantInclude},
 			} {
 				t.Run(p.name, func(t *testing.T) {
 					gi.Projection = p.proj
-					got := c.fieldsIncluded(q, gi)
+					got := c.globalFieldsIncluded(q, gi)
 					if got != p.want {
 						t.Errorf("got %t, want %t", got, p.want)
 					}


### PR DESCRIPTION
Unless a local index specifies ALL as its projection, it cannot in
general satisfy a query that wants all the fields of the
document. (The DynamoDB documentation claims that fields missing in a
local index are retrieved from the table, but apparently that only
applies to fields that are explicitly named in the query.)