### PR TITLE
all: run Docker dependent tests whenever possible

### DIFF
--- a/internal/docstore/mongodocstore/mongo_test.go
+++ b/internal/docstore/mongodocstore/mongo_test.go
@@ -30,6 +30,7 @@ import (
 	"gocloud.dev/internal/docstore"
 	"gocloud.dev/internal/docstore/driver"
 	"gocloud.dev/internal/docstore/drivertest"
+	"gocloud.dev/internal/testing/setup"
 )
 
 const (
@@ -136,6 +137,9 @@ func TestConformance(t *testing.T) {
 }
 
 func newTestClient(t *testing.T) *mongo.Client {
+	if !setup.RunTestsDependingOnDocker() {
+		t.Skip("Skipping Mongo tests since the Mongo server is not available")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	client, err := Dial(ctx, serverURI)
@@ -143,9 +147,6 @@ func newTestClient(t *testing.T) *mongo.Client {
 		t.Fatalf("dialing to %s: %v", serverURI, err)
 	}
 	if err := client.Ping(ctx, nil); err != nil {
-		if err == context.DeadlineExceeded {
-			t.Skip("could not connect to local mongoDB server (connection timed out)")
-		}
 		t.Fatalf("connecting to %s: %v", serverURI, err)
 	}
 	return client

--- a/internal/docstore/mongodocstore/mongo_test.go
+++ b/internal/docstore/mongodocstore/mongo_test.go
@@ -137,7 +137,7 @@ func TestConformance(t *testing.T) {
 }
 
 func newTestClient(t *testing.T) *mongo.Client {
-	if !setup.RunTestsDependingOnDocker() {
+	if !setup.HasDockerTestEnvironment() {
 		t.Skip("Skipping Mongo tests since the Mongo server is not available")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -63,7 +63,7 @@ fi
 
 # start_local_deps.sh requires that Docker is installed, via Travis services,
 # which are only supported on Linux.
-# Without the dependencies running, tests that depend on them are skipped.
+# Tests that depend on them should check the Travis environment before running.
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   echo
   echo "Starting local dependencies..."

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -77,7 +77,7 @@ result=0
 echo
 echo "Running Go tests..."
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  go test -v -mod=readonly -race -coverpkg=./... -coverprofile=coverage.out ./... || result=1
+  go test -mod=readonly -race -coverpkg=./... -coverprofile=coverage.out ./... || result=1
   if [ -f coverage.out ] && [ $result -eq 0 ]; then
     # Filter out test and sample packages.
     grep -v test coverage.out | grep -v samples > coverage2.out
@@ -85,7 +85,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     bash <(curl -s https://codecov.io/bash)
   fi
 else
-  go test -v -mod=readonly -race ./... || result=1
+  go test -mod=readonly -race ./... || result=1
   # No need to run other checks on OSs other than linux.
   exit $result
 fi

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -77,7 +77,7 @@ result=0
 echo
 echo "Running Go tests..."
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  go test -mod=readonly -race -coverpkg=./... -coverprofile=coverage.out ./... || result=1
+  go test -v -mod=readonly -race -coverpkg=./... -coverprofile=coverage.out ./... || result=1
   if [ -f coverage.out ] && [ $result -eq 0 ]; then
     # Filter out test and sample packages.
     grep -v test coverage.out | grep -v samples > coverage2.out

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -85,7 +85,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     bash <(curl -s https://codecov.io/bash)
   fi
 else
-  go test -mod=readonly -race ./... || result=1
+  go test -v -mod=readonly -race ./... || result=1
   # No need to run other checks on OSs other than linux.
   exit $result
 fi

--- a/internal/testing/setup/setup.go
+++ b/internal/testing/setup/setup.go
@@ -334,3 +334,11 @@ func NewGCPDialOptions(t *testing.T, recording bool, filename string) (opts []gr
 	}
 	return opts, done
 }
+
+// RunTestsDependingOnDocker returns true when either:
+// 1) Not on Travis.
+// 2) On Travis Linux environment, where Docker is available.
+func RunTestsDependingOnDocker() bool {
+	s := os.Getenv("TRAVIS_OS_NAME")
+	return s == "" || s == "linux"
+}

--- a/internal/testing/setup/setup.go
+++ b/internal/testing/setup/setup.go
@@ -335,10 +335,10 @@ func NewGCPDialOptions(t *testing.T, recording bool, filename string) (opts []gr
 	return opts, done
 }
 
-// RunTestsDependingOnDocker returns true when either:
+// HasDockerTestEnvironment returns true when either:
 // 1) Not on Travis.
 // 2) On Travis Linux environment, where Docker is available.
-func RunTestsDependingOnDocker() bool {
+func HasDockerTestEnvironment() bool {
 	s := os.Getenv("TRAVIS_OS_NAME")
 	return s == "" || s == "linux"
 }

--- a/pubsub/kafkapubsub/kafka_test.go
+++ b/pubsub/kafkapubsub/kafka_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"gocloud.dev/internal/testing/setup"
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/driver"
 	"gocloud.dev/pubsub/drivertest"
@@ -66,7 +67,7 @@ func localKafkaRunning() bool {
 }
 
 func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
-	if !localKafkaRunning() {
+	if !setup.RunTestsDependingOnDocker() || !localKafkaRunning() {
 		t.Skip("No local Kafka running, see pubsub/kafkapubsub/localkafka.sh")
 	}
 	return &harness{uniqueID: rand.Int()}, nil

--- a/pubsub/kafkapubsub/kafka_test.go
+++ b/pubsub/kafkapubsub/kafka_test.go
@@ -54,13 +54,13 @@ type harness struct {
 }
 
 var checkOnce sync.Once
-var kafkaRunning bool
+var kafkaError error
 
-func localKafkaRunning() (err error) {
+func localKafkaRunning() error {
 	checkOnce.Do(func() {
-		_, err = sarama.NewClient(localBrokerAddrs, MinimalConfig())
+		_, kafkaError = sarama.NewClient(localBrokerAddrs, MinimalConfig())
 	})
-	return err
+	return kafkaError
 }
 
 func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {

--- a/pubsub/kafkapubsub/kafka_test.go
+++ b/pubsub/kafkapubsub/kafka_test.go
@@ -25,7 +25,6 @@ import (
 	"math/rand"
 	"os"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -53,22 +52,9 @@ type harness struct {
 	numTopics uint32
 }
 
-var checkOnce sync.Once
-var kafkaError error
-
-func localKafkaRunning() error {
-	checkOnce.Do(func() {
-		_, kafkaError = sarama.NewClient(localBrokerAddrs, MinimalConfig())
-	})
-	return kafkaError
-}
-
 func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
 	if !setup.HasDockerTestEnvironment() {
 		t.Skip("Skipping Kafka tests since the Kafka server is not available")
-	}
-	if err := localKafkaRunning(); err != nil {
-		t.Fatalf("No local Kafka running: %v, see pubsub/kafkapubsub/localkafka.sh", err)
 	}
 	return &harness{uniqueID: rand.Int()}, nil
 }
@@ -199,9 +185,6 @@ func (asTest) BeforeSend(as func(interface{}) bool) error {
 func TestKafkaKey(t *testing.T) {
 	if !setup.HasDockerTestEnvironment() {
 		t.Skip("Skipping Kafka tests since the Kafka server is not available")
-	}
-	if err := localKafkaRunning(); err != nil {
-		t.Fatalf("No local Kafka running: %v, see pubsub/kafkapubsub/localkafka.sh", err)
 	}
 	const (
 		keyName  = "kafkakey"

--- a/pubsub/rabbitpubsub/rabbit_test.go
+++ b/pubsub/rabbitpubsub/rabbit_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/streadway/amqp"
 	"gocloud.dev/gcerrors"
+	"gocloud.dev/internal/testing/setup"
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/driver"
 	"gocloud.dev/pubsub/drivertest"
@@ -42,12 +43,15 @@ const rabbitURL = "amqp://guest:guest@localhost:5672/"
 var logOnce sync.Once
 
 func mustDialRabbit(t testing.TB) amqpConnection {
-	conn, err := amqp.Dial(rabbitURL)
-	if err != nil {
+	if !setup.RunTestsDependingOnDocker() {
 		logOnce.Do(func() {
-			t.Logf("using the fake because the RabbitMQ server is not up (dial error: %v)", err)
+			t.Log("using the fake because the RabbitMQ server is not available")
 		})
 		return newFakeConnection()
+	}
+	conn, err := amqp.Dial(rabbitURL)
+	if err != nil {
+		t.Fatal(err)
 	}
 	logOnce.Do(func() {
 		t.Logf("using the RabbitMQ server at %s", rabbitURL)

--- a/pubsub/rabbitpubsub/rabbit_test.go
+++ b/pubsub/rabbitpubsub/rabbit_test.go
@@ -43,7 +43,7 @@ const rabbitURL = "amqp://guest:guest@localhost:5672/"
 var logOnce sync.Once
 
 func mustDialRabbit(t testing.TB) amqpConnection {
-	if !setup.RunTestsDependingOnDocker() {
+	if !setup.HasDockerTestEnvironment() {
 		logOnce.Do(func() {
 			t.Log("using the fake because the RabbitMQ server is not available")
 		})

--- a/runtimevar/etcdvar/etcdvar_test.go
+++ b/runtimevar/etcdvar/etcdvar_test.go
@@ -33,41 +33,27 @@ import (
 // To run these tests against a local etcd server, first run ./localetcd.sh.
 // Then wait a few seconds for the server to be ready.
 
-var (
-	etcdClient *clientv3.Client
-	etcdError  error
-)
-
-func init() {
-	if setup.HasDockerTestEnvironment() {
-		etcdClient, etcdError = clientv3.NewFromURL("http://localhost:2379")
-		if etcdError == nil {
-			// Check to see if the local etcd is actually running.
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			defer cancel()
-			_, etcdError = etcdClient.Put(ctx, "unused", "unused")
-		}
-	}
+type harness struct {
+	client *clientv3.Client
 }
-
-type harness struct{}
 
 func newHarness(t *testing.T) (drivertest.Harness, error) {
 	if !setup.HasDockerTestEnvironment() {
 		t.Skip("Skipping etcd tests since the etcd server is not available")
 	}
-	if etcdError != nil {
-		t.Fatal("No local etcd server running, see runtimevar/etcdvar/localetcd.sh", etcdError)
+	c, err := clientv3.NewFromURL("http://localhost:2379")
+	if err != nil {
+		t.Fatalf("No local etcd server running: %v; see runtimevar/etcdvar/localetcd.sh", err)
 	}
-	return &harness{}, nil
+	return &harness{client: c}, nil
 }
 
 func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtimevar.Decoder) (driver.Watcher, error) {
-	return newWatcher(etcdClient, name, decoder, nil), nil
+	return newWatcher(h.client, name, decoder, nil), nil
 }
 
 func (h *harness) CreateVariable(ctx context.Context, name string, val []byte) error {
-	_, err := etcdClient.Put(ctx, name, string(val))
+	_, err := h.client.Put(ctx, name, string(val))
 	return err
 }
 
@@ -76,7 +62,7 @@ func (h *harness) UpdateVariable(ctx context.Context, name string, val []byte) e
 }
 
 func (h *harness) DeleteVariable(ctx context.Context, name string) error {
-	_, err := etcdClient.Delete(ctx, name)
+	_, err := h.client.Delete(ctx, name)
 	return err
 }
 

--- a/runtimevar/etcdvar/etcdvar_test.go
+++ b/runtimevar/etcdvar/etcdvar_test.go
@@ -39,7 +39,7 @@ var (
 )
 
 func init() {
-	if setup.RunTestsDependingOnDocker() {
+	if setup.HasDockerTestEnvironment() {
 		etcdClient, etcdError = clientv3.NewFromURL("http://localhost:2379")
 		if etcdError == nil {
 			// Check to see if the local etcd is actually running.
@@ -53,7 +53,7 @@ func init() {
 type harness struct{}
 
 func newHarness(t *testing.T) (drivertest.Harness, error) {
-	if !setup.RunTestsDependingOnDocker() {
+	if !setup.HasDockerTestEnvironment() {
 		t.Skip("Skipping etcd tests since the etcd server is not available")
 	}
 	if etcdError != nil {

--- a/secrets/vault/vault_test.go
+++ b/secrets/vault/vault_test.go
@@ -39,6 +39,7 @@ const (
 	testToken  = "faketoken"
 )
 
+// enableTransit cheks and makes sure the Transit API is enable only once.
 var enableTransit sync.Once
 
 type harness struct {

--- a/secrets/vault/vault_test.go
+++ b/secrets/vault/vault_test.go
@@ -39,7 +39,7 @@ const (
 	testToken  = "faketoken"
 )
 
-// enableTransit cheks and makes sure the Transit API is enable only once.
+// enableTransit checks and makes sure the Transit API is enabled only once.
 var enableTransit sync.Once
 
 type harness struct {

--- a/secrets/vault/vault_test.go
+++ b/secrets/vault/vault_test.go
@@ -53,7 +53,7 @@ func (h *harness) MakeDriver(ctx context.Context) (driver.Keeper, driver.Keeper,
 func (h *harness) Close() {}
 
 func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
-	if !setup.RunTestsDependingOnDocker() {
+	if !setup.HasDockerTestEnvironment() {
 		t.Skip("Skipping Vault tests since the Vault server is not available")
 	}
 	c, err := Dial(ctx, &Config{


### PR DESCRIPTION
Fixes #2005 

All tests that require Docker container to run will run when either:
 1) Not on Travis.
 2) On Travis Linux environment, where Docker is available.