### PR TITLE
internal/gocdk: consolidate some helpers && verify project root dir

### DIFF
--- a/internal/cmd/gocdk/apply.go
+++ b/internal/cmd/gocdk/apply.go
@@ -41,7 +41,7 @@ func registerApplyCmd(ctx context.Context, pctx *processContext, rootCmd *cobra.
 }
 
 func apply(ctx context.Context, pctx *processContext, biome string, input bool) error {
-	moduleRoot, err := findModuleRoot(ctx, pctx.workdir)
+	moduleRoot, err := pctx.ModuleRoot(ctx)
 	if err != nil {
 		return xerrors.Errorf("apply %s: %w", biome, err)
 	}
@@ -54,7 +54,7 @@ func apply(ctx context.Context, pctx *processContext, biome string, input bool) 
 	// dictate the messaging and errors. We should visually differentiate
 	// when we insert verbiage on top of terraform.
 	c := exec.CommandContext(ctx, "terraform", "apply", "-input="+strconv.FormatBool(input))
-	c.Dir = findBiomeDir(moduleRoot, biome)
+	c.Dir = biomeDir(moduleRoot, biome)
 	c.Env = pctx.env
 	c.Stdin = pctx.stdin
 	c.Stdout = pctx.stdout
@@ -69,7 +69,7 @@ func apply(ctx context.Context, pctx *processContext, biome string, input bool) 
 // If one doesn't exist, ensureTerraformInit runs terraform init.
 func ensureTerraformInit(ctx context.Context, pctx *processContext, moduleRoot, biome string, input bool) error {
 	// Check for .terraform directory.
-	biomePath := findBiomeDir(moduleRoot, biome)
+	biomePath := biomeDir(moduleRoot, biome)
 	_, err := os.Stat(filepath.Join(biomePath, ".terraform"))
 	if err == nil {
 		// .terraform exists, no op.

--- a/internal/cmd/gocdk/biome.go
+++ b/internal/cmd/gocdk/biome.go
@@ -36,14 +36,14 @@ type biomeConfig struct {
 	Launcher     *string `json:"launcher,omitempty"`
 }
 
-// biomeRootDir returns the path to the biomes directory.
-func biomeRootDir(moduleRoot string) string {
+// biomesRootDir returns the path to the biomes directory.
+func biomesRootDir(moduleRoot string) string {
 	return filepath.Join(moduleRoot, "biomes")
 }
 
 // biomeDir returns the path to the named biome.
 func biomeDir(moduleRoot, name string) string {
-	return filepath.Join(biomeRootDir(moduleRoot), name)
+	return filepath.Join(biomesRootDir(moduleRoot), name)
 }
 
 // readBiomeConfig reads and parses the biome configuration from the filesystem.

--- a/internal/cmd/gocdk/biome_add.go
+++ b/internal/cmd/gocdk/biome_add.go
@@ -52,15 +52,15 @@ func biomeAdd(ctx context.Context, pctx *processContext, newName string) error {
 	logger := log.New(pctx.stderr, "gocdk: ", log.Ldate|log.Ltime)
 	logger.Printf("Adding biome %q...", newName)
 
-	projectDir, err := findModuleRoot(ctx, pctx.workdir)
+	moduleRoot, err := pctx.ModuleRoot(ctx)
 	if err != nil {
-		xerrors.Errorf("biome add: %w", err)
+		return xerrors.Errorf("biome add: %w", err)
 	}
-	dstPath := findBiomeDir(projectDir, newName)
+	dstPath := biomeDir(moduleRoot, newName)
 	data := struct {
 		ProjectName string
 	}{
-		ProjectName: filepath.Base(projectDir),
+		ProjectName: filepath.Base(moduleRoot),
 	}
 
 	if err := materializeTemplateDir(dstPath, "biome_add", data); err != nil {

--- a/internal/cmd/gocdk/build.go
+++ b/internal/cmd/gocdk/build.go
@@ -54,7 +54,7 @@ func registerBuildCmd(ctx context.Context, pctx *processContext, rootCmd *cobra.
 // TODO(rvangent): Rename ref and/or dockerTag for consistency?
 // https://github.com/google/go-cloud/pull/2144#discussion_r288625539
 func build(ctx context.Context, pctx *processContext, ref string) error {
-	moduleRoot, err := findModuleRoot(ctx, pctx.workdir)
+	moduleRoot, err := pctx.ModuleRoot(ctx)
 	if err != nil {
 		return xerrors.Errorf("gocdk build: %w", err)
 	}
@@ -76,7 +76,7 @@ func build(ctx context.Context, pctx *processContext, ref string) error {
 }
 
 func listBuilds(ctx context.Context, pctx *processContext) error {
-	moduleRoot, err := findModuleRoot(ctx, pctx.workdir)
+	moduleRoot, err := pctx.ModuleRoot(ctx)
 	if err != nil {
 		return xerrors.Errorf("list builds: %w", err)
 	}

--- a/internal/cmd/gocdk/demo_test.go
+++ b/internal/cmd/gocdk/demo_test.go
@@ -36,10 +36,10 @@ func TestAddDemo(t *testing.T) {
 	}
 	defer cleanup()
 
-	// Call the main package run function as if 'add-demo' were being called
+	// Call the main package run function as if 'gocdk demo add' were being called
 	// from the command line for each of the demos.
 	for _, demo := range allDemos {
-		if err := run(ctx, pctx, []string{"demo", "add", demo.name}); err != nil {
+		if err := run(ctx, pctx, []string{"demo", "add", demo}); err != nil {
 			t.Fatalf("run demo error: %+v", err)
 		}
 	}

--- a/internal/cmd/gocdk/init_test.go
+++ b/internal/cmd/gocdk/init_test.go
@@ -170,11 +170,17 @@ func containsLine(data []byte, want string) bool {
 	return false
 }
 
+const testTempDirPrefix = "gocdk-test"
+
 // newTestProject creates a temporary project using "gocdk init" and
 // returns a pctx with workdir set to the project directory, and a cleanup
 // function.
 func newTestProject(ctx context.Context) (*processContext, func(), error) {
 	dir, err := ioutil.TempDir("", testTempDirPrefix)
+	if err != nil {
+		return nil, nil, err
+	}
+	dir, err = filepath.EvalSymlinks(dir) // in case TMPDIR has a symlink like on darwin
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/cmd/gocdk/launch.go
+++ b/internal/cmd/gocdk/launch.go
@@ -52,7 +52,7 @@ func registerLaunchCmd(ctx context.Context, pctx *processContext, rootCmd *cobra
 }
 
 func launch(ctx context.Context, pctx *processContext, biome, dockerImage string) error {
-	moduleRoot, err := findModuleRoot(ctx, pctx.workdir)
+	moduleRoot, err := pctx.ModuleRoot(ctx)
 	if err != nil {
 		return xerrors.Errorf("gocdk launch: %w", err)
 	}
@@ -72,7 +72,7 @@ func launch(ctx context.Context, pctx *processContext, biome, dockerImage string
 		return xerrors.Errorf("gocdk launch: %w", err)
 	}
 	if cfg.Launcher == nil {
-		return xerrors.Errorf("gocdk launch: launcher not specified in %s", filepath.Join(findBiomeDir(moduleRoot, biome), biomeConfigFileName))
+		return xerrors.Errorf("gocdk launch: launcher not specified in %s", filepath.Join(biomeDir(moduleRoot, biome), biomeConfigFileName))
 	}
 	launcher, err := newLauncher(ctx, pctx, *cfg.Launcher)
 	if err != nil {
@@ -81,7 +81,7 @@ func launch(ctx context.Context, pctx *processContext, biome, dockerImage string
 
 	// Read the launch specifier from the biome's Terraform output.
 	tfOutput, err := tfReadOutput(ctx,
-		findBiomeDir(moduleRoot, biome),
+		biomeDir(moduleRoot, biome),
 		pctx.env)
 	if err != nil {
 		return xerrors.Errorf("gocdk launch: %w", err)

--- a/internal/cmd/gocdk/main.go
+++ b/internal/cmd/gocdk/main.go
@@ -139,7 +139,7 @@ func (pctx *processContext) ModuleRoot(ctx context.Context) (string, error) {
 		return "", xerrors.Errorf("couldn't find a Go module root at or above %s", pctx.workdir)
 	}
 	root := string(output)
-	if _, err := os.Stat(biomeRootDir(root)); err != nil {
+	if _, err := os.Stat(biomesRootDir(root)); err != nil {
 		return "", xerrors.Errorf("Go module root %s doesn't look like a Go CDK project (no biomes/ directory)", root)
 	}
 	return root, nil

--- a/internal/cmd/gocdk/main_test.go
+++ b/internal/cmd/gocdk/main_test.go
@@ -16,86 +16,70 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-func TestFindModuleRoot(t *testing.T) {
+func TestProcessContextModuleRoot(t *testing.T) {
+	ctx := context.Background()
 	t.Run("SameDirAsModule", func(t *testing.T) {
-		dir, cleanup, err := newTestModule()
+		pctx, cleanup, err := newTestProject(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer cleanup()
-		dir, err = filepath.EvalSymlinks(dir) // in case TMPDIR has a symlink like on darwin
+
+		got, err := pctx.ModuleRoot(ctx)
+		if got != pctx.workdir || err != nil {
+			t.Errorf("got %q/%v want %q/<nil>", got, err, pctx.workdir)
+		}
+	})
+	t.Run("NoBiomesDir", func(t *testing.T) {
+		pctx, cleanup, err := newTestProject(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer cleanup()
+		if err := os.RemoveAll(biomeRootDir(pctx.workdir)); err != nil {
+			t.Fatal(err)
+		}
 
-		got, err := findModuleRoot(context.Background(), dir)
-		if got != dir || err != nil {
-			t.Errorf("findModuleRoot(ctx, %q) = %q, %v; want %q, <nil>", dir, got, err, dir)
+		if _, err = pctx.ModuleRoot(ctx); err == nil {
+			t.Errorf("got nil error, want non-nil error due to missing biomes/ dir")
 		}
 	})
 	t.Run("NoModFile", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "gocdk-test")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(dir)
-		dir, err = filepath.EvalSymlinks(dir) // in case TMPDIR has a symlink like on darwin
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		got, err := findModuleRoot(context.Background(), dir)
-		if err == nil {
-			t.Errorf("findModuleRoot(ctx, %q) = %q, %v; want _, non-nil", dir, got, err)
-		}
-	})
-	t.Run("ParentDirectory", func(t *testing.T) {
-		dir, cleanup, err := newTestModule()
+		pctx, cleanup, err := newTestProject(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer cleanup()
-		dir, err = filepath.EvalSymlinks(dir) // in case TMPDIR has a symlink like on darwin
+		if err := os.Remove(filepath.Join(pctx.workdir, "go.mod")); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err = pctx.ModuleRoot(ctx); err == nil {
+			t.Errorf("got nil error, want non-nil error due to missing go.mod")
+		}
+	})
+	t.Run("ParentDirectory", func(t *testing.T) {
+		pctx, cleanup, err := newTestProject(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		subdir := filepath.Join(dir, "subdir")
+		defer cleanup()
+
+		rootdir := pctx.workdir
+		subdir := filepath.Join(rootdir, "subdir")
 		if err := os.Mkdir(subdir, 0777); err != nil {
 			t.Fatal(err)
 		}
+		pctx.workdir = subdir
 
-		got, err := findModuleRoot(context.Background(), subdir)
-		if got != dir || err != nil {
-			t.Errorf("findModuleRoot(ctx, %q) = %q, %v; want %q, <nil>", dir, got, err, dir)
+		got, err := pctx.ModuleRoot(ctx)
+		if got != rootdir || err != nil {
+			t.Errorf("got %q/%v want %q/<nil>", got, err, rootdir)
 		}
 	})
-}
-
-const testTempDirPrefix = "gocdk-test"
-
-// newTestModule creates a temporary directory with a go.mod at the root,
-// and returns the path. The returned cleanup function removes the
-// temporary directory and its contents.
-func newTestModule() (string, func(), error) {
-	dir, err := ioutil.TempDir("", testTempDirPrefix)
-	if err != nil {
-		return "", nil, err
-	}
-	cleanup := func() {
-		os.RemoveAll(dir)
-	}
-
-	err = ioutil.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com\n"), 0666)
-	if err != nil {
-		cleanup()
-		return "", nil, err
-	}
-
-	return dir, cleanup, nil
 }

--- a/internal/cmd/gocdk/main_test.go
+++ b/internal/cmd/gocdk/main_test.go
@@ -41,7 +41,7 @@ func TestProcessContextModuleRoot(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer cleanup()
-		if err := os.RemoveAll(biomeRootDir(pctx.workdir)); err != nil {
+		if err := os.RemoveAll(biomesRootDir(pctx.workdir)); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/cmd/gocdk/serve.go
+++ b/internal/cmd/gocdk/serve.go
@@ -56,7 +56,7 @@ func registerServeCmd(ctx context.Context, pctx *processContext, rootCmd *cobra.
 func serve(ctx context.Context, pctx *processContext, opts *serveOptions) error {
 	// Check first that we're in a Go module.
 	var err error
-	opts.moduleRoot, err = findModuleRoot(ctx, pctx.workdir)
+	opts.moduleRoot, err = pctx.ModuleRoot(ctx)
 	if err != nil {
 		return xerrors.Errorf("gocdk serve: %w", err)
 	}
@@ -67,7 +67,7 @@ func serve(ctx context.Context, pctx *processContext, opts *serveOptions) error 
 		// TODO(light): Keep err in formatting chain for debugging.
 		return xerrors.Errorf("gocdk serve: biome configuration not found for %s. "+
 			"Make sure that %s exists and has `\"serve_enabled\": true`.",
-			opts.biome, filepath.Join(findBiomeDir(opts.moduleRoot, opts.biome), biomeConfigFileName))
+			opts.biome, filepath.Join(biomeDir(opts.moduleRoot, opts.biome), biomeConfigFileName))
 	}
 	if err != nil {
 		return xerrors.Errorf("gocdk serve: %w", err)
@@ -75,7 +75,7 @@ func serve(ctx context.Context, pctx *processContext, opts *serveOptions) error 
 	if biomeConfig.ServeEnabled == nil || !*biomeConfig.ServeEnabled {
 		return xerrors.Errorf("gocdk serve: biome %s has not enabled serving. "+
 			"Add `\"serve_enabled\": true` to %s and try again.",
-			opts.biome, filepath.Join(findBiomeDir(opts.moduleRoot, opts.biome), biomeConfigFileName))
+			opts.biome, filepath.Join(biomeDir(opts.moduleRoot, opts.biome), biomeConfigFileName))
 	}
 
 	// Start reverse proxy on address.
@@ -190,7 +190,7 @@ loop:
 		}
 
 		// Read output from Terraform built during apply or refresh.
-		tfOutput, err := tfReadOutput(ctx, findBiomeDir(opts.moduleRoot, opts.biome), pctx.env)
+		tfOutput, err := tfReadOutput(ctx, biomeDir(opts.moduleRoot, opts.biome), pctx.env)
 		if err != nil {
 			logger.Printf("Terraform: %v", err)
 			if process == nil {


### PR DESCRIPTION
Fixes #2210.

I started fixing #2210 (about "demo add" happening even when you're not in the project directory) and kind of went down a rabbit hole:

* I ended up modifying `findModuleRoot` to do the check for whether we're in a Go CDK directory, since we pretty much want this everywhere. I also renamed it to `ModuleRoot` on `processContext` since we always call it with `pctx.workdir`.

* I also renamed `findBiomeDir()` to `biomeDir()` and added `biomeRootDir()`. The `find` seems unnecessary since it's just constructing the path, not finding anything.

* I got rid of the `newTestModule` helper in favor of using `newTestProject`, which uses `gocdk init` to create a Go CDK project. This simplified a few tests where we were having to create `biomes` files etc. manually. In particular, `newTestBiome` is no longer needed.

* Fixed a bug in `biome add` where an error wasn't being returned.

* Simplified list of available demos; we just need the demo name, everything else can be computed.