### PR TITLE
internal/cmd/gocdk: add apply -input flag

### DIFF
--- a/internal/cmd/gocdk/serve.go
+++ b/internal/cmd/gocdk/serve.go
@@ -132,7 +132,7 @@ func serveBuildLoop(ctx context.Context, pctx *processContext, logger *log.Logge
 	}()
 
 	// Apply Terraform configuration in biome.
-	if err := apply(ctx, pctx, []string{opts.biome}); err != nil {
+	if err := apply(ctx, pctx, []string{"-input=false", "--", opts.biome}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Prevents serve from prompting user for unset Terraform variables. The user should create .tfvars files or set environment variables for serve.

Updates #1821