### PR TITLE
internal/travis: clean up runchecks.sh

### DIFF
--- a/internal/contributebot/go.sum
+++ b/internal/contributebot/go.sum
@@ -224,6 +224,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/tidwall/pretty v0.0.0-20190325153808-1166b9ac2b65/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/uber-go/atomic v1.3.2/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=

--- a/internal/testing/listdeps.sh
+++ b/internal/testing/listdeps.sh
@@ -23,15 +23,14 @@ set -euo pipefail
 # and go 1.12; please make sure to use the same version of Go as used by Travis
 # (see .travis.yml) when updating the alldeps file.
 tmpfile=$(mktemp)
-
-for path in "." "./internal/cmd/gocdk" "./internal/contributebot" "./internal/website" "./samples/appengine"; do
-  ( cd "$path" && go list -deps -f '{{with .Module}}{{.Path}}{{end}}' ./... >> $tmpfile)
-done
-
 function cleanup() {
   rm -rf "$tmpfile"
 }
 trap cleanup EXIT
+
+for path in "." "./internal/cmd/gocdk" "./internal/contributebot" "./internal/website" "./samples/appengine"; do
+  ( cd "$path" && go list -deps -f '{{with .Module}}{{.Path}}{{end}}' ./... >> $tmpfile)
+done
 
 # Sort using the native byte values to keep results from different environment consistent.
 LC_ALL=C sort "$tmpfile" | uniq

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -150,7 +150,9 @@ wire diff ./... || {
 echo
 echo "Running Go tests for sub-modules..."
 for path in "./internal/cmd/gocdk" "./internal/contributebot" "./internal/website" "./samples/appengine"; do
+  echo "Running tests in $path..."
   ( cd "$path" && exec go test -mod=readonly ./... ) || result=1
+  echo "Running wire checks in $path..."
   ( cd "$path" && exec wire check ./... ) || result=1
   ( cd "$path" && exec wire diff ./... ) || (echo "FAIL: wire diff found diffs!" && result=1)
 done

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -17,12 +17,14 @@
 # compatibility checks, consistency checks, Wire, etc.
 
 # https://coderwall.com/p/fkfaqq/safer-bash-scripts-with-set-euxo-pipefail
-set -euxo pipefail
+# Change to -euxo if debugging.
+set -euo pipefail
 
 if [[ $# -gt 0 ]]; then
   echo "usage: runchecks.sh" 1>&2
   exit 64
 fi
+
 
 # The following logic lets us skip the (lengthy) installation process and tests
 # in some cases where the PR carries trivial changes that don't affect the code
@@ -48,25 +50,32 @@ if [[ ! -z "$TRAVIS_BRANCH" ]] && [[ ! -z "$TRAVIS_PULL_REQUEST_SHA" ]]; then
   #
   # If there are no such files, grep returns 1 and we don't have to run the
   # tests.
-  echo "Looking for files that changed"
+  echo "The following files changed:"
+  cat $tmpfile
   if grep -vP "(^internal/website|.md$)" $tmpfile; then
-    echo "Running tests"
+    echo "--> Found some non-trivial changes, running tests"
   else
-    echo "Diff doesn't affect tests; not running them"
+    echo "--> Diff doesn't affect tests; not running them"
     exit 0
   fi
 fi
+
 
 # start_local_deps.sh requires that Docker is installed, via Travis services,
 # which are only supported on Linux.
 # Without the dependencies running, tests that depend on them are skipped.
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  echo
+  echo "Starting local dependencies..."
   ./internal/testing/start_local_deps.sh
 fi
+
 
 # Run Go tests for the root. Only do coverage for the Linux build
 # because it is slow, and codecov will only save the last one anyway.
 result=0
+echo
+echo "Running Go tests..."
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   go test -mod=readonly -race -coverpkg=./... -coverprofile=coverage.out ./... || result=1
   if [ -f coverage.out ] && [ $result -eq 0 ]; then
@@ -81,29 +90,30 @@ else
   exit $result
 fi
 
-# Ensure .go files are formatted with "gofmt -s".
+
+echo
+echo "Ensuring .go files are formatted with gofmt -s..."
 DIFF=$(gofmt -s -d `find . -name '*.go' -type f`)
 if [ -n "$DIFF" ]; then
-  echo "Please run gofmt -s and commit the result"
+  echo "FAIL: please run gofmt -s and commit the result"
   echo "$DIFF";
   exit 1;
 fi;
 
-# Ensure that the code has no extra dependencies (including transitive
-# dependencies) that we're not already aware of by comparing with
-# ./internal/testing/alldeps
-#
-# Whenever project dependencies change, rerun ./internal/testing/listdeps.sh
-#
-# Run this only on the latest version of Go, since module behavior may differ
-# across versions.
+
+echo
+echo "Ensuring that there are no dependencies not listed in ./internal/testing/alldeps..."
 if [[ $(go version) == *1\.12* ]]; then
   ./internal/testing/listdeps.sh | diff ./internal/testing/alldeps - || {
-    echo "FAIL: dependencies changed; compare listdeps.sh output with alldeps" && result=1
+    echo "FAIL: dependencies changed; run: internal/testing/listdeps.sh > internal/testing/alldeps" && result=1
+    # Module behavior may differ across versions.
+    echo "using go version 1.12."
   }
 fi
 
-# Ensure that any new packages have the corresponding entries in Hugo.
+
+echo
+echo "Ensuring that any new packages have the corresponding entries in Hugo..."
 missing_packages="$(internal/website/listnewpkgs.sh)"
 if ! [[ -z "$missing_packages" ]]; then
   echo "FAIL: missing package meta tags for:" 1>&2
@@ -111,23 +121,34 @@ if ! [[ -z "$missing_packages" ]]; then
   result=1
 fi
 
-# Ensure that all examples used in Hugo match what's in source.
+
+echo
+echo "Ensuring that all examples used in Hugo match what's in source..."
 internal/website/gatherexamples/run.sh | diff internal/website/data/examples.json - > /dev/null || {
   echo "FAIL: examples changed; run: internal/website/gatherexamples/run.sh > internal/website/data/examples.json"
+  result=1
 }
 
 # For pull requests, check if there are undeclared incompatible API changes.
 # Skip this if we're already going to fail since it is expensive.
 if [[ ${result} -eq 0 ]] && [[ ! -z "$TRAVIS_BRANCH" ]] && [[ ! -z "$TRAVIS_PULL_REQUEST_SHA" ]]; then
+  echo
   ./internal/testing/check_api_change.sh || result=1;
 fi
 
+
+echo
+echo "Checking for wire problems or diffs..."
 go install -mod=readonly github.com/google/wire/cmd/wire
 wire check ./... || result=1
 # "wire diff" fails with exit code 1 if any diffs are detected.
-wire diff ./... || { echo "FAIL: wire diff found diffs!" && result=1; }
+wire diff ./... || {
+  echo "FAIL: wire diff found diffs!";
+  result=1;
+}
 
-# Run Go tests for each additional module, without coverage.
+echo
+echo "Running Go tests for sub-modules..."
 for path in "./internal/cmd/gocdk" "./internal/contributebot" "./internal/website" "./samples/appengine"; do
   ( cd "$path" && exec go test -mod=readonly ./... ) || result=1
   ( cd "$path" && exec wire check ./... ) || result=1


### PR DESCRIPTION
Removes the `-x` bash command so that we no longer echo every command, and inserts some explicit `echo`s to keep track of what's going on. IMHO this makes the output a lot more readable.