### PR TITLE
testing: properly skip tests/aws/app tests when no environment is set up

### DIFF
--- a/tests/aws/app/app_test.go
+++ b/tests/aws/app/app_test.go
@@ -63,10 +63,10 @@ func TestMain(m *testing.M) {
 	if hostIP == "" || gcpProjectID == "" {
 		log.Println("Test environments need to be setup to run server tests.")
 		flag.PrintDefaults()
-		return
-	}
-	if err := startApp(); err != nil {
-		log.Fatal("startApp: ", err)
+	} else {
+		if err := startApp(); err != nil {
+			log.Fatal("startApp: ", err)
+		}
 	}
 	os.Exit(m.Run())
 }
@@ -116,6 +116,9 @@ func signerFromFile(path string) (ssh.Signer, error) {
 
 func TestRequestLog(t *testing.T) {
 	t.Parallel()
+	if hostIP == "" || gcpProjectID == "" {
+		t.Skip("environment not set up")
+	}
 	suf, err := testutil.URLSuffix()
 	if err != nil {
 		t.Fatal("cannot generate URL suffix:", err)
@@ -155,6 +158,9 @@ func readLogEntries(ctx context.Context, c *logadmin.Client, u string) error {
 
 func TestTrace(t *testing.T) {
 	t.Parallel()
+	if hostIP == "" || gcpProjectID == "" {
+		t.Skip("environment not set up")
+	}
 	suf, err := testutil.URLSuffix()
 	if err != nil {
 		t.Fatal("cannot generate URL suffix:", err)

--- a/tests/aws/app/app_test.go
+++ b/tests/aws/app/app_test.go
@@ -68,6 +68,9 @@ func TestMain(m *testing.M) {
 			log.Fatal("startApp: ", err)
 		}
 	}
+	// Per https://golang.org/pkg/testing/#hdr-Main, TestMain should call os.Exit
+	// with the result of m.Run in any case.
+	// See also https://github.com/golang/go/issues/31969
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
Returning from TestMain doesn't play well with `go test -json` (see #2041). Instead we'll properly skip these tests when no test environment is set up