### PR TITLE
testing: fix error reporting when the build fails

### DIFF
--- a/internal/testing/test-summary/test-summary.go
+++ b/internal/testing/test-summary/test-summary.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -60,6 +61,13 @@ func run(r io.Reader) (msg string, failures bool, err error) {
 	scanner := bufio.NewScanner(bufio.NewReader(r))
 	prevPkg := "" // In progress mode, the package we previously wrote, to avoid repeating it.
 	for scanner.Scan() {
+		// When the build fails, go test -json doesn't emit a valid JSON value, only
+		// a line of output starting with FAIL. Report a more reasonable error in
+		// this case.
+		if strings.HasPrefix(scanner.Text(), "FAIL") {
+			return "", true, fmt.Errorf("No test output: %q", scanner.Text())
+		}
+
 		var event TestEvent
 		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
 			return "", false, fmt.Errorf("%q: %v", scanner.Text(), err)


### PR DESCRIPTION
Without this change, when the build fails we get a very funky error from the summarizer (essentially a JSON parsing error). This PR makes it more intelligible.
