### PR TITLE
internal/docstore/mongodocstore: add BeforeQuery and BeforeDo

### DIFF
--- a/internal/docstore/mongodocstore/mongo_test.go
+++ b/internal/docstore/mongodocstore/mongo_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"gocloud.dev/internal/docstore"
 	"gocloud.dev/internal/docstore/driver"
 	"gocloud.dev/internal/docstore/drivertest"
@@ -111,10 +112,22 @@ func (verifyAs) CollectionCheck(coll *docstore.Collection) error {
 }
 
 func (verifyAs) BeforeDo(as func(i interface{}) bool) error {
+	var find *options.FindOneOptions
+	var insert *options.InsertOneOptions
+	var replace *options.ReplaceOptions
+	var update *options.UpdateOptions
+	var del *options.DeleteOptions
+	if !as(&find) && !as(&insert) && !as(&replace) && !as(&update) && !as(&del) {
+		return errors.New("ActionList.BeforeDo failed")
+	}
 	return nil
 }
 
 func (verifyAs) BeforeQuery(as func(i interface{}) bool) error {
+	var find *options.FindOptions
+	if !as(&find) {
+		return errors.New("Query.BeforeQuery failed")
+	}
 	return nil
 }
 

--- a/internal/docstore/mongodocstore/query.go
+++ b/internal/docstore/mongodocstore/query.go
@@ -42,6 +42,19 @@ func (c *collection) RunGetQuery(ctx context.Context, q *driver.Query) (driver.D
 		}
 		filter = append(filter, bf)
 	}
+	if q.BeforeQuery != nil {
+		asFunc := func(i interface{}) bool {
+			p, ok := i.(**options.FindOptions)
+			if !ok {
+				return false
+			}
+			*p = opts
+			return true
+		}
+		if err := q.BeforeQuery(asFunc); err != nil {
+			return nil, fmt.Errorf("Find: %v", err)
+		}
+	}
 	cursor, err := c.coll.Find(ctx, filter, opts)
 	if err != nil {
 		return nil, fmt.Errorf("Find: %v", err)

--- a/internal/docstore/mongodocstore/query.go
+++ b/internal/docstore/mongodocstore/query.go
@@ -52,12 +52,12 @@ func (c *collection) RunGetQuery(ctx context.Context, q *driver.Query) (driver.D
 			return true
 		}
 		if err := q.BeforeQuery(asFunc); err != nil {
-			return nil, fmt.Errorf("Find: %v", err)
+			return nil, err
 		}
 	}
 	cursor, err := c.coll.Find(ctx, filter, opts)
 	if err != nil {
-		return nil, fmt.Errorf("Find: %v", err)
+		return nil, err
 	}
 	return &docIterator{cursor: cursor, idField: c.idField, ctx: ctx}, nil
 }


### PR DESCRIPTION
mongo is a little bit different, it doesn't have special types for the inputs, but one can use the corresponding options types to do similar things like other drivers.

Fixes #1675 