### PR TITLE
testing: -progress only reports 'pass' for packages

### DIFF
--- a/internal/testing/test-summary/test-summary.go
+++ b/internal/testing/test-summary/test-summary.go
@@ -84,7 +84,7 @@ func run(r io.Reader) (msg string, failures bool, err error) {
 			fmt.Print(event.Output)
 		}
 
-		// The Test field, if present, specifies the test, example, or benchmark
+		// The Test field, if non-empty, specifies the test, example, or benchmark
 		// function that caused the event. Events for the overall package test do
 		// not set Test. We don't want to count package passes/fails because these
 		// don't represent specific tests being run. However, skips of an entire

--- a/internal/testing/test-summary/test-summary.go
+++ b/internal/testing/test-summary/test-summary.go
@@ -84,19 +84,21 @@ func run(r io.Reader) (msg string, failures bool, err error) {
 		// However, skips of an entire package are not duplicated with individual
 		// test skips.
 		if event.Test == "" && (event.Action == "pass" || event.Action == "fail") {
-			continue
+		} else {
+			counts[event.Action]++
 		}
-		counts[event.Action]++
 		if event.Action == "fail" {
 			failedTests = append(failedTests, filepath.Join(event.Package, event.Test))
 		}
 		if *progress && (event.Action == "pass" || event.Action == "fail" || event.Action == "skip") {
-			if event.Package == prevPkg {
-				fmt.Printf("%s     %s (%.2fs)\n", event.Action, event.Test, event.Elapsed)
-			} else {
-				path := filepath.Join(event.Package, event.Test)
-				fmt.Printf("%s %s (%.2fs)\n", event.Action, path, event.Elapsed)
-				prevPkg = event.Package
+			if event.Test == "" || (event.Action == "fail" || event.Action == "skip") {
+				if event.Package == prevPkg {
+					fmt.Printf("%s     %s (%.2fs)\n", event.Action, event.Test, event.Elapsed)
+				} else {
+					path := filepath.Join(event.Package, event.Test)
+					fmt.Printf("%s %s (%.2fs)\n", event.Action, path, event.Elapsed)
+					prevPkg = event.Package
+				}
 			}
 		}
 	}

--- a/internal/testing/test-summary/test-summary.go
+++ b/internal/testing/test-summary/test-summary.go
@@ -94,10 +94,10 @@ func run(r io.Reader) (msg string, failures bool, err error) {
 		}
 
 		if *progress {
-			// Only print progress for fail/skip events for packages and tests, or
+			// Only print progress for fail events for packages and tests, or
 			// pass events for packages only (not individual tests, since this is
 			// too noisy).
-			if event.Action == "fail" || event.Action == "skip" || (event.Test == "" && event.Action == "pass") {
+			if event.Action == "fail" || (event.Test == "" && event.Action == "pass") {
 				path := filepath.Join(event.Package, event.Test)
 				fmt.Printf("%s %s (%.2fs)\n", event.Action, path, event.Elapsed)
 			}

--- a/internal/testing/test-summary/test-summary.go
+++ b/internal/testing/test-summary/test-summary.go
@@ -60,7 +60,6 @@ func main() {
 func run(r io.Reader) (msg string, failures bool, err error) {
 	counts := map[string]int{}
 	scanner := bufio.NewScanner(bufio.NewReader(r))
-	prevPkg := "" // In progress mode, the package we previously wrote, to avoid repeating it.
 
 	var failedTests []string
 
@@ -76,29 +75,31 @@ func run(r io.Reader) (msg string, failures bool, err error) {
 		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
 			return "", false, fmt.Errorf("%q: %v", scanner.Text(), err)
 		}
-		if *verbose && event.Action == "output" {
-			fmt.Print(event.Output)
-		}
-		// Ignore pass or fail events that don't have a Test; they refer to the
-		// package as a whole, and we would be over-counting if we included them.
-		// However, skips of an entire package are not duplicated with individual
-		// test skips.
-		if event.Test == "" && (event.Action == "pass" || event.Action == "fail") {
-		} else {
-			counts[event.Action]++
-		}
+
 		if event.Action == "fail" {
 			failedTests = append(failedTests, filepath.Join(event.Package, event.Test))
 		}
-		if *progress && (event.Action == "pass" || event.Action == "fail" || event.Action == "skip") {
-			if event.Test == "" || (event.Action == "fail" || event.Action == "skip") {
-				if event.Package == prevPkg {
-					fmt.Printf("%s     %s (%.2fs)\n", event.Action, event.Test, event.Elapsed)
-				} else {
-					path := filepath.Join(event.Package, event.Test)
-					fmt.Printf("%s %s (%.2fs)\n", event.Action, path, event.Elapsed)
-					prevPkg = event.Package
-				}
+
+		if *verbose && event.Action == "output" {
+			fmt.Print(event.Output)
+		}
+
+		// The Test field, if present, specifies the test, example, or benchmark
+		// function that caused the event. Events for the overall package test do
+		// not set Test. We don't want to count package passes/fails because these
+		// don't represent specific tests being run. However, skips of an entire
+		// package are not duplicated with individual test skips.
+		if event.Test != "" || event.Action == "skip" {
+			counts[event.Action]++
+		}
+
+		if *progress {
+			// Only print progress for fail/skip events for packages and tests, or
+			// pass events for packages only (not individual tests, since this is
+			// too noisy).
+			if event.Action == "fail" || event.Action == "skip" || (event.Test == "" && event.Action == "pass") {
+				path := filepath.Join(event.Package, event.Test)
+				fmt.Printf("%s %s (%.2fs)\n", event.Action, path, event.Elapsed)
 			}
 		}
 	}


### PR DESCRIPTION
Following the discussion in #2171 

Fails/skips reported per test. Passes only reported for whole packages. This seems like a nice compromise between verbosity and utility. For more verboseness we always have the `-verbose` flag.

I've refactored the code a bit, and removed the `prevPkg` logic because it seems unnecessary now and it becomes more tricky to maintain when we only print pass for packages.

Sample output with `-progress` with no failures:

```
skip gocloud.dev (0.00s)
pass gocloud.dev/aws (0.00s)
pass gocloud.dev/gcerrors (0.00s)
pass gocloud.dev/health (0.00s)
pass gocloud.dev/health/sqlhealth (0.00s)
pass gocloud.dev/internal/batcher (0.00s)
pass gocloud.dev/internal/docstore/internal/fields (0.00s)
pass gocloud.dev/aws/awscloud (0.00s)
skip gocloud.dev/aws/rds (0.00s)
skip gocloud.dev/azure/azurecloud (0.00s)
skip gocloud.dev/azure/azuredb (0.00s)
pass gocloud.dev/internal/docstore/driver (0.00s)
pass gocloud.dev/gcp (0.00s)
skip gocloud.dev/blob/memblob/TestConformance/TestSignedURL (0.00s)
pass gocloud.dev/internal/docstore (0.00s)
skip gocloud.dev/blob/memblob/TestConformanceWithPrefix/TestSignedURL (0.00s)
pass gocloud.dev/blob/memblob (0.00s)
pass gocloud.dev/internal/escape (0.00s)
pass gocloud.dev/gcp/gcpcloud (0.00s)
pass gocloud.dev/internal/gcerr (0.00s)
skip gocloud.dev/internal/docstore/memdocstore/TestConformance/TypeDrivenCodec (0.00s)
skip gocloud.dev/internal/docstore/memdocstore/TestConformance/BlindCodec (0.00s)
pass gocloud.dev/internal/docstore/memdocstore (0.00s)
pass gocloud.dev/blob/gcsblob (0.00s)
pass gocloud.dev/internal/oc (0.00s)
pass gocloud.dev/blob/s3blob (0.01s)
pass gocloud.dev/blob/azureblob (0.00s)
pass gocloud.dev/internal/openurl (0.00s)
pass gocloud.dev/internal/trace (0.00s)
pass gocloud.dev/internal/testing/test-summary (0.00s)
pass gocloud.dev/internal/docstore/mongodocstore (0.00s)
pass gocloud.dev/internal/retry (0.00s)
skip gocloud.dev/mysql/TestOpen (0.00s)
pass gocloud.dev/mysql (0.00s)
skip gocloud.dev/mysql/azuremysql/TestOpen (0.10s)
pass gocloud.dev/mysql/azuremysql (0.00s)
skip gocloud.dev/internal/docstore/dynamodocstore/TestConformance/GetQuery/AllByPlayerAsc (0.00s)
skip gocloud.dev/internal/docstore/dynamodocstore/TestConformance/GetQuery/AllByPlayerDesc (0.00s)
skip gocloud.dev/internal/docstore/dynamodocstore/TestConformance/GetQuery/GameByPlayer (0.00s)
pass gocloud.dev/internal/docstore/dynamodocstore (0.00s)
pass gocloud.dev/internal/docstore/firedocstore (0.00s)
skip gocloud.dev/postgres/TestOpen (0.00s)
pass gocloud.dev/postgres (0.00s)
skip gocloud.dev/mysql/cloudmysql/TestOpen (0.04s)
pass gocloud.dev/mysql/cloudmysql (0.00s)
skip gocloud.dev/mysql/rdsmysql/TestOpen (0.05s)
pass gocloud.dev/mysql/rdsmysql (0.00s)
skip gocloud.dev/postgres/rdspostgres/TestOpen (0.08s)
skip gocloud.dev/postgres/rdspostgres/TestOpenBadValues (0.02s)
pass gocloud.dev/postgres/rdspostgres (0.00s)
pass gocloud.dev/requestlog (0.00s)
skip gocloud.dev/postgres/cloudpostgres/TestOpen (0.06s)
skip gocloud.dev/postgres/cloudpostgres/TestOpenBadValue (0.08s)
pass gocloud.dev/postgres/cloudpostgres (0.00s)
pass gocloud.dev/pubsub/mempubsub (0.00s)
pass gocloud.dev/runtimevar (0.00s)
skip gocloud.dev/pubsub/TestReceivePerformance (0.00s)
pass gocloud.dev/pubsub (0.00s)
skip gocloud.dev/pubsub/azuresb/TestConformance (0.00s)
skip gocloud.dev/pubsub/azuresb/TestConformanceWithAutodelete (0.00s)
skip gocloud.dev/pubsub/kafkapubsub/TestConformance/TestNack (3.08s)
pass gocloud.dev/pubsub/azuresb (0.00s)
skip gocloud.dev/pubsub/awssnssqs/TestConformanceSQSTopic/TestSendReceiveTwo (0.00s)
pass gocloud.dev/pubsub/awssnssqs (0.00s)
pass gocloud.dev/pubsub/kafkapubsub (0.01s)
pass gocloud.dev/pubsub/gcppubsub (0.00s)
skip gocloud.dev/pubsub/natspubsub/TestConformance/TestNack (0.03s)
pass gocloud.dev/pubsub/natspubsub (0.00s)
pass gocloud.dev/pubsub/rabbitpubsub (0.00s)
pass gocloud.dev/runtimevar/constantvar (0.00s)
pass gocloud.dev/runtimevar/awsparamstore (0.00s)
pass gocloud.dev/runtimevar/gcpruntimeconfig (0.00s)
pass gocloud.dev/secrets (0.00s)
pass gocloud.dev/runtimevar/etcdvar (0.00s)
pass gocloud.dev/secrets/localsecrets (0.00s)
pass gocloud.dev/runtimevar/httpvar (0.00s)
pass gocloud.dev/secrets/awskms (0.00s)
pass gocloud.dev/secrets/gcpkms (0.00s)
pass gocloud.dev/server (0.00s)
pass gocloud.dev/secrets/azurekeyvault (0.00s)
pass gocloud.dev/secrets/vault (0.00s)
skip gocloud.dev/tests/gcp/app/TestTrace (0.00s)
skip gocloud.dev/tests/gcp/app/TestRequestLog (0.00s)
pass gocloud.dev/tests/gcp/app (0.00s)
skip gocloud.dev/tests/aws/app/TestTrace (0.00s)
skip gocloud.dev/tests/aws/app/TestRequestLog (0.00s)
pass gocloud.dev/tests/aws/app (0.00s)
pass gocloud.dev/blob/fileblob (1.17s)
pass gocloud.dev/runtimevar/blobvar (0.66s)
pass gocloud.dev/runtimevar/filevar (0.84s)
pass gocloud.dev/blob (1.30s)
skip gocloud.dev/blob/driver (0.00s)
skip gocloud.dev/blob/drivertest (0.00s)
skip gocloud.dev/gcp/cloudsql (0.00s)
skip gocloud.dev/internal/docstore/drivertest (0.00s)
skip gocloud.dev/internal/testing (0.00s)
skip gocloud.dev/internal/testing/octest (0.00s)
skip gocloud.dev/internal/testing/setup (0.00s)
skip gocloud.dev/internal/testing/terraform (0.00s)
skip gocloud.dev/internal/useragent (0.00s)
skip gocloud.dev/pubsub/driver (0.00s)
skip gocloud.dev/pubsub/drivertest (0.00s)
skip gocloud.dev/runtimevar/driver (0.00s)
skip gocloud.dev/runtimevar/drivertest (0.00s)
skip gocloud.dev/secrets/driver (0.00s)
skip gocloud.dev/secrets/drivertest (0.00s)
skip gocloud.dev/server/driver (0.00s)
skip gocloud.dev/server/sdserver (0.00s)
skip gocloud.dev/server/xrayserver (0.00s)
skip gocloud.dev/tests/internal/testutil (0.00s)
ran 1581; passed 1532; failed 0; skipped 49
```