### PR TITLE
gocdk: fix executable path for windows by adding .EXE suffix

### DIFF
--- a/internal/cmd/gocdk/demo_test.go
+++ b/internal/cmd/gocdk/demo_test.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -57,6 +58,9 @@ func TestAddDemo(t *testing.T) {
 
 	// Build the binary.
 	exePath := filepath.Join(dir, "add-demo-test")
+	if runtime.GOOS == "windows" {
+		exePath += ".EXE"
+	}
 	if err := buildForServe(ctx, pctx, dir, exePath); err != nil {
 		t.Fatal("buildForServe(...):", err)
 	}

--- a/internal/cmd/gocdk/serve.go
+++ b/internal/cmd/gocdk/serve.go
@@ -239,6 +239,7 @@ loop:
 }
 
 // buildForServe runs Wire and `go build` at moduleRoot to create exePath.
+// Note that on Windows, exePath must end with .EXE.
 func buildForServe(ctx context.Context, pctx *processContext, moduleRoot string, exePath string) error {
 	moduleEnv := overrideEnv(pctx.env, "GO111MODULE=on")
 

--- a/internal/cmd/gocdk/serve_test.go
+++ b/internal/cmd/gocdk/serve_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -80,6 +81,9 @@ func testBuildForServe(t *testing.T, files map[string]string) {
 		stderr:  ioutil.Discard,
 	}
 	exePath := filepath.Join(dir, "hello")
+	if runtime.GOOS == "windows" {
+		exePath += ".EXE"
+	}
 
 	// Build program.
 	if err := buildForServe(context.Background(), pctx, dir, exePath); err != nil {


### PR DESCRIPTION
Fixes #2155.

On Windows, the executable must end with `.EXE`.