### PR TITLE
internal/website: add concept guide for escape hatches

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -155,7 +155,7 @@ func (r *Reader) Size() int64 {
 }
 
 // As converts i to provider-specific types.
-// See https://godoc.org/gocloud.dev#hdr-As for background information, the "As"
+// See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the provider-specific package
 // documentation for the specific types supported for that provider.
 func (r *Reader) As(i interface{}) bool {
@@ -199,7 +199,7 @@ type Attributes struct {
 }
 
 // As converts i to provider-specific types.
-// See https://godoc.org/gocloud.dev#hdr-As for background information, the "As"
+// See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the provider-specific package
 // documentation for the specific types supported for that provider.
 func (a *Attributes) As(i interface{}) bool {
@@ -348,7 +348,7 @@ type ListOptions struct {
 	// BeforeList is a callback that will be called before each call to the
 	// the underlying provider's list functionality.
 	// asFunc converts its argument to provider-specific types.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	BeforeList func(asFunc func(interface{}) bool) error
 }
 
@@ -420,7 +420,7 @@ type ListObject struct {
 }
 
 // As converts i to provider-specific types.
-// See https://godoc.org/gocloud.dev#hdr-As for background information, the "As"
+// See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the provider-specific package
 // documentation for the specific types supported for that provider.
 func (o *ListObject) As(i interface{}) bool {
@@ -492,7 +492,7 @@ func newBucket(b driver.Bucket) *Bucket {
 }
 
 // As converts i to provider-specific types.
-// See https://godoc.org/gocloud.dev#hdr-As for background information, the "As"
+// See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the provider-specific package
 // documentation for the specific types supported for that provider.
 func (b *Bucket) As(i interface{}) bool {
@@ -505,7 +505,7 @@ func (b *Bucket) As(i interface{}) bool {
 // ErrorAs converts err to provider-specific types.
 // ErrorAs panics if i is nil or not a pointer.
 // ErrorAs returns false if err == nil.
-// See https://godoc.org/gocloud.dev#hdr-As for background information.
+// See https://gocloud.dev/concepts/as/ for background information.
 func (b *Bucket) ErrorAs(err error, i interface{}) bool {
 	return gcerr.ErrorAs(err, i, b.b.ErrorAs)
 }
@@ -919,7 +919,7 @@ type ReaderOptions struct {
 	// case it may not be called at all).
 	//
 	// asFunc converts its argument to provider-specific types.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	BeforeRead func(asFunc func(interface{}) bool) error
 }
 
@@ -980,7 +980,7 @@ type WriterOptions struct {
 	// sending an upload request.
 	//
 	// asFunc converts its argument to provider-specific types.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	BeforeWrite func(asFunc func(interface{}) bool) error
 }
 
@@ -990,7 +990,7 @@ type CopyOptions struct {
 	// initiated.
 	//
 	// asFunc converts its argument to provider-specific types.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	BeforeCopy func(asFunc func(interface{}) bool) error
 }
 

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -226,12 +226,12 @@ type Bucket interface {
 	ErrorCode(error) gcerrors.ErrorCode
 
 	// As converts i to provider-specific types.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	As(i interface{}) bool
 
 	// ErrorAs allows providers to expose provider-specific types for returned
 	// errors.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	ErrorAs(error, interface{}) bool
 
 	// Attributes returns attributes for the blob. If the specified object does

--- a/doc.go
+++ b/doc.go
@@ -39,41 +39,9 @@ URLs
 
 See https://gocloud.dev/concepts/urls/ for a discussion of URLs in the Go CDK.
 
-Escaping the abstraction
-
-It is not feasible or desirable for APIs like blob.Bucket to encompass the full
-functionality of every provider. Rather, we intend to provide a subset of the
-most commonly used functionality. There will be cases where a developer wants
-to access provider-specific functionality, such as unexposed APIs or data
-fields, errors or options. This can be accomplished using As functions.
-
-
 As
 
-As functions in the APIs provide the user a way to escape the Go CDK
-abstraction to access provider-specific types. They might be used as an interim
-solution until a feature request to the Go CDK is implemented. Or, the Go CDK
-may choose not to support specific features, and the use of As will be
-permanent.
-
-Using As implies that the resulting code is no longer portable; the
-provider-specific code will need to be ported in order to switch providers.
-Therefore, it should be avoided if possible.
-
-Each API will include examples demonstrating how to use its various As
-functions, and each provider implementation will document what types it
-supports for each.
-
-Usage:
-
-1. Declare a variable of the provider-specific type you want to access.
-
-2. Pass a pointer to it to As.
-
-3. If the type is supported, As will return true and copy the
-provider-specific type into your variable. Otherwise, it will return false.
-
-Provider-specific types that are intended to be mutable will be exposed
-as a pointer to the underlying type.
+See https://gocloud.dev/concepts/as/ for a discussion of how to write
+provider-specific code with the Go CDK.
 */
 package cloud // import "gocloud.dev"

--- a/internal/docs/design.md
+++ b/internal/docs/design.md
@@ -434,7 +434,7 @@ https://landing.google.com/sre/book/chapters/addressing-cascading-failures.html
 
 The Go CDK allows users to escape the abstraction as needed using `As`
 functions, described in more detail in the
-[top-level godoc](https://godoc.org/gocloud.dev#hdr-As). `As` functions take an
+[concept guide](https://gocloud.dev/concepts/as/). `As` functions take an
 `interface{}` and return a `bool`; they return `true` if the underlying concrete
 type could be converted into the type provided as the `interface{}`.
 

--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -245,7 +245,7 @@ func (e ActionListError) Unwrap() error {
 // BeforeDo takes a callback function that will be called before the ActionList
 // is executed by the underlying provider's action functionality. The callback
 // takes a parameter, asFunc, that converts its argument to provider-specific
-// types. See https://godoc.org/gocloud.dev#hdr-As for background information.
+// types. See https://gocloud.dev/concepts/as/ for background information.
 func (l *ActionList) BeforeDo(f func(asFunc func(interface{}) bool) error) *ActionList {
 	l.beforeDo = f
 	return l
@@ -461,7 +461,7 @@ func parseFieldPath(fp FieldPath) ([]string, error) {
 }
 
 // As converts i to provider-specific types.
-// See https://godoc.org/gocloud.dev#hdr-As for background information, the "As"
+// See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the provider-specific package
 // documentation for the specific types supported for that provider.
 func (c *Collection) As(i interface{}) bool {

--- a/internal/docstore/driver/driver.go
+++ b/internal/docstore/driver/driver.go
@@ -54,7 +54,7 @@ type Collection interface {
 	QueryPlan(*Query) (string, error)
 
 	// As converts i to provider-specific types.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	As(i interface{}) bool
 
 	// ErrorCode should return a code that describes the error, which was returned by
@@ -178,7 +178,7 @@ type DocumentIterator interface {
 	Stop()
 
 	// As converts i to provider-specific types.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	As(i interface{}) bool
 }
 

--- a/internal/docstore/query.go
+++ b/internal/docstore/query.go
@@ -99,7 +99,7 @@ func (q *Query) Limit(n int) *Query {
 // BeforeQuery takes a callback function that will be called before the Query is
 // executed to the underlying provider's query functionality. The callback takes
 // a parameter, asFunc, that converts its argument to provider-specific types.
-// See https://godoc.org/gocloud.dev#hdr-As for background information.
+// See https://gocloud.dev/concepts/as/ for background information.
 func (q *Query) BeforeQuery(f func(asFunc func(interface{}) bool) error) *Query {
 	q.dq.BeforeQuery = f
 	return q
@@ -200,7 +200,7 @@ func (it *DocumentIterator) Stop() {
 }
 
 // As converts i to provider-specific types.
-// See https://godoc.org/gocloud.dev#hdr-As for background information, the "As"
+// See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the provider-specific package
 // documentation for the specific types supported for that provider.
 func (it *DocumentIterator) As(i interface{}) bool {

--- a/internal/website/content/concepts/as.md
+++ b/internal/website/content/concepts/as.md
@@ -1,0 +1,39 @@
+---
+title: Using provider-specific APIs
+date: 2019-05-10T11:17:09-07:00
+---
+
+It is not feasible or desirable for APIs like `blob.Bucket` to encompass the
+full functionality of every provider. Rather, we intend to provide a subset
+of the most commonly used functionality. There will be cases where a
+developer wants to access provider-specific functionality, such as unexposed
+APIs or data fields, errors, or options. This can be accomplished using `As`
+functions.
+
+<!--more-->
+
+## `As` {#as}
+
+`As` functions in the APIs provide the user a way to escape the Go CDK
+abstraction to access provider-specific types. They might be used as an
+interim solution until a feature request to the Go CDK is implemented. Or,
+the Go CDK may choose not to support specific features, and the use of `As`
+will be permanent.
+
+Using `As` implies that the resulting code is no longer portable; the
+provider-specific code will need to be ported in order to switch providers.
+Therefore, it should be avoided if possible.
+
+Each API includes examples demonstrating how to use its various `As`
+functions, and each provider implementation documents what types it supports
+for each.
+
+Usage:
+
+1. Declare a variable of the provider-specific type you want to access.
+2. Pass a pointer to it to `As`.
+3. If the type is supported, `As` will return `true` and copy the
+   provider-specific type into your variable. Otherwise, it will return `false`.
+
+Provider-specific types that are intended to be mutable will be exposed
+as a pointer to the underlying type.

--- a/pubsub/driver/driver.go
+++ b/pubsub/driver/driver.go
@@ -59,7 +59,7 @@ type Message struct {
 	// The callback must be called exactly once, before the message is sent.
 	//
 	// asFunc converts its argument to provider-specific types.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	BeforeSend func(asFunc func(interface{}) bool) error
 }
 
@@ -96,11 +96,11 @@ type Topic interface {
 	IsRetryable(err error) bool
 
 	// As allows providers to expose provider-specific types.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	As(i interface{}) bool
 
 	// ErrorAs allows providers to expose provider-specific types for errors.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	ErrorAs(error, interface{}) bool
 
 	// ErrorCode should return a code that describes the error, which was returned by
@@ -183,11 +183,11 @@ type Subscription interface {
 	IsRetryable(err error) bool
 
 	// As converts i to provider-specific types.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	As(i interface{}) bool
 
 	// ErrorAs allows providers to expose provider-specific types for errors.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	ErrorAs(error, interface{}) bool
 
 	// ErrorCode should return a code that describes the error, which was returned by

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -147,7 +147,7 @@ type Message struct {
 	// The callback will be called exactly once, before the message is sent.
 	//
 	// asFunc converts its argument to provider-specific types.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	BeforeSend func(asFunc func(interface{}) bool) error
 
 	// asFunc invokes driver.Message.AsFunc.
@@ -217,7 +217,7 @@ func (m *Message) Nack() {
 }
 
 // As converts i to provider-specific types.
-// See https://godoc.org/gocloud.dev#hdr-As for background information, the "As"
+// See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the provider-specific package
 // documentation for the specific types supported for that provider.
 // As panics unless it is called on a message obtained from Subscription.Receive.
@@ -310,7 +310,7 @@ func (t *Topic) Shutdown(ctx context.Context) (err error) {
 }
 
 // As converts i to provider-specific types.
-// See https://godoc.org/gocloud.dev#hdr-As for background information, the "As"
+// See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the provider-specific package
 // documentation for the specific types supported for that provider.
 func (t *Topic) As(i interface{}) bool {
@@ -320,7 +320,7 @@ func (t *Topic) As(i interface{}) bool {
 // ErrorAs converts err to provider-specific types.
 // ErrorAs panics if i is nil or not a pointer.
 // ErrorAs returns false if err == nil.
-// See https://godoc.org/gocloud.dev#hdr-As for background information.
+// See https://gocloud.dev/concepts/as/ for background information.
 func (t *Topic) ErrorAs(err error, i interface{}) bool {
 	return gcerr.ErrorAs(err, i, t.driver.ErrorAs)
 }
@@ -741,7 +741,7 @@ func (s *Subscription) Shutdown(ctx context.Context) (err error) {
 }
 
 // As converts i to provider-specific types.
-// See https://godoc.org/gocloud.dev#hdr-As for background information, the "As"
+// See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the provider-specific package
 // documentation for the specific types supported for that provider.
 func (s *Subscription) As(i interface{}) bool {

--- a/runtimevar/driver/driver.go
+++ b/runtimevar/driver/driver.go
@@ -42,7 +42,7 @@ type State interface {
 	UpdateTime() time.Time
 
 	// As converts i to provider-specific types.
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	As(interface{}) bool
 }
 

--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -93,7 +93,7 @@ type Snapshot struct {
 }
 
 // As converts i to provider-specific types.
-// See https://godoc.org/gocloud.dev#hdr-As for background information, the "As"
+// See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the provider-specific package
 // documentation for the specific types supported for that provider.
 func (s *Snapshot) As(i interface{}) bool {
@@ -348,7 +348,7 @@ func wrapError(w driver.Watcher, err error) error {
 // ErrorAs converts err to provider-specific types.
 // ErrorAs panics if i is nil or not a pointer.
 // ErrorAs returns false if err == nil.
-// See https://godoc.org/gocloud.dev#hdr-As for background information.
+// See https://gocloud.dev/concepts/as/ for background information.
 func (c *Variable) ErrorAs(err error, i interface{}) bool {
 	return gcerr.ErrorAs(err, i, c.dw.ErrorAs)
 }

--- a/secrets/driver/driver.go
+++ b/secrets/driver/driver.go
@@ -42,7 +42,7 @@ type Keeper interface {
 	// ErrorAs allows providers to expose provider-specific types for returned
 	// errors.
 	//
-	// See https://godoc.org/gocloud.dev#hdr-As for background information.
+	// See https://gocloud.dev/concepts/as/ for background information.
 	ErrorAs(err error, i interface{}) bool
 
 	// ErrorCode should return a code that describes the error, which was returned

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -159,7 +159,7 @@ func (k *Keeper) Close() error {
 }
 
 // ErrorAs converts i to provider-specific types. See
-// https://godoc.org/gocloud.dev#hdr-As for background information and the
+// https://gocloud.dev/concepts/as/ for background information and the
 // provider-specific package documentation for the specific types supported for
 // that provider.
 //


### PR DESCRIPTION
Using the same content as was in the package godoc with minimal formatting changes.

Updates #1469