### PR TITLE
internal/travis: remove double check for go mod tidy at root

### DIFF
--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -141,13 +141,6 @@ fi;
 
 
 echo
-echo "Ensuring that go mod tidy has been run for the root module..."
-( ./internal/testing/check_mod_tidy.sh && echo "  OK" ) || {
-  echo "FAIL: please run ./internal/testing/gomodcleanup.sh" && result=1
-}
-
-
-echo
 echo "Ensuring that gocdk static content is up to date..."
 tmpstaticgo=$(mktemp)
 function cleanupstaticgo() {


### PR DESCRIPTION
Forgot to remove this when I copied it to the loop above.