### PR TITLE
docstore: relax the error semantics of unordered action lists

### DIFF
--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -243,13 +243,17 @@ func (l *ActionList) BeforeDo(f func(asFunc func(interface{}) bool) error) *Acti
 //
 // If Do returns a non-nil error, it will be of type ActionListError. If any action
 // fails, the returned error will contain the position in the ActionList of each
-// failed action. As a special case, none of the actions will be executed if any is
-// invalid (for example, a Put whose document is missing its key field).
+// failed action (but see the discussion of unordered mode, below). As a special
+// case, none of the actions will be executed if any is invalid (for example, a Put
+// whose document is missing its key field).
 //
 // In ordered mode (when the Unordered method was not called on the list), execution
 // will stop after the first action that fails.
 //
-// In unordered mode, all the actions will be executed.
+// In unordered mode, all the actions will be executed. Docstore tries to execute the
+// actions as efficiently as possible. Sometimes this makes it impossible to
+// attribute failures to specific actions; in such cases, the returned
+// ActionListError will have entries whose Index field is negative.
 func (l *ActionList) Do(ctx context.Context) error {
 	var das []*driver.Action
 	var alerr ActionListError


### PR DESCRIPTION
Don't insist that failures be attributed to specific actions. This
lets us use the MongoDB BulkWrite RPC for unordered action lists,
which is significantly faster than running the individual RPCs
concurrently.

See #1999.