### PR TITLE
internal/contributebot: fix mod file

### DIFF
--- a/internal/contributebot/go.mod
+++ b/internal/contributebot/go.mod
@@ -3,7 +3,7 @@ module gocloud.dev/internal/contributebot
 replace gocloud.dev => ../..
 
 require (
-	cloud.google.com/go v0.37.4
+	cloud.google.com/go v0.38.0
 	github.com/Azure/go-autorest v12.0.0+incompatible // indirect
 	github.com/DataDog/zstd v1.4.0 // indirect
 	github.com/Jeffail/gabs v1.2.0 // indirect

--- a/internal/contributebot/go.sum
+++ b/internal/contributebot/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.37.4 h1:glPeL3BQJsbF6aIIYfZizMwc5LTYz250bDMjttbBGAU=
 cloud.google.com/go v0.37.4/go.mod h1:NHPJ89PdicEuT9hdPXMROBD91xc5uRDxsMtSB16k7hw=
+cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
+cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 contrib.go.opencensus.io/exporter/aws v0.0.0-20181029163544-2befc13012d0/go.mod h1:uu1P0UCM/6RbsMrgPa98ll8ZcHM858i/AD06a9aLRCA=
 contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRqYosuDstRB9un7SOx2k/9ckA=
 contrib.go.opencensus.io/exporter/stackdriver v0.10.2/go.mod h1:3lP9Dec8Q/6iqhtwFdgCmg4F3n2TXEP/yZKdPcd0GCc=


### PR DESCRIPTION
This is failing Travis:
https://travis-ci.com/google/go-cloud/jobs/198855413

```
go: updates to go.mod needed, disabled by -mod=readonly
```

Not sure how it got past Travis during the original PR...?