### PR TITLE
server: default to DefaultServeMux in constructor, not ServeHTTP

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -76,6 +76,9 @@ type Options struct {
 // New creates a new server. New(nil) is the same as new(Server).
 func New(h http.Handler, opts *Options) *Server {
 	srv := new(Server)
+	if h == nil {
+		h = http.DefaultServeMux
+	}
 	srv.handler = h
 	if opts != nil {
 		srv.reqlog = opts.RequestLogger
@@ -149,10 +152,6 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	r = r.WithContext(ctx)
-
-	if h.handler == nil {
-		h.handler = http.DefaultServeMux
-	}
 	h.handler.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
Think it makes more sense here, and doing it in `ServeHTTP` is probably a race if two requests come in at the same time during startup.