### PR TITLE
docstore: add a MustDocument method to simplify testing

### DIFF
--- a/internal/docstore/drivertest/drivertest.go
+++ b/internal/docstore/drivertest/drivertest.go
@@ -22,14 +22,11 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/uuid"
 	"gocloud.dev/gcerrors"
 	"gocloud.dev/internal/docstore"
 	ds "gocloud.dev/internal/docstore"
@@ -745,26 +742,6 @@ type nativeMinimal struct {
 	T  time.Time
 	LF []float64
 	LS []string
-}
-
-// MakeUniqueStringDeterministicForTesting uses a specified seed value to
-// produce the same sequence of values in driver.UniqueString for testing.
-//
-// Call when running tests that will be replayed.
-func MakeUniqueStringDeterministicForTesting(seed int64) {
-	r := &randReader{r: rand.New(rand.NewSource(seed))}
-	uuid.SetRand(r)
-}
-
-type randReader struct {
-	mu sync.Mutex
-	r  *rand.Rand
-}
-
-func (r *randReader) Read(buf []byte) (int, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.r.Read(buf)
 }
 
 // The following is the schema for the collection used for query testing.

--- a/internal/docstore/drivertest/util.go
+++ b/internal/docstore/drivertest/util.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drivertest
+
+import (
+	"math/rand"
+	"sync"
+
+	"github.com/google/uuid"
+	"gocloud.dev/internal/docstore/driver"
+)
+
+// MakeUniqueStringDeterministicForTesting uses a specified seed value to
+// produce the same sequence of values in driver.UniqueString for testing.
+//
+// Call when running tests that will be replayed.
+func MakeUniqueStringDeterministicForTesting(seed int64) {
+	r := &randReader{r: rand.New(rand.NewSource(seed))}
+	uuid.SetRand(r)
+}
+
+type randReader struct {
+	mu sync.Mutex
+	r  *rand.Rand
+}
+
+func (r *randReader) Read(buf []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.r.Read(buf)
+}
+
+// MustDocument is like driver.NewDocument, but panics on error.
+func MustDocument(doc interface{}) driver.Document {
+	dd, err := driver.NewDocument(doc)
+	if err != nil {
+		panic(err)
+	}
+	return dd
+}

--- a/internal/docstore/dynamodocstore/codec_test.go
+++ b/internal/docstore/dynamodocstore/codec_test.go
@@ -108,17 +108,9 @@ func (ct *codecTester) NativeDecode(value, dest interface{}) error {
 }
 
 func (ct *codecTester) DocstoreEncode(obj interface{}) (interface{}, error) {
-	doc, err := driver.NewDocument(obj)
-	if err != nil {
-		return nil, err
-	}
-	return encodeDoc(doc)
+	return encodeDoc(drivertest.MustDocument(obj))
 }
 
 func (ct *codecTester) DocstoreDecode(value, dest interface{}) error {
-	doc, err := driver.NewDocument(dest)
-	if err != nil {
-		return err
-	}
-	return decodeDoc(value.(*dyn.AttributeValue), doc)
+	return decodeDoc(value.(*dyn.AttributeValue), drivertest.MustDocument(dest))
 }

--- a/internal/docstore/firedocstore/codec_test.go
+++ b/internal/docstore/firedocstore/codec_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	ts "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/go-cmp/cmp"
-	"gocloud.dev/internal/docstore/driver"
+	"gocloud.dev/internal/docstore/drivertest"
 	"google.golang.org/genproto/googleapis/type/latlng"
 )
 
