### PR TITLE
internal/website/content: add concept guide for URLs

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -23,7 +23,7 @@
 // AZURE_STORAGE_ACCOUNT is required, along with one of the other two.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // Escaping
 //

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -40,7 +40,7 @@
 // for managing your initialization code.
 //
 // Alternatively, you can construct a *Bucket via a URL and OpenBucket.
-// See https://godoc.org/gocloud.dev#hdr-URLs for more information.
+// See https://gocloud.dev/concepts/urls/ for more information.
 //
 //
 // Errors
@@ -1006,7 +1006,7 @@ type BucketURLOpener interface {
 // URLMux is a URL opener multiplexer. It matches the scheme of the URLs
 // against a set of registered schemes and calls the opener that matches the
 // URL's scheme.
-// See https://godoc.org/gocloud.dev#hdr-URLs for more information.
+// See https://gocloud.dev/concepts/urls/ for more information.
 //
 // The zero value is a multiplexer with no registered schemes.
 type URLMux struct {
@@ -1056,7 +1056,7 @@ func DefaultURLMux() *URLMux {
 
 // OpenBucket opens the bucket identified by the URL given.
 // See the URLOpener documentation in provider-specific subpackages for
-// details on supported URL formats, and https://godoc.org/gocloud.dev#hdr-URLs
+// details on supported URL formats, and https://gocloud.dev/concepts/urls/
 // for more information.
 func OpenBucket(ctx context.Context, urlstr string) (*Bucket, error) {
 	return defaultURLMux.OpenBucket(ctx, urlstr)

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -20,7 +20,7 @@
 // For blob.OpenBucket, fileblob registers for the scheme "file".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // Escaping
 //

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -23,7 +23,7 @@
 // https://cloud.google.com/docs/authentication/production.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // Escaping
 //

--- a/blob/memblob/memblob.go
+++ b/blob/memblob/memblob.go
@@ -20,7 +20,7 @@
 // For blob.OpenBucket memblob registers for the scheme "mem".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -23,7 +23,7 @@
 // for more details.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // Escaping
 //

--- a/doc.go
+++ b/doc.go
@@ -37,51 +37,7 @@ For non-reference documentation, see https://gocloud.dev/
 
 URLs
 
-In addition to creating portable types via provider-specific constructors
-(e.g., creating a blob.Bucket using s3blob.OpenBucket), many portable types
-can also be created using a URL. The scheme of the URL specifies the provider,
-and each provider implementation has code to convert the URL into the data
-needed to call its constructor. For example, calling blob.OpenBucket with
-s3blob://my-bucket will return a blob.Bucket created using s3blob.OpenBucket.
-
-Each portable API package will document the types that it supports opening
-by URL; for example, the blob package supports Buckets, while the pubsub
-package supports Topics and Subscriptions. Each provider implementation will
-document what scheme(s) it registers for, and what format of URL it expects.
-
-Each portable type URL opener will accept URL schemes with an <api>+ prefix
-(e.g., blob+file:///dir" instead of "file:///dir", as well as schemes with an
-<api>+<type>+ prefix (e.g., blob+bucket+file:///dir).
-
-Each portable API package should include an example using a URL, and
-many providers will include provider-specific examples as well.
-
-
-URL Muxes
-
-Each portable type that's openable via URL will have a top-level function
-you can call, like blob.OpenBucket. This top-level function uses a default
-instance of an URLMux multiplexer to map schemes to a provider-specific
-opener for the type. For example, blob has a BucketURLOpener interface that
-providers implement and then register using RegisterBucket.
-
-Many applications will work just fine using the default mux through the
-top-level Open functions. However, if you want more control, you can create
-your own URLMux and register the provider URLOpeners you need. Most providers
-will export URLOpeners that give you more fine grained control over the
-arguments needed by the constructor. In particular, portable types opened via
-URL will often use default credentials from the environment. For example, the
-AWS URL openers use the credentials saved by "aws login" (we don't want to
-include credentials in the URL itself, since they are likely to be sensitive).
-
-  - Instantiate the provider's URLOpener with the specific fields you need.
-    For example, s3blob.URLOpener{ConfigProvider: myAWSProvider} using a
-    ConfigProvider that holds explicit AWS credentials.
-  - Create your own instance of the URLMux, e.g., mymux := new(blob.URLMux).
-  - Register your custom URLOpener on your mux, e.g.,
-    mymux.RegisterBucket(s3blob.Scheme, myS3URLOpener).
-  - Now use your mux to open URLs, e.g. mymux.OpenBucket('s3://my-bucket').
-
+See https://gocloud.dev/concepts/urls/ for a discussion of URLs in the Go CDK.
 
 Escaping the abstraction
 

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -417,7 +417,7 @@ type CollectionURLOpener interface {
 
 // URLMux is a URL opener multiplexer. It matches the scheme of the URLs against
 // a set of registered schemes and calls the opener that matches the URL's
-// scheme. See https://godoc.org/gocloud.dev#hdr-URLs for more information.
+// scheme. See https://gocloud.dev/concepts/urls/ for more information.
 //
 // The zero value is a multiplexer with no registered scheme.
 type URLMux struct {
@@ -467,7 +467,7 @@ func DefaultURLMux() *URLMux {
 
 // OpenCollection opens the collection identified by the URL given.
 // See the URLOpener documentation in provider-specific subpackages for details
-// on supported URL formats, and https://godoc.org/gocloud.dev#hdr-URLs for more
+// on supported URL formats, and https://gocloud.dev/concepts/urls/ for more
 // information.
 func OpenCollection(ctx context.Context, urlstr string) (*Collection, error) {
 	return defaultURLMux.OpenCollection(ctx, urlstr)

--- a/internal/docstore/dynamodocstore/dynamo.go
+++ b/internal/docstore/dynamodocstore/dynamo.go
@@ -24,7 +24,7 @@
 // https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more details.
 // To customize the URL opener, or for more details on the URL format, see
 // URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/internal/docstore/firedocstore/fs.go
+++ b/internal/docstore/firedocstore/fs.go
@@ -25,7 +25,7 @@
 // https://cloud.google.com/docs/authentication/production.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/internal/docstore/memdocstore/mem.go
+++ b/internal/docstore/memdocstore/mem.go
@@ -31,7 +31,7 @@
 // "mem".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 package memdocstore // import "gocloud.dev/internal/docstore/memdocstore"
 
 import (

--- a/internal/docstore/mongodocstore/mongo.go
+++ b/internal/docstore/mongodocstore/mongo.go
@@ -21,7 +21,7 @@
 // variable "MONGO_SERVER_URL".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/internal/website/content/concepts/_index.md
+++ b/internal/website/content/concepts/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Concepts"
+date: 2019-05-06T09:52:00-07:00
+showInSidenav: true
+pagesInSidenav: true
+weight: 4
+---
+
+The documents in this section describe higher level concepts in the Go CDK.

--- a/internal/website/content/concepts/urls.md
+++ b/internal/website/content/concepts/urls.md
@@ -1,0 +1,60 @@
+---
+title: "URLs"
+date: 2019-05-06T09:55:09-07:00
+---
+
+In addition to creating portable types via provider-specific constructors
+(e.g., creating a `*blob.Bucket` using [`s3blob.OpenBucket`][]), many portable types
+can also be created using a URL. The scheme of the URL specifies the provider,
+and each provider implementation has code to convert the URL into the data
+needed to call its constructor. For example, calling
+`blob.OpenBucket("s3blob://my-bucket")` will return a `*blob.Bucket` created
+using [`s3blob.OpenBucket`][].
+
+[`s3blob.OpenBucket`]: https://godoc.org/gocloud.dev/blob/s3blob#OpenBucket
+
+<!--more-->
+
+Each portable API package will document the types that it supports opening
+by URL. For example, the `blob` package supports `Bucket`s, while the `pubsub`
+package supports `Topic`s and `Subscription`s. Each provider implementation will
+document what scheme(s) it registers for, and what format of URL it expects.
+
+Each portable type URL opener will accept URL schemes with an `<api>+` prefix
+(e.g. `blob+file:///dir` instead of `file:///dir`, as well as schemes with an
+`<api>+<type>+` prefix (e.g. `blob+bucket+file:///dir`).
+
+Each portable API package should include an example using a URL, and
+many providers will include provider-specific examples as well.
+
+## Muxes
+
+Each portable type that is openable via URL will have a top-level function
+you can call, like [`blob.OpenBucket`][]. This top-level function uses a default
+instance of a `URLMux` multiplexer to map schemes to a provider-specific
+opener for the type. For example, `blob` has a [`BucketURLOpener`][] interface
+that providers implement and then register using [`RegisterBucket`][] on the
+result of [`DefaultURLMux`][].
+
+Many applications will work just fine using the default mux through the
+top-level `Open` functions. However, if you want more control, you can create
+your own `URLMux` and register the provider `URLOpener`s you need. Most
+providers will export URLOpeners that give you more fine grained control over
+the arguments needed by the constructor. In particular, portable types opened
+via URL will often use default credentials from the environment. For example,
+the AWS URL openers use the credentials saved by "aws login" (we don't want
+to include credentials in the URL itself, since they are likely to be
+sensitive).
+
+1. Instantiate the provider's `URLOpener` with the specific fields you need.
+   For example, `s3blob.URLOpener{ConfigProvider: myAWSProvider}` using a
+   `ConfigProvider` that holds explicit AWS credentials.
+2. Create your own instance of the `URLMux`. For example: `mymux := new(blob.URLMux)`
+3. Register your custom URLOpener on your mux. For example:
+   `mymux.RegisterBucket(s3blob.Scheme, myS3URLOpener)`
+4. Now use your mux to open URLs: `mymux.OpenBucket("s3://my-bucket")`
+
+[`blob.OpenBucket`]: https://godoc.org/gocloud.dev/blob#OpenBucket
+[`BucketURLOpener`]: https://godoc.org/gocloud.dev/blob#BucketURLOpener
+[`DefaultURLMux`]: https://godoc.org/gocloud.dev/blob#DefaultURLMux
+[`RegisterBucket`]: https://godoc.org/gocloud.dev/blob#URLMux.RegisterBucket

--- a/internal/website/content/howto/blob/open-bucket.md
+++ b/internal/website/content/howto/blob/open-bucket.md
@@ -24,7 +24,7 @@ import"][] the driver package to link it in. See the
 both forms for each storage provider.
 
 ["blank import"]: https://golang.org/doc/effective_go.html#blank_import
-[documentation on URLs]: https://godoc.org/gocloud.dev#hdr-URLs
+[documentation on URLs]: {{< ref "/concepts/urls.md" >}}
 
 ## S3 {#s3}
 

--- a/internal/website/content/howto/pubsub/publish.md
+++ b/internal/website/content/howto/pubsub/publish.md
@@ -34,7 +34,7 @@ import"][] the driver package to link it in. See the
 both forms for each pub/sub provider.
 
 ["blank import"]: https://golang.org/doc/effective_go.html#blank_import
-[documentation on URLs]: https://godoc.org/gocloud.dev#hdr-URLs
+[documentation on URLs]: {{< ref "/concepts/urls.md" >}}
 
 ## Amazon Simple Notification Service {#sns}
 

--- a/internal/website/content/howto/pubsub/subscribe.md
+++ b/internal/website/content/howto/pubsub/subscribe.md
@@ -42,7 +42,7 @@ on configuration, you can use `pubsub.OpenSubscription`, making sure you
 both forms for each pub/sub provider.
 
 ["blank import"]: https://golang.org/doc/effective_go.html#blank_import
-[documentation on URLs]: https://godoc.org/gocloud.dev#hdr-URLs
+[documentation on URLs]: {{< ref "/concepts/urls.md" >}}
 
 ## Amazon Simple Queueing Service {#sqs}
 

--- a/internal/website/content/howto/secrets/open-keeper.md
+++ b/internal/website/content/howto/secrets/open-keeper.md
@@ -23,7 +23,7 @@ based on configuration, you can use `secrets.OpenKeeper`, making sure you
 both forms for each secret keeper provider.
 
 ["blank import"]: https://golang.org/doc/effective_go.html#blank_import
-[documentation on URLs]: https://godoc.org/gocloud.dev#hdr-URLs
+[documentation on URLs]: {{< ref "/concepts/urls.md" >}}
 
 ## AWS Key Management Service
 

--- a/mysql/rdsmysql/rdsmysql.go
+++ b/mysql/rdsmysql/rdsmysql.go
@@ -23,7 +23,7 @@
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
 //
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 package rdsmysql // import "gocloud.dev/mysql/rdsmysql"
 
 import (

--- a/postgres/cloudpostgres/cloudpostgres.go
+++ b/postgres/cloudpostgres/cloudpostgres.go
@@ -24,7 +24,7 @@
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
 //
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 package cloudpostgres // import "gocloud.dev/postgres/cloudpostgres"
 
 import (

--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -24,7 +24,7 @@
 // for more details.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // Message Delivery Semantics
 //

--- a/pubsub/azuresb/azuresb.go
+++ b/pubsub/azuresb/azuresb.go
@@ -24,7 +24,7 @@
 // the environment variable "SERVICEBUS_CONNECTION_STRING".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // Message Delivery Semantics
 //

--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -25,7 +25,7 @@
 // https://cloud.google.com/docs/authentication/production.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // Message Delivery Semantics
 //

--- a/pubsub/kafkapubsub/kafka.go
+++ b/pubsub/kafkapubsub/kafka.go
@@ -32,7 +32,7 @@
 // set of server addresses.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // Escaping
 //

--- a/pubsub/mempubsub/mem.go
+++ b/pubsub/mempubsub/mem.go
@@ -25,7 +25,7 @@
 // for the scheme "mem".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // Message Delivery Semantics
 //

--- a/pubsub/natspubsub/nats.go
+++ b/pubsub/natspubsub/nats.go
@@ -25,7 +25,7 @@
 // environment variable "NATS_SERVER_URL".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // Message Delivery Semantics
 //

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -34,7 +34,7 @@
 //
 // Alternatively, you can construct a *Topic/*Subscription via a URL and
 // OpenTopic/OpenSubscription.
-// See https://godoc.org/gocloud.dev#hdr-URLs for more information.
+// See https://gocloud.dev/concepts/urls/ for more information.
 //
 // At-most-once and At-least-once Delivery
 //
@@ -864,7 +864,7 @@ type SubscriptionURLOpener interface {
 // URLMux is a URL opener multiplexer. It matches the scheme of the URLs
 // against a set of registered schemes and calls the opener that matches the
 // URL's scheme.
-// See https://godoc.org/gocloud.dev#hdr-URLs for more information.
+// See https://gocloud.dev/concepts/urls/ for more information.
 //
 // The zero value is a multiplexer with no registered schemes.
 type URLMux struct {
@@ -950,7 +950,7 @@ func DefaultURLMux() *URLMux {
 
 // OpenTopic opens the Topic identified by the URL given.
 // See the URLOpener documentation in provider-specific subpackages for
-// details on supported URL formats, and https://godoc.org/gocloud.dev#hdr-URLs
+// details on supported URL formats, and https://gocloud.dev/concepts/urls
 // for more information.
 func OpenTopic(ctx context.Context, urlstr string) (*Topic, error) {
 	return defaultURLMux.OpenTopic(ctx, urlstr)
@@ -958,7 +958,7 @@ func OpenTopic(ctx context.Context, urlstr string) (*Topic, error) {
 
 // OpenSubscription opens the Subscription identified by the URL given.
 // See the URLOpener documentation in provider-specific subpackages for
-// details on supported URL formats, and https://godoc.org/gocloud.dev#hdr-URLs
+// details on supported URL formats, and https://gocloud.dev/concepts/urls
 // for more information.
 func OpenSubscription(ctx context.Context, urlstr string) (*Subscription, error) {
 	return defaultURLMux.OpenSubscription(ctx, urlstr)

--- a/pubsub/rabbitpubsub/doc.go
+++ b/pubsub/rabbitpubsub/doc.go
@@ -33,7 +33,7 @@
 // environment variable "RABBIT_SERVER_URL".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // Message Delivery Semantics
 //

--- a/runtimevar/awsparamstore/awsparamstore.go
+++ b/runtimevar/awsparamstore/awsparamstore.go
@@ -25,7 +25,7 @@
 // for more details.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/runtimevar/blobvar/blobvar.go
+++ b/runtimevar/blobvar/blobvar.go
@@ -23,7 +23,7 @@
 // variable "BLOBVAR_BUCKET_URL".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/runtimevar/constantvar/constantvar.go
+++ b/runtimevar/constantvar/constantvar.go
@@ -20,7 +20,7 @@
 //
 // For runtimevar.OpenVariable, constantvar registers for the scheme "constant".
 // For more details on the URL format, see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/runtimevar/etcdvar/etcdvar.go
+++ b/runtimevar/etcdvar/etcdvar.go
@@ -22,7 +22,7 @@
 // variable "ETCD_SERVER_URL".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/runtimevar/filevar/filevar.go
+++ b/runtimevar/filevar/filevar.go
@@ -31,7 +31,7 @@
 // For runtimevar.OpenVariable, filevar registers for the scheme "file".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/runtimevar/gcpruntimeconfig/gcpruntimeconfig.go
+++ b/runtimevar/gcpruntimeconfig/gcpruntimeconfig.go
@@ -26,7 +26,7 @@
 // https://cloud.google.com/docs/authentication/production.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/runtimevar/httpvar/httpvar.go
+++ b/runtimevar/httpvar/httpvar.go
@@ -21,7 +21,7 @@
 // "https". The default URL opener will use http.DefaultClient.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -39,7 +39,7 @@
 // return a value without blocking.
 //
 // Alternatively, you can construct a *Variable via a URL and OpenVariable.
-// See https://godoc.org/gocloud.dev#hdr-URLs for more information.
+// See https://gocloud.dev/concepts/urls/ for more information.
 //
 //
 // OpenCensus Integration
@@ -365,7 +365,7 @@ type VariableURLOpener interface {
 // URLMux is a URL opener multiplexer. It matches the scheme of the URLs
 // against a set of registered schemes and calls the opener that matches the
 // URL's scheme.
-// See https://godoc.org/gocloud.dev#hdr-URLs for more information.
+// See https://gocloud.dev/concepts/urls/ for more information.
 //
 // The zero value is a multiplexer with no registered schemes.
 type URLMux struct {
@@ -415,7 +415,7 @@ func DefaultURLMux() *URLMux {
 
 // OpenVariable opens the variable identified by the URL given.
 // See the URLOpener documentation in provider-specific subpackages for
-// details on supported URL formats, and https://godoc.org/gocloud.dev#hdr-URLs
+// details on supported URL formats, and https://gocloud.dev/concepts/urls
 // for more information.
 func OpenVariable(ctx context.Context, urlstr string) (*Variable, error) {
 	return defaultURLMux.OpenVariable(ctx, urlstr)

--- a/samples/gocdk-blob/main.go
+++ b/samples/gocdk-blob/main.go
@@ -36,7 +36,7 @@ import (
 
 const helpSuffix = `
 
-  See https://godoc.org/gocloud.dev#hdr-URLs for more background on
+  See https://gocloud.dev/concepts/urls/ for more background on
   Go CDK URLs, and sub-packages under gocloud.dev/blob
   (https://godoc.org/gocloud.dev/blob#pkg-subdirectories)
   for details on the blob.Bucket URL format.

--- a/samples/gocdk-pubsub/main.go
+++ b/samples/gocdk-pubsub/main.go
@@ -38,7 +38,7 @@ import (
 
 const helpSuffix = `
 
-  See https://godoc.org/gocloud.dev#hdr-URLs for more background on
+  See https://gocloud.dev/concepts/urls/ for more background on
   Go CDK URLs, and sub-packages under gocloud.dev/pubsub
   (https://godoc.org/gocloud.dev/pubsub#pkg-subdirectories)
   for details on the topic/subscription URL format.

--- a/samples/gocdk-runtimevar/main.go
+++ b/samples/gocdk-runtimevar/main.go
@@ -38,7 +38,7 @@ import (
 
 const helpSuffix = `
 
-  See https://godoc.org/gocloud.dev#hdr-URLs for more background on
+  See https://gocloud.dev/concepts/urls/ for more background on
   Go CDK URLs, and sub-packages under gocloud.dev/runtimevar
   (https://godoc.org/gocloud.dev/runtimevar#pkg-subdirectories)
   for details on the runtimevar.Variable URL format.

--- a/samples/gocdk-secrets/main.go
+++ b/samples/gocdk-secrets/main.go
@@ -37,7 +37,7 @@ import (
 
 const helpSuffix = `
 
-  See https://godoc.org/gocloud.dev#hdr-URLs for more background on
+  See https://gocloud.dev/concepts/urls/ for more background on
   Go CDK URLs, and sub-packages under gocloud.dev/secrets
   (https://godoc.org/gocloud.dev/secrets#pkg-subdirectories)
   for details on the secrets.Keeper URL format.

--- a/secrets/awskms/kms.go
+++ b/secrets/awskms/kms.go
@@ -23,7 +23,7 @@
 // for more details.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/secrets/azurekeyvault/akv.go
+++ b/secrets/azurekeyvault/akv.go
@@ -23,7 +23,7 @@
 // environment.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/secrets/gcpkms/kms.go
+++ b/secrets/gcpkms/kms.go
@@ -23,7 +23,7 @@
 // https://cloud.google.com/docs/authentication/production.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/secrets/localsecrets/localsecrets.go
+++ b/secrets/localsecrets/localsecrets.go
@@ -21,7 +21,7 @@
 // For secrets.OpenKeeper, localsecrets registers for the scheme "base64key".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -33,7 +33,7 @@
 // for managing your initialization code.
 //
 // Alternatively, you can construct a *Keeper via a URL and OpenKeeper.
-// See https://godoc.org/gocloud.dev#hdr-URLs for more information.
+// See https://gocloud.dev/concepts/urls/ for more information.
 //
 //
 // OpenCensus Integration
@@ -191,7 +191,7 @@ type KeeperURLOpener interface {
 // URLMux is a URL opener multiplexer. It matches the scheme of the URLs
 // against a set of registered schemes and calls the opener that matches the
 // URL's scheme.
-// See https://godoc.org/gocloud.dev#hdr-URLs for more information.
+// See https://gocloud.dev/concepts/urls/ for more information.
 //
 // The zero value is a multiplexer with no registered schemes.
 type URLMux struct {
@@ -241,7 +241,7 @@ func DefaultURLMux() *URLMux {
 
 // OpenKeeper opens the Keeper identified by the URL given.
 // See the URLOpener documentation in provider-specific subpackages for
-// details on supported URL formats, and https://godoc.org/gocloud.dev#hdr-URLs
+// details on supported URL formats, and https://gocloud.dev/concepts/urls
 // for more information.
 func OpenKeeper(ctx context.Context, urlstr string) (*Keeper, error) {
 	return defaultURLMux.OpenKeeper(ctx, urlstr)

--- a/secrets/vault/vault.go
+++ b/secrets/vault/vault.go
@@ -23,7 +23,7 @@
 // variables "VAULT_SERVER_URL" and "VAULT_SERVER_TOKEN".
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
-// See https://godoc.org/gocloud.dev#hdr-URLs for background information.
+// See https://gocloud.dev/concepts/urls/ for background information.
 //
 // As
 //


### PR DESCRIPTION
Using the same content as was in the package godoc with minimal formatting changes.

Updates #1469