### PR TITLE
firedocstore: remove wrong TODO

### DIFF
--- a/internal/docstore/firedocstore/fs.go
+++ b/internal/docstore/firedocstore/fs.go
@@ -295,7 +295,6 @@ func (c *collection) runGets(ctx context.Context, gets []*driver.Action) (int, e
 			return i, gcerr.Newf(gcerr.NotFound, nil, "document at path %q is missing", path)
 		}
 		pdoc := resp.Result.(*pb.BatchGetDocumentsResponse_Found).Found
-		// TODO(jba): support field paths in decoding.
 		if err := decodeDoc(pdoc, gets[i].Doc, c.nameField); err != nil {
 			return i, err
 		}


### PR DESCRIPTION
We don't need to support field paths in decoding, because we use
the field mask in the RPC to get only the fields we want from the service.