### PR TITLE
pubsub/azuresb: fix tests after recent drivertest changes

### DIFF
--- a/pubsub/azuresb/azuresb_test.go
+++ b/pubsub/azuresb/azuresb_test.go
@@ -223,7 +223,7 @@ func (sbAsTest) MessageCheck(m *pubsub.Message) error {
 }
 
 func (sbAsTest) BeforeSend(as func(interface{}) bool) error {
-	var m servicebus.Message
+	var m *servicebus.Message
 	if !as(&m) {
 		return fmt.Errorf("cast failed for %T", &m)
 	}


### PR DESCRIPTION
These are tests that don't run on Travis, and I must have failed to run them after making `drivertest` changes in #1787.