### PR TITLE
docstore: support struct tags

### DIFF
--- a/internal/docstore/driver/codec.go
+++ b/internal/docstore/driver/codec.go
@@ -271,20 +271,18 @@ func encodeStructWithFields(v reflect.Value, fields fields.List, e Encoder) erro
 	for _, f := range fields {
 		fv, ok := fieldByIndex(v, f.Index)
 		if !ok {
+			// if !ok, then f is a field in an embedded pointer to struct, and that embedded pointer
+			// is nil in v. In other words, the field exists in the struct type, but not this particular
+			// struct value. So we just ignore it.
 			continue
 		}
 		if f.ParsedTag.(tagOptions).omitEmpty && isEmptyValue(fv) {
 			continue
 		}
-		if ok {
-			if err := encode(fv, e2); err != nil {
-				return err
-			}
-			e2.MapKey(f.Name)
+		if err := encode(fv, e2); err != nil {
+			return err
 		}
-		// if !ok, then f is a field in an embedded pointer to struct, and that embedded pointer
-		// is nil in v. In other words, the field exists in the struct type, but not this particular
-		// struct value. So we just ignore it.
+		e2.MapKey(f.Name)
 	}
 	return nil
 }

--- a/internal/docstore/driver/codec.go
+++ b/internal/docstore/driver/codec.go
@@ -270,6 +270,12 @@ func encodeStructWithFields(v reflect.Value, fields fields.List, e Encoder) erro
 	e2 := e.EncodeMap(len(fields))
 	for _, f := range fields {
 		fv, ok := fieldByIndex(v, f.Index)
+		if !ok {
+			continue
+		}
+		if f.ParsedTag.(tagOptions).omitEmpty && isEmptyValue(fv) {
+			continue
+		}
 		if ok {
 			if err := encode(fv, e2); err != nil {
 				return err
@@ -716,4 +722,48 @@ func wrap(err error, code gcerr.ErrorCode) error {
 		err = gcerr.New(code, err, 2, err.Error())
 	}
 	return err
+}
+
+var fieldCache = fields.NewCache(parseTag, nil, nil)
+
+// Copied from encoding/json, go 1.12.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+// Options for struct tags.
+type tagOptions struct {
+	omitEmpty bool // do not encode value if empty
+}
+
+// parseTag interprets docstore struct field tags.
+func parseTag(t reflect.StructTag) (name string, keep bool, other interface{}, err error) {
+	name, keep, opts, err := fields.ParseStandardTag("docstore", t)
+	if err != nil {
+		return "", false, nil, gcerr.Newf(gcerr.InvalidArgument, err, "parsing struct tags")
+	}
+	tagOpts := tagOptions{}
+	for _, opt := range opts {
+		switch opt {
+		case "omitempty":
+			tagOpts.omitEmpty = true
+		default:
+			return "", false, nil, gcerr.Newf(gcerr.InvalidArgument, nil, "unknown tag option: %q", opt)
+		}
+	}
+	return name, keep, tagOpts, nil
 }

--- a/internal/docstore/driver/codec_test.go
+++ b/internal/docstore/driver/codec_test.go
@@ -76,6 +76,9 @@ type MyStruct struct {
 	*Embed2
 	embed3
 	*embed4
+	Omit      int `docstore:"-"`
+	OmitEmpty int `docstore:",omitempty"`
+	Rename    int `docstore:"rename"`
 }
 
 func TestEncode(t *testing.T) {
@@ -146,38 +149,44 @@ func TestEncode(t *testing.T) {
 		},
 		{
 			MyStruct{
-				A:      1,
-				B:      &tru,
-				C:      []*te{{'T'}},
-				D:      []time.Time{tm},
-				T:      ts,
-				Embed1: Embed1{E1: "E1"},
-				Embed2: &Embed2{E2: "E2"},
-				embed3: embed3{E3: "E3"},
-				embed4: &embed4{E4: "E4"},
+				A:         1,
+				B:         &tru,
+				C:         []*te{{'T'}},
+				D:         []time.Time{tm},
+				T:         ts,
+				Embed1:    Embed1{E1: "E1"},
+				Embed2:    &Embed2{E2: "E2"},
+				embed3:    embed3{E3: "E3"},
+				embed4:    &embed4{E4: "E4"},
+				Omit:      3,
+				OmitEmpty: 4,
+				Rename:    5,
 			},
 			map[string]interface{}{
-				"A":  int64(1),
-				"B":  true,
-				"C":  []interface{}{"T"},
-				"D":  []interface{}{tmb},
-				"T":  tsb,
-				"E1": "E1",
-				"E2": "E2",
-				"E3": "E3",
-				"E4": "E4",
+				"A":         int64(1),
+				"B":         true,
+				"C":         []interface{}{"T"},
+				"D":         []interface{}{tmb},
+				"T":         tsb,
+				"E1":        "E1",
+				"E2":        "E2",
+				"E3":        "E3",
+				"E4":        "E4",
+				"OmitEmpty": int64(4),
+				"rename":    int64(5),
 			},
 		},
 		{
 			MyStruct{},
 			map[string]interface{}{
-				"A":  int64(0),
-				"B":  nil,
-				"C":  nil,
-				"D":  nil,
-				"T":  nil,
-				"E1": "",
-				"E3": "",
+				"A":      int64(0),
+				"B":      nil,
+				"C":      nil,
+				"D":      nil,
+				"T":      nil,
+				"E1":     "",
+				"E3":     "",
+				"rename": int64(0),
 			},
 		},
 	} {

--- a/internal/docstore/driver/document.go
+++ b/internal/docstore/driver/document.go
@@ -22,8 +22,6 @@ import (
 	"gocloud.dev/internal/gcerr"
 )
 
-var fieldCache = fields.NewCache(nil, nil, nil)
-
 // A Document is a lightweight wrapper around either a map[string]interface{} or a
 // struct pointer. It provides operations to get and set fields and field paths.
 type Document struct {

--- a/internal/docstore/dynamodocstore/query.go
+++ b/internal/docstore/dynamodocstore/query.go
@@ -77,7 +77,7 @@ func (c *collection) planQuery(q *driver.Query) (*queryRunner, error) {
 		}
 		if !hasRevisionField {
 			pb = pb.AddNames(expression.Name(docstore.RevisionField))
-			q.FieldPaths = append(q.FieldPaths, []string{docstore.RevisionField})
+			q.FieldPaths = append(q.FieldPaths, []string{docstore.RevisionFieldo})
 		}
 		cb = cb.WithProjection(pb)
 		cbUsed = true

--- a/internal/docstore/dynamodocstore/query.go
+++ b/internal/docstore/dynamodocstore/query.go
@@ -77,7 +77,7 @@ func (c *collection) planQuery(q *driver.Query) (*queryRunner, error) {
 		}
 		if !hasRevisionField {
 			pb = pb.AddNames(expression.Name(docstore.RevisionField))
-			q.FieldPaths = append(q.FieldPaths, []string{docstore.RevisionFieldo})
+			q.FieldPaths = append(q.FieldPaths, []string{docstore.RevisionField})
 		}
 		cb = cb.WithProjection(pb)
 		cbUsed = true


### PR DESCRIPTION
Add support for tags with keys "docstore".

Support "-" to mean omit field, and "omitempty" to mean omit the field
if the value is empty (using the same code as in encoding/json).