### PR TITLE
mongodocstore: provide an option to lowercase field names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/soheilhy/cmux v0.1.4 // indirect
 	github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94
+	github.com/tidwall/pretty v0.0.0-20190325153808-1166b9ac2b65 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	github.com/ugorji/go v1.1.1 // indirect
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/tidwall/pretty v0.0.0-20190325153808-1166b9ac2b65 h1:rQ229MBgvW68s1/g6f1/63TgYwYxfF4E+bi/KC19P8g=
+github.com/tidwall/pretty v0.0.0-20190325153808-1166b9ac2b65/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/internal/docstore/mongodocstore/codec.go
+++ b/internal/docstore/mongodocstore/codec.go
@@ -31,8 +31,8 @@ import (
 // This code is copied from memdocstore/codec.go, with some changes:
 // - special treatment for primitive.Binary
 
-func encodeDoc(doc driver.Document) (map[string]interface{}, error) {
-	var e encoder
+func encodeDoc(doc driver.Document, lowercaseFields bool) (map[string]interface{}, error) {
+	e := encoder{lowercaseFields: lowercaseFields}
 	if err := doc.Encode(&e); err != nil {
 		return nil, err
 	}
@@ -48,7 +48,8 @@ func encodeValue(x interface{}) (interface{}, error) {
 }
 
 type encoder struct {
-	val interface{}
+	val             interface{}
+	lowercaseFields bool
 }
 
 func (e *encoder) EncodeNil()                 { e.val = nil }
@@ -77,7 +78,7 @@ func (e *encoder) EncodeList(n int) driver.Encoder {
 	// All slices and arrays are encoded as []interface{}
 	s := make([]interface{}, n)
 	e.val = s
-	return &listEncoder{s: s}
+	return &listEncoder{s: s, encoder: encoder{lowercaseFields: e.lowercaseFields}}
 }
 
 type listEncoder struct {
@@ -93,15 +94,14 @@ type mapEncoder struct {
 	encoder
 }
 
-func (e *encoder) EncodeMap(n int, isStruct bool) driver.Encoder {
+func (e *encoder) EncodeMap(n int, _ bool) driver.Encoder {
 	m := make(map[string]interface{}, n)
 	e.val = m
-	return &mapEncoder{m: m, isStruct: isStruct}
+	return &mapEncoder{m: m, encoder: encoder{lowercaseFields: e.lowercaseFields}}
 }
 
 func (e *mapEncoder) MapKey(k string) {
-	// The BSON codec encodes structs by  lower-casing field names.
-	if e.isStruct {
+	if e.lowercaseFields {
 		k = strings.ToLower(k)
 	}
 	e.m[k] = e.val

--- a/internal/docstore/mongodocstore/mongo_test.go
+++ b/internal/docstore/mongodocstore/mongo_test.go
@@ -195,33 +195,6 @@ func TestOpenCollectionURL(t *testing.T) {
 	}
 }
 
-func TestIDFieldNodup(t *testing.T) {
-	must := func(err error) {
-		t.Helper()
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	ctx := context.Background()
-	client := newTestClient(t)
-	defer func() { client.Disconnect(ctx) }()
-	db := client.Database(dbName)
-	dc, err := newCollection(db.Collection("idfield"), "Name", nil, &Options{LowercaseFields: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	coll := docstore.NewCollection(dc)
-
-	must(coll.Put(ctx, map[string]interface{}{"name": 1}))
-	type S struct {
-		Name int
-		Val  string
-	}
-	must(coll.Put(ctx, &S{Name: 2, Val: "X"}))
-
-}
-
 func TestLowercaseFields(t *testing.T) {
 	// Verify that the LowercaseFields option works in all cases.
 	must := func(err error) {


### PR DESCRIPTION
Add an option to OpenCollection that causes field names to be lowercased
on encoding, and also when mentioned in actions and queries.

See #1899 for rationale.

Fixes #1899.