### PR TITLE
rabbitpubsub: use timer in ReceiveBatch, not ticker

### DIFF
--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -576,7 +576,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 
 	// Get up to maxMessages waiting messages, but don't take too long.
 	var ms []*driver.Message
-	maxTime := time.Tick(50 * time.Millisecond)
+	maxTime := time.NewTimer(50 * time.Millisecond)
 	for {
 		select {
 		case <-ctx.Done():
@@ -609,7 +609,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 				return ms, nil
 			}
 
-		case <-maxTime:
+		case <-maxTime.C:
 			// Timed out. Return whatever we have. If we have nothing, we'll get
 			// called again soon, but returning allows us to give up the lock.
 			return ms, nil

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -611,7 +611,8 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 
 		case <-maxTime.C:
 			// Timed out. Return whatever we have. If we have nothing, we'll get
-			// called again soon, but returning allows us to give up the lock.
+			// called again soon, but returning allows us to give up the lock in
+			// case there are acks/nacks to be sent.
 			return ms, nil
 		}
 	}


### PR DESCRIPTION
We were creating a ticker on each call to ReceiveBatch, but we weren't
stopping it.  Also, we only care about the first channel send (if
any). So switch to a timer instead.

In informal CPU profiling of a simplified program, this helped
significantly with CPU usage.

Fixes #2103.