### PR TITLE
dynamodocstore: require opt-in for table scans

### DIFF
--- a/internal/docstore/drivertest/drivertest.go
+++ b/internal/docstore/drivertest/drivertest.go
@@ -1236,7 +1236,8 @@ func testAs(t *testing.T, coll *ds.Collection, st AsTest) {
 		coll.Query().Where("Score", ">", 50),
 	}
 	for _, q := range qs {
-		if err := st.QueryCheck(q.BeforeQuery(st.BeforeQuery).Get(ctx)); err != nil {
+		iter := q.BeforeQuery(st.BeforeQuery).Get(ctx)
+		if err := st.QueryCheck(iter); err != nil {
 			t.Error(err)
 		}
 	}

--- a/internal/docstore/dynamodocstore/dynamo_test.go
+++ b/internal/docstore/dynamodocstore/dynamo_test.go
@@ -176,6 +176,7 @@ func TestProcessURL(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		_, _, _, _, _, err = o.processURL(u)
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)

--- a/internal/docstore/dynamodocstore/dynamo_test.go
+++ b/internal/docstore/dynamodocstore/dynamo_test.go
@@ -63,11 +63,11 @@ func (h *harness) Close() {
 }
 
 func (h *harness) MakeCollection(context.Context) (driver.Collection, error) {
-	return newCollection(dyn.New(h.sess), collectionName1, drivertest.KeyField, "")
+	return newCollection(dyn.New(h.sess), collectionName1, drivertest.KeyField, "", nil)
 }
 
 func (h *harness) MakeTwoKeyCollection(context.Context) (driver.Collection, error) {
-	return newCollection(dyn.New(h.sess), collectionName2, "Game", "Player")
+	return newCollection(dyn.New(h.sess), collectionName2, "Game", "Player", &Options{AllowScans: true})
 }
 
 type verifyAs struct{}
@@ -156,6 +156,8 @@ func TestProcessURL(t *testing.T) {
 		{"dynamodb://docstore-test?partition_key=_kind&sort_key=_id", false},
 		// OK, overriding region.
 		{"dynamodb://docstore-test?partition_key=_kind&region=" + region, false},
+		// OK, allow_scans.
+		{"dynamodb://docstore-test?partition_key=_kind&allow_scans=true" + region, false},
 		// Unknown parameter.
 		{"dynamodb://docstore-test?partition_key=_kind&param=value", true},
 		// With path.
@@ -174,7 +176,7 @@ func TestProcessURL(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, _, _, _, err = o.processURL(u)
+		_, _, _, _, _, err = o.processURL(u)
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
 		}

--- a/internal/docstore/dynamodocstore/dynamo_test.go
+++ b/internal/docstore/dynamodocstore/dynamo_test.go
@@ -176,7 +176,6 @@ func TestProcessURL(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		_, _, _, _, _, err = o.processURL(u)
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)

--- a/internal/docstore/dynamodocstore/example_test.go
+++ b/internal/docstore/dynamodocstore/example_test.go
@@ -30,7 +30,7 @@ func Example() {
 		fmt.Println(err)
 		return
 	}
-	coll, err := dynamodocstore.OpenCollection(dynamodb.New(sess), "docstore-test", "_id", "")
+	coll, err := dynamodocstore.OpenCollection(dynamodb.New(sess), "docstore-test", "_id", "", nil)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/internal/docstore/dynamodocstore/query.go
+++ b/internal/docstore/dynamodocstore/query.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
 	"gocloud.dev/internal/docstore"
 	"gocloud.dev/internal/docstore/driver"
+	"gocloud.dev/internal/gcerr"
 )
 
 // TODO: support parallel scans (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan)
@@ -39,6 +40,9 @@ func (c *collection) RunGetQuery(ctx context.Context, q *driver.Query) (driver.D
 	if err != nil {
 		return nil, err
 	}
+	if err := c.checkPlan(qr); err != nil {
+		return nil, err
+	}
 	it := &documentIterator{
 		qr:    qr,
 		limit: q.Limit,
@@ -49,6 +53,13 @@ func (c *collection) RunGetQuery(ctx context.Context, q *driver.Query) (driver.D
 		return nil, err
 	}
 	return it, nil
+}
+
+func (c *collection) checkPlan(qr *queryRunner) error {
+	if qr.scanIn != nil && qr.scanIn.FilterExpression != nil && !c.opts.AllowScans {
+		return gcerr.Newf(gcerr.InvalidArgument, nil, "query requires a table scan; set Options.AllowScans to true to enable")
+	}
+	return nil
 }
 
 func (c *collection) planQuery(q *driver.Query) (*queryRunner, error) {

--- a/internal/docstore/query.go
+++ b/internal/docstore/query.go
@@ -186,6 +186,9 @@ func (it *DocumentIterator) As(i interface{}) bool {
 	if i == nil {
 		return false
 	}
+	if it.iter == nil {
+		return false
+	}
 	return it.iter.As(i)
 }
 

--- a/internal/docstore/query.go
+++ b/internal/docstore/query.go
@@ -183,10 +183,7 @@ func (it *DocumentIterator) Stop() {
 // examples in this package for examples, and the provider-specific package
 // documentation for the specific types supported for that provider.
 func (it *DocumentIterator) As(i interface{}) bool {
-	if i == nil {
-		return false
-	}
-	if it.iter == nil {
+	if i == nil || it.iter == nil {
 		return false
 	}
 	return it.iter.As(i)


### PR DESCRIPTION
Return error if a non-trivial query requires a table scan.

Add an option that the user can set to opt in to scans.