### PR TITLE
secrets/localsecrets: error if secret material not 32 bytes

### DIFF
--- a/runtimevar/filevar/filevar_test.go
+++ b/runtimevar/filevar/filevar_test.go
@@ -268,7 +268,7 @@ func TestOpenVariableURL(t *testing.T) {
 
 func setupTestSecrets(ctx context.Context, dir, secretsPath string) (func(), error) {
 	const keeperEnv = "RUNTIMEVAR_KEEPER_URL"
-	const keeperURL = "stringkey://my-key"
+	const keeperURL = "stringkey://my-special-very-secret-secretkey"
 	oldURL := os.Getenv(keeperEnv)
 	os.Setenv(keeperEnv, keeperURL)
 	cleanup := func() { os.Setenv(keeperEnv, oldURL) }

--- a/runtimevar/runtimevar_test.go
+++ b/runtimevar/runtimevar_test.go
@@ -640,7 +640,10 @@ func TestBytesDecoder(t *testing.T) {
 
 func TestDecryptDecoder(t *testing.T) {
 	ctx := context.Background()
-	secretKey := localsecrets.ByteKey("I'm a secret string!")
+	secretKey, err := localsecrets.ThirtyTwoByteSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
 	keeper := localsecrets.NewKeeper(secretKey)
 
 	tests := []struct {

--- a/runtimevar/runtimevar_test.go
+++ b/runtimevar/runtimevar_test.go
@@ -640,7 +640,7 @@ func TestBytesDecoder(t *testing.T) {
 
 func TestDecryptDecoder(t *testing.T) {
 	ctx := context.Background()
-	secretKey, err := localsecrets.ThirtyTwoByteSecret()
+	secretKey, err := localsecrets.NewRandomKey()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/secrets/example_openkeeper_test.go
+++ b/secrets/example_openkeeper_test.go
@@ -35,7 +35,7 @@ func Example_openKeeper() {
 	// All secrets.OpenKeeper URLs also work with "secrets+" or "secrets+keeper+" prefixes,
 	// e.g., "secrets+base64key://..." or "secrets+variable+base64key://...".
 	// All secrets URLs also work with the "secrets+" prefix, e.g., "secrets+base64key://".
-	k, err := secrets.OpenKeeper(ctx, "base64key://bXktc2VjcmV0LWtleQ==")
+	k, err := secrets.OpenKeeper(ctx, "base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/secrets/example_test.go
+++ b/secrets/example_test.go
@@ -30,7 +30,7 @@ func Example() {
 
 	// Construct a *secrets.Keeper from one of the secrets subpackages.
 	// This example uses localsecrets.
-	sk, err := localsecrets.ThirtyTwoByteSecret()
+	sk, err := localsecrets.NewRandomKey()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/secrets/example_test.go
+++ b/secrets/example_test.go
@@ -30,7 +30,11 @@ func Example() {
 
 	// Construct a *secrets.Keeper from one of the secrets subpackages.
 	// This example uses localsecrets.
-	keeper := localsecrets.NewKeeper(localsecrets.ByteKey("secret key"))
+	sk, err := localsecrets.ThirtyTwoByteSecret()
+	if err != nil {
+		log.Fatal(err)
+	}
+	keeper := localsecrets.NewKeeper(sk)
 	defer keeper.Close()
 
 	// Now we can use keeper to Encrypt.

--- a/secrets/localsecrets/example_test.go
+++ b/secrets/localsecrets/example_test.go
@@ -61,7 +61,7 @@ func Example_openKeeper() {
 
 	// Using "base64key://", the URL hostname must be a base64-encoded key.
 	// The first 32 bytes of the decoding are used as the secret key.
-	keeper, err = secrets.OpenKeeper(ctx, "base64key://bXktc2VjcmV0LWtleQ==")
+	keeper, err = secrets.OpenKeeper(ctx, "base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/secrets/localsecrets/example_test.go
+++ b/secrets/localsecrets/example_test.go
@@ -26,10 +26,11 @@ import (
 func Example() {
 	// localsecrets.Keeper untilizes the golang.org/x/crypto/nacl/secretbox package
 	// for the crypto implementation, and secretbox requires a secret key
-	// that is a [32]byte. Because most users will have keys which are strings,
-	// the localsecrets package supplies a helper function to convert your key
-	// and also crop it to size, if necessary.
-	secretKey := localsecrets.ByteKey("I'm a secret string!")
+	// that is a [32]byte. localsecrets
+	secretKey, err := localsecrets.ThirtyTwoByteSecret()
+	if err != nil {
+		log.Fatal(err)
+	}
 	keeper := localsecrets.NewKeeper(secretKey)
 	defer keeper.Close()
 

--- a/secrets/localsecrets/example_test.go
+++ b/secrets/localsecrets/example_test.go
@@ -27,7 +27,7 @@ func Example() {
 	// localsecrets.Keeper untilizes the golang.org/x/crypto/nacl/secretbox package
 	// for the crypto implementation, and secretbox requires a secret key
 	// that is a [32]byte. localsecrets
-	secretKey, err := localsecrets.ThirtyTwoByteSecret()
+	secretKey, err := localsecrets.NewRandomKey()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/secrets/localsecrets/localsecrets.go
+++ b/secrets/localsecrets/localsecrets.go
@@ -81,7 +81,11 @@ func (o *URLOpener) OpenKeeperURL(ctx context.Context, u *url.URL) (*secrets.Kee
 		}
 		return NewKeeper(sk), nil
 	}
-	return NewKeeper(ByteKey(u.Host)), nil
+	sk, err := ByteKey(u.Host)
+	if err != nil {
+		return nil, err
+	}
+	return NewKeeper(sk), nil
 }
 
 // keeper holds a secret for use in symmetric encryption,
@@ -106,16 +110,39 @@ func Base64Key(base64str string) ([32]byte, error) {
 	if err != nil {
 		return sk32, err
 	}
+	keySize := len([]byte(key))
+	if keySize != 32 {
+		return sk32, fmt.Errorf("Base64Key: secret material is %v bytes, want 32 bytes", keySize)
+	}
 	copy(sk32[:], key)
 	return sk32, nil
 }
 
 // ByteKey takes a secret key as a string and converts it
-// to a [32]byte, cropping it if necessary.
-func ByteKey(sk string) [32]byte {
+// to a [32]byte, erroring if the string is not 32 bytes of data.
+func ByteKey(sk string) ([32]byte, error) {
 	var sk32 [32]byte
-	copy(sk32[:], []byte(sk))
-	return sk32
+	skb := []byte(sk)
+	keySize := len(skb)
+	if keySize != 32 {
+		return sk32, fmt.Errorf("ByteKey: secret material is %v bytes, want 32 bytes", keySize)
+	}
+	copy(sk32[:], skb)
+	return sk32, nil
+}
+
+// ThirtyTwoByteSecret will generate random secret material suitable to be
+// used as the secret key argument to NewKeeper.
+func ThirtyTwoByteSecret() ([32]byte, error) {
+	var sk32 [32]byte
+	randomBytes := make([]byte, 32)
+	// Read random numbers into the passed slice until it's full
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		return sk32, err
+	}
+	copy(sk32[:], randomBytes)
+	return sk32, nil
 }
 
 const nonceSize = 24

--- a/secrets/localsecrets/localsecrets.go
+++ b/secrets/localsecrets/localsecrets.go
@@ -103,7 +103,7 @@ func NewKeeper(sk [32]byte) *secrets.Keeper {
 }
 
 // Base64Key takes a secret key as a base64 string and converts it
-// to a [32]byte, cropping it if necessary.
+// to a [32]byte, erroring if the decoded data is not 32 bytes.
 func Base64Key(base64str string) ([32]byte, error) {
 	var sk32 [32]byte
 	key, err := base64.StdEncoding.DecodeString(base64str)
@@ -135,13 +135,11 @@ func ByteKey(sk string) ([32]byte, error) {
 // used as the secret key argument to NewKeeper.
 func ThirtyTwoByteSecret() ([32]byte, error) {
 	var sk32 [32]byte
-	randomBytes := make([]byte, 32)
-	// Read random numbers into the passed slice until it's full
-	_, err := rand.Read(randomBytes)
+	// Read random numbers into the passed slice until it's full.
+	_, err := rand.Read(sk32[:])
 	if err != nil {
 		return sk32, err
 	}
-	copy(sk32[:], randomBytes)
 	return sk32, nil
 }
 

--- a/secrets/localsecrets/localsecrets.go
+++ b/secrets/localsecrets/localsecrets.go
@@ -112,7 +112,7 @@ func Base64Key(base64str string) ([32]byte, error) {
 	}
 	keySize := len([]byte(key))
 	if keySize != 32 {
-		return sk32, fmt.Errorf("Base64Key: secret material is %v bytes, want 32 bytes", keySize)
+		return sk32, fmt.Errorf("Base64Key: secret key material is %v bytes, want 32 bytes", keySize)
 	}
 	copy(sk32[:], key)
 	return sk32, nil
@@ -125,15 +125,15 @@ func ByteKey(sk string) ([32]byte, error) {
 	skb := []byte(sk)
 	keySize := len(skb)
 	if keySize != 32 {
-		return sk32, fmt.Errorf("ByteKey: secret material is %v bytes, want 32 bytes", keySize)
+		return sk32, fmt.Errorf("ByteKey: secret key material is %v bytes, want 32 bytes", keySize)
 	}
 	copy(sk32[:], skb)
 	return sk32, nil
 }
 
-// ThirtyTwoByteSecret will generate random secret material suitable to be
+// NewRandomKey will generate random secret key material suitable to be
 // used as the secret key argument to NewKeeper.
-func ThirtyTwoByteSecret() ([32]byte, error) {
+func NewRandomKey() ([32]byte, error) {
 	var sk32 [32]byte
 	// Read random numbers into the passed slice until it's full.
 	_, err := rand.Read(sk32[:])

--- a/secrets/localsecrets/localsecrets_test.go
+++ b/secrets/localsecrets/localsecrets_test.go
@@ -28,11 +28,11 @@ import (
 type harness struct{}
 
 func (h *harness) MakeDriver(ctx context.Context) (driver.Keeper, driver.Keeper, error) {
-	secret1, err := ThirtyTwoByteSecret()
+	secret1, err := NewRandomKey()
 	if err != nil {
 		log.Fatal(err)
 	}
-	secret2, err := ThirtyTwoByteSecret()
+	secret2, err := NewRandomKey()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/secrets/localsecrets/localsecrets_test.go
+++ b/secrets/localsecrets/localsecrets_test.go
@@ -17,6 +17,7 @@ package localsecrets
 import (
 	"context"
 	"errors"
+	"log"
 	"testing"
 
 	"gocloud.dev/secrets"
@@ -27,7 +28,15 @@ import (
 type harness struct{}
 
 func (h *harness) MakeDriver(ctx context.Context) (driver.Keeper, driver.Keeper, error) {
-	return &keeper{secretKey: ByteKey("very secret secret")}, &keeper{secretKey: ByteKey("different secret")}, nil
+	secret1, err := ThirtyTwoByteSecret()
+	if err != nil {
+		log.Fatal(err)
+	}
+	secret2, err := ThirtyTwoByteSecret()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return &keeper{secretKey: secret1}, &keeper{secretKey: secret2}, nil
 }
 
 func (h *harness) Close() {}
@@ -60,13 +69,13 @@ func TestOpenKeeper(t *testing.T) {
 		WantErr bool
 	}{
 		// OK.
-		{"stringkey://my-secret", false},
+		{"stringkey://my-special-very-secret-secretkey", false},
 		// Invalid parameter.
-		{"stringkey://my-secret?param=value", true},
+		{"stringkey://my-special-very-secret-secretkey?param=value", true},
 		// OK.
-		{"base64key://bXktc2VjcmV0LWtleQ==", false},
+		{"base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=", false},
 		// Invalid parameter.
-		{"base64key://bXktc2VjcmV0LWtleQ==?param=value", true},
+		{"base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=?param=value", true},
 		// Invalid base64 key.
 		{"base64key://not-valid-base64", true},
 	}


### PR DESCRIPTION
This PR updates the `localsecrets` methods `ByteKey` and `Base64Key` to error if not given 32 bytes of secret material (measured after decoding, in the case of `Base64Key`).

It also adds a convenience method for generating 32 random bytes to use. 

fixes #1664 