### PR TITLE
internal/docstore/mongodocstore: add as to query

### DIFF
--- a/internal/docstore/mongodocstore/mongo.go
+++ b/internal/docstore/mongodocstore/mongo.go
@@ -23,6 +23,11 @@
 // see URLOpener.
 // See https://godoc.org/gocloud.dev#hdr-URLs for background information.
 //
+// As
+//
+// mongodocstore exposes the following types for As:
+// - DocumentIterator: *mongo.Cursor
+//
 // Docstore types not supported by the Go mongo client, go.mongodb.org/mongo-driver/mongo:
 // TODO(jba): write
 //

--- a/internal/docstore/mongodocstore/query.go
+++ b/internal/docstore/mongodocstore/query.go
@@ -105,7 +105,14 @@ func (it *docIterator) Stop() {
 	_ = it.cursor.Close(it.ctx)
 }
 
-func (it *docIterator) As(i interface{}) bool { return false }
+func (it *docIterator) As(i interface{}) bool {
+	p, ok := i.(**mongo.Cursor)
+	if !ok {
+		return false
+	}
+	*p = it.cursor
+	return true
+}
 
 func (c *collection) QueryPlan(q *driver.Query) (string, error) {
 	return "unknown", nil


### PR DESCRIPTION
Updates #1675 

Mongo doesn't have a special type for `Find`, only add `As` support for the `Cursor` type.