### PR TITLE
travis: remove coverage.out file so it doesn't get resent

### DIFF
--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -93,6 +93,7 @@ while read -r path || [[ -n "$path" ]]; do
       grep -v test coverage.out > coverage2.out
       mv coverage2.out coverage.out
       bash <(curl -s https://codecov.io/bash)
+      rm coverage.out
     fi
   else
     echo "Running Go tests..."


### PR DESCRIPTION
Currently we send `codecov` results for the core module, then the core module + the next module, then 3 modules, ... etc.