### PR TITLE
pubsub/gcppubsub: refactor usage of recorder flag

### DIFF
--- a/internal/testing/replay/replay.go
+++ b/internal/testing/replay/replay.go
@@ -178,12 +178,14 @@ func scrubRecording(filepath string, dropRequestHeaders, dropResponseHeaders *re
 	return c.Save()
 }
 
-// NewGCPDialOptions return grpc.DialOptions that are to be appended to a GRPC dial request.
-// These options allow a recorder/replayer to intercept RPCs and save RPCs to the file at filename,
-// or read the RPCs from the file and return them.
-func NewGCPDialOptions(t *testing.T, mode recorder.Mode, filename string) (opts []grpc.DialOption, done func()) {
+// NewGCPDialOptions return grpc.DialOptions that are to be appended to a GRPC
+// dial request. These options allow a recorder/replayer to intercept RPCs and
+// save RPCs to the file at filename, or read the RPCs from the file and return
+// them. When recording is set to true, we're in recording mode; otherwise we're
+// in replaying mode.
+func NewGCPDialOptions(t *testing.T, recording bool, filename string) (opts []grpc.DialOption, done func()) {
 	path := filepath.Join("testdata", filename)
-	if mode == recorder.ModeRecording {
+	if recording {
 		t.Logf("Recording into golden file %s", path)
 		r, err := rpcreplay.NewRecorder(path, nil)
 		if err != nil {

--- a/internal/testing/setup/setup.go
+++ b/internal/testing/setup/setup.go
@@ -185,14 +185,9 @@ func NewGCPClient(ctx context.Context, t *testing.T) (client *gcp.HTTPClient, rt
 // Otherwise, the session reads a replay file and runs the test as a replay,
 // which never makes an outgoing RPC and uses fake credentials.
 func NewGCPgRPCConn(ctx context.Context, t *testing.T, endPoint, api string) (*grpc.ClientConn, func()) {
-	mode := recorder.ModeReplaying
-	if *Record {
-		mode = recorder.ModeRecording
-	}
-
-	opts, done := replay.NewGCPDialOptions(t, mode, t.Name()+".replay")
+	opts, done := replay.NewGCPDialOptions(t, *Record, t.Name()+".replay")
 	opts = append(opts, useragent.GRPCDialOption(api))
-	if mode == recorder.ModeRecording {
+	if *Record {
 		// Add credentials for real RPCs.
 		creds, err := gcp.DefaultCredentials(ctx)
 		if err != nil {


### PR DESCRIPTION
This is refactoring one of the last remaining uses of the `recorder` package - here used just for a flag, so I'm replacing it with a boolean.

This is currently stuck on #1972 since I can't test the recording properly (replay passes).

Updates #770 
