### PR TITLE
pubsub/kafkapubsub/tests: make local kafka daemon rebalance faster, speeding up tests

### DIFF
--- a/pubsub/kafkapubsub/localkafka.sh
+++ b/pubsub/kafkapubsub/localkafka.sh
@@ -28,6 +28,6 @@ echo
 # Clean up and run Kafka.
 echo "Starting Kafka..."
 docker rm -f kafka &> /dev/null || :
-docker run -d --net=host -p 9092:9092 --name=kafka -e KAFKA_ZOOKEEPER_CONNECT=localhost:2181 -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092 -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 -e KAFKA_AUTO_CREATE_TOPICS_ENABLE=false confluentinc/cp-kafka:4.1.0 &> /dev/null
+docker run -d --net=host -p 9092:9092 --name=kafka -e KAFKA_ZOOKEEPER_CONNECT=localhost:2181 -e KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=100 -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092 -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 -e KAFKA_AUTO_CREATE_TOPICS_ENABLE=false confluentinc/cp-kafka:5.1.3 &> /dev/null
 echo "...done. Run \"docker rm -f kafka\" to clean up the container."
 echo


### PR DESCRIPTION
Fixes #2185.

Before: 
```
$ cd pubsub/kafkapubsub
$ go test
PASS
ok  	gocloud.dev/pubsub/kafkapubsub	53.279s
```

After: 
```
$ cd pubsub/kafkapubsub
$ go test
PASS
ok  	gocloud.dev/pubsub/kafkapubsub	14.385s
```
