### PR TITLE
travis: skip a couple of module tests on windows

### DIFF
--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -96,7 +96,14 @@ while read -r path || [[ -n "$path" ]]; do
     fi
   else
     echo "Running Go tests..."
-    go test -mod=readonly -race ./... || result=1
+    # TODO(rvangent): Special case modules to skip for Windows. Perhaps
+    # this should be data-driven by allmodules?
+    # (https://github.com/google/go-cloud/issues/2111).
+    if [[ "${TRAVIS_OS_NAME:-}" == "windows" ]] && ([[ "$path" == "internal/contributebot" ]] || [[ "$path" == "internal/website" ]]); then
+      echo "  Skipping tests on Window"
+    else
+      go test -mod=readonly -race ./... || result=1
+    fi
   fi
   # Do these additional checks for the Linux build on Travis, or when running
   # locally.


### PR DESCRIPTION
Fixes #2155.

Skip tests on Windows for a couple of internal modules.

* `internal/contributebot` will never run on Windows.
* `internal/gatherexamples` will never run on Windows.

Ideally this would be data-driven from `allmodules` instead of naming modules to skip explicitly; added a TODO for that.