@@ -29,14 +29,6 @@ import (
 // These aren't tested in the docstore-wide conformance tests.
 func TestCodecSpecial(t *testing.T) {
 	const nameField = "Name"
-	mustdoc := func(x interface{}) driver.Document {
-		t.Helper()
-		doc, err := driver.NewDocument(x)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return doc
-	}
 
 	type S struct {
 		Name    string
@@ -59,12 +51,12 @@ func TestCodecSpecial(t *testing.T) {
 	}
 	var got S
 
-	enc, err := encodeDoc(mustdoc(in), nameField)
+	enc, err := encodeDoc(drivertest.MustDocument(in), nameField)
 	if err != nil {
 		t.Fatal(err)
 	}
 	enc.Name = "collPath/" + in.Name
-	gotdoc := mustdoc(&got)
+	gotdoc := drivertest.MustDocument(&got)
 	// Test type-driven decoding (where the types of the struct fields are available).
 	if err := decodeDoc(enc, gotdoc, nameField); err != nil {
 		t.Fatal(err)
@@ -75,7 +67,7 @@ func TestCodecSpecial(t *testing.T) {
 
 	// Test type-blind decoding.
 	gotmap := map[string]interface{}{}
-	gotmapdoc := mustdoc(gotmap)
+	gotmapdoc := drivertest.MustDocument(gotmap)
 	if err := decodeDoc(enc, gotmapdoc, nameField); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/docstore/firedocstore/fs_test.go
+++ b/internal/docstore/firedocstore/fs_test.go
@@ -85,26 +85,18 @@ func (c *codecTester) NativeDecode(value, dest interface{}) error {
 }
 
 func (c *codecTester) DocstoreEncode(x interface{}) (interface{}, error) {
-	doc, err := driver.NewDocument(x)
-	if err != nil {
-		return nil, err
-	}
 	var e encoder
-	if err := doc.Encode(&e); err != nil {
+	if err := drivertest.MustDocument(x).Encode(&e); err != nil {
 		return nil, err
 	}
 	return &pb.Document{Fields: e.pv.GetMapValue().Fields}, nil
 }
 
 func (c *codecTester) DocstoreDecode(value, dest interface{}) error {
-	doc, err := driver.NewDocument(dest)
-	if err != nil {
-		return err
-	}
 	mv := &pb.Value{ValueType: &pb.Value_MapValue{MapValue: &pb.MapValue{
 		Fields: value.(*pb.Document).Fields,
 	}}}
-	return doc.Decode(decoder{mv})
+	return drivertest.MustDocument(dest).Decode(decoder{mv})
 }
 
 type verifyAs struct{}

--- a/internal/docstore/firedocstore/query_test.go
+++ b/internal/docstore/firedocstore/query_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"gocloud.dev/internal/docstore/driver"
+	"gocloud.dev/internal/docstore/drivertest"
 	pb "google.golang.org/genproto/googleapis/firestore/v1"
 )
 
@@ -140,10 +141,7 @@ func TestEvaluateFilter(t *testing.T) {
 		"b":  true,
 		"mi": math.MaxInt64,
 	}
-	doc, err := driver.NewDocument(m)
-	if err != nil {
-		t.Fatal(err)
-	}
+	doc := drivertest.MustDocument(m)
 	for _, test := range []struct {
 		field, op string
 		value     interface{}

--- a/internal/docstore/memdocstore/codec_test.go
+++ b/internal/docstore/memdocstore/codec_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"gocloud.dev/internal/docstore/driver"
+	"gocloud.dev/internal/docstore/drivertest"
 )
 
 type aStruct struct {
@@ -71,10 +71,7 @@ func TestEncodeDoc(t *testing.T) {
 			},
 		},
 	} {
-		doc, err := driver.NewDocument(test.in)
-		if err != nil {
-			t.Fatal(err)
-		}
+		doc := drivertest.MustDocument(test.in)
 		got, err := encodeDoc(doc)
 		if err != nil {
 			t.Fatal(err)
@@ -128,10 +125,7 @@ func TestDecodeDoc(t *testing.T) {
 		},
 	} {
 		got := test.val
-		doc, err := driver.NewDocument(test.val)
-		if err != nil {
-			t.Fatal(err)
-		}
+		doc := drivertest.MustDocument(test.val)
 		if err := decodeDoc(test.in, doc, nil); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/docstore/mongodocstore/mongo_test.go
+++ b/internal/docstore/mongodocstore/mongo_test.go
@@ -72,11 +72,7 @@ func (codecTester) UnsupportedTypes() []drivertest.UnsupportedType {
 }
 
 func (codecTester) DocstoreEncode(x interface{}) (interface{}, error) {
-	doc, err := driver.NewDocument(x)
-	if err != nil {
-		return nil, err
-	}
-	m, err := encodeDoc(doc, true)
+	m, err := encodeDoc(drivertest.MustDocument(x), true)
 	if err != nil {
 		return nil, err
 	}
@@ -84,15 +80,11 @@ func (codecTester) DocstoreEncode(x interface{}) (interface{}, error) {
 }
 
 func (codecTester) DocstoreDecode(value, dest interface{}) error {
-	doc, err := driver.NewDocument(dest)
-	if err != nil {
-		return err
-	}
 	var m map[string]interface{}
 	if err := bson.Unmarshal(value.([]byte), &m); err != nil {
 		return err
 	}
-	return decodeDoc(m, doc, mongoIDField)
+	return decodeDoc(m, drivertest.MustDocument(dest), mongoIDField)
 }
 
 func (codecTester) NativeEncode(x interface{}) (interface{}, error) {
@@ -219,10 +211,7 @@ func TestLowercaseFields(t *testing.T) {
 	}
 
 	// driver.Document.GetField is case-insensitive on structs.
-	doc, err := driver.NewDocument(&S{ID: 1, DocstoreRevision: 1})
-	if err != nil {
-		t.Fatal(err)
-	}
+	doc := drivertest.MustDocument(&S{ID: 1, DocstoreRevision: 1})
 	for _, f := range []string{"ID", "Id", "id", "DocstoreRevision", "docstorerevision"} {
 		got, err := doc.GetField(f)
 		if err != nil {


### PR DESCRIPTION
Avoid having to deal with the error from NewDocument for tests.