### PR TITLE
internal/gocdk: add a newTestProject helper and use it

### DIFF
--- a/internal/cmd/gocdk/apply_test.go
+++ b/internal/cmd/gocdk/apply_test.go
@@ -39,22 +39,17 @@ func TestApply(t *testing.T) {
 	}
 
 	t.Run("TerraformNotInitialized", func(t *testing.T) {
-		dir, cleanup, err := newTestModule()
+		ctx := context.Background()
+		pctx, cleanup, err := newTestProject(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer cleanup()
 		const biomeName = "dev"
 		const wantGreeting = "HALLO WORLD"
-		if err := newTestBiome(dir, biomeName, wantGreeting, new(biomeConfig)); err != nil {
+		if err := newTestBiome(pctx.workdir, biomeName, wantGreeting, new(biomeConfig)); err != nil {
 			t.Fatal(err)
 		}
-		pctx := &processContext{
-			workdir: dir,
-			stdout:  ioutil.Discard,
-			stderr:  ioutil.Discard,
-		}
-		ctx := context.Background()
 
 		// Call the main package run function as if 'apply' and biomeName were passed
 		// on the command line. As part of this, ensureTerraformInit is called to check
@@ -67,7 +62,7 @@ func TestApply(t *testing.T) {
 		// we configured. Terraform output fails if 'terraform init' was not called.
 		// It also fails if 'terraform apply' has never been run, as there will be no
 		// terraform state file (terraform.tfstate).
-		outputs, err := tfReadOutput(ctx, findBiomeDir(dir, biomeName), os.Environ())
+		outputs, err := tfReadOutput(ctx, findBiomeDir(pctx.workdir, biomeName), os.Environ())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/gocdk/biome_add_test.go
+++ b/internal/cmd/gocdk/biome_add_test.go
@@ -17,9 +17,7 @@ package main
 import (
 	"context"
 	"io/ioutil"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -27,27 +25,19 @@ import (
 
 func TestBiomeAdd(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		dir, cleanup, err := newTestModule()
+		ctx := context.Background()
+		pctx, cleanup, err := newTestProject(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		os.MkdirAll(filepath.Join(dir, "biomes"), 0777)
 		defer cleanup()
-
-		ctx := context.Background()
-		pctx := &processContext{
-			workdir: dir,
-			stdin:   strings.NewReader(""),
-			stdout:  ioutil.Discard,
-			stderr:  ioutil.Discard,
-		}
 		const newBiome = "foo"
 		if err := biomeAdd(ctx, pctx, []string{"add", newBiome}); err != nil {
 			t.Fatal(err)
 		}
 
 		// Ensure at least one file exists in the new biome with extension .tf.
-		newBiomePath := filepath.Join(dir, "biomes", newBiome)
+		newBiomePath := filepath.Join(pctx.workdir, "biomes", newBiome)
 		newBiomeContents, err := ioutil.ReadDir(newBiomePath)
 		if err != nil {
 			t.Error(err)
@@ -71,7 +61,7 @@ func TestBiomeAdd(t *testing.T) {
 			ServeEnabled: configBool(false),
 			Launcher:     configString("cloudrun"),
 		}
-		got, err := readBiomeConfig(dir, newBiome)
+		got, err := readBiomeConfig(pctx.workdir, newBiome)
 		if err != nil {
 			t.Fatalf("biomeAdd: %+v", err)
 		}

--- a/internal/cmd/gocdk/demo.go
+++ b/internal/cmd/gocdk/demo.go
@@ -97,6 +97,12 @@ func instantiateDemo(pctx *processContext, demo *demoInfo, force bool) error {
 	logger := log.New(pctx.stderr, "gocdk: ", log.Ldate|log.Ltime)
 	logger.Printf("Adding %q...", demo.name)
 
+	// TODO(rvangent): Consider using materializeTemplateDir here. It can't
+	// be used right now because it treats the source files as templates;
+	// the demo .go files have embedded templates that shouldn't be
+	// processed at copy time.
+	// It would also need support for "force".
+
 	dstPath := path.Join(pctx.workdir, filepath.Base(demo.goDemoPath))
 	if !force {
 		if _, err := os.Stat(dstPath); err == nil {

--- a/internal/cmd/gocdk/init.go
+++ b/internal/cmd/gocdk/init.go
@@ -95,6 +95,7 @@ func init_(ctx context.Context, pctx *processContext, args []string) error {
 	return nil
 }
 
+// TODO(rvangent): Consider having this log all of the file(s) it adds?
 func materializeTemplateDir(dst string, srcRoot string, data interface{}) error {
 	dir, err := static.Open(srcRoot)
 	if err != nil {

--- a/internal/cmd/gocdk/init_test.go
+++ b/internal/cmd/gocdk/init_test.go
@@ -170,3 +170,27 @@ func containsLine(data []byte, want string) bool {
 	}
 	return false
 }
+
+// newTestProject creates a temporary project using "gocdk init" and
+// returns a pctx with workdir set to the project directory, and a cleanup
+// function.
+func newTestProject(ctx context.Context) (*processContext, func(), error) {
+	dir, err := ioutil.TempDir("", testTempDirPrefix)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanup := func() {
+		os.RemoveAll(dir)
+	}
+	pctx := &processContext{
+		workdir: dir,
+		env:     os.Environ(),
+		stdout:  ioutil.Discard,
+		stderr:  ioutil.Discard,
+	}
+	if err := run(ctx, pctx, []string{"init", "-m", "example.com/test", "--allow-existing-dir", dir}, new(bool)); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	return pctx, cleanup, nil
+}


### PR DESCRIPTION
This provides a more realistic test for most use cases. The old helper just creates an empty directory with a `go.mod`, this one creates a real GoCDK project using `gocdk init`. It also saves some boilerplate to create the `pctx`.