### PR TITLE
internal/cmd/gocdk: fix argument length validation for deploy

### DIFF
--- a/internal/cmd/gocdk/deploy.go
+++ b/internal/cmd/gocdk/deploy.go
@@ -25,7 +25,7 @@ func registerDeployCmd(ctx context.Context, pctx *processContext, rootCmd *cobra
 		Use:   "deploy BIOME",
 		Short: "TODO Deploy the biome",
 		Long:  "TODO more about deploy",
-		Args:  cobra.ExactArgs(0),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			biome := args[0]
 			if err := build(ctx, pctx, defaultDockerTag); err != nil {


### PR DESCRIPTION
**Reminder:** Don't merge until after freeze.