### PR TITLE
internal/gocdk: fix panic if ctrl-c early in gocdk serve

### DIFF
--- a/internal/cmd/gocdk/serve.go
+++ b/internal/cmd/gocdk/serve.go
@@ -191,7 +191,9 @@ loop:
 		spareAlloc, liveAlloc = liveAlloc, spareAlloc
 	}
 	logger.Println("Shutting down...")
-	endServerProcess(process)
+	if process != nil {
+		endServerProcess(process)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Before:

```
$ gocdk serve
gocdk: 2019/04/29 16:04:51 Preparing to serve dev...

[Terraform stuff omitted]

gocdk: 2019/04/29 16:04:52 Building server...
^Cgocdk: 2019/04/29 16:04:53 Build: build server: wire: signal: interrupt
gocdk: 2019/04/29 16:04:53 Shutting down...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xa0 pc=0x7acd4a]

goroutine 10 [running]:
main.endServerProcess(0x0)
	/usr/local/google/home/rvangent/go/src/github.com/google/go-cloud/internal/cmd/gocdk/serve.go:370 +0x6a
main.serveBuildLoop(0x8c87a0, 0xc00006e440, 0xc0000a81e0, 0xc00011a500, 0xc00005c320, 0xc00006e140, 0x0, 0x0)
	/usr/local/google/home/rvangent/go/src/github.com/google/go-cloud/internal/cmd/gocdk/serve.go:194 +0xadb
main.serve.func2(0x8, 0x86ef18)
	/usr/local/google/home/rvangent/go/src/github.com/google/go-cloud/internal/cmd/gocdk/serve.go:91 +0x57
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0001168a0, 0xc00006e480)
	/usr/local/google/home/rvangent/go/pkg/mod/golang.org/x/sync@v0.0.0-20190423024810-112230192c58/errgroup/errgroup.go:57 +0x57
created by golang.org/x/sync/errgroup.(*Group).Go
	/usr/local/google/home/rvangent/go/pkg/mod/golang.org/x/sync@v0.0.0-20190423024810-112230192c58/errgroup/errgroup.go:54 +0x66
$
```

After:
```
$ gocdk serve
gocdk: 2019/04/29 16:06:37 Preparing to serve dev...

[Terraform stuff omitted]

gocdk: 2019/04/29 16:06:37 Building server...
^Cgocdk: 2019/04/29 16:06:38 Build: build server: wire: signal: interrupt
gocdk: 2019/04/29 16:06:38 Shutting down...
$
```
