### PR TITLE
mongodocstore: be more precise about encoding keys

### DIFF
--- a/internal/docstore/docstore.go
+++ b/internal/docstore/docstore.go
@@ -112,9 +112,8 @@ func (l *ActionList) add(a *Action) *ActionList {
 // AlreadyExists is returned if it does. (See gocloud.dev/gcerrors for more on error
 // codes.)
 //
-// If the document doesn't have key
-// fields, key fields with unique values will be created and doc will be populated
-// with them.
+// If the document doesn't have key fields, key fields with unique values will be
+// created and doc will be populated with them.
 //
 // If doc is a map, or a struct with a revision field, then the revision field will
 // be set to the revision of the newly created document.
@@ -195,7 +194,6 @@ func (l *ActionList) Get(doc Document, fps ...FieldPath) *ActionList {
 //
 // Update does not modify its doc argument, except to set the new revision. To obtain
 // the updated document, call Get after calling Update.
-// TODO(jba): test that doc's revision field is updated.
 func (l *ActionList) Update(doc Document, mods Mods) *ActionList {
 	return l.add(&Action{
 		kind: driver.Update,

--- a/internal/docstore/docstore_test.go
+++ b/internal/docstore/docstore_test.go
@@ -158,9 +158,10 @@ func TestToDriverMods(t *testing.T) {
 	} {
 		got, gotErr := toDriverMods(test.mods)
 		if test.wantErr {
-			if gotErr == nil {
-				t.Errorf("%v: got nil, want error", test.mods)
+			if gcerrors.Code(gotErr) != gcerrors.InvalidArgument {
+				t.Errorf("%v: got error '%v', want InvalidArgument", test.mods, gotErr)
 			}
+
 		} else if !cmp.Equal(got, test.want) {
 			t.Errorf("%v: got %v, want %v", test.mods, got, test.want)
 		}

--- a/internal/docstore/driver/codec.go
+++ b/internal/docstore/driver/codec.go
@@ -201,8 +201,8 @@ func encode(v reflect.Value, enc Encoder) error {
 
 // Encode an array or non-nil slice.
 func encodeList(v reflect.Value, enc Encoder) error {
-	// Byte slices or byte arrays encode specially.
-	if v.Type().Elem().Kind() == reflect.Uint8 {
+	// Byte slices encode specially.
+	if v.Type().Kind() == reflect.Slice && v.Type().Elem().Kind() == reflect.Uint8 {
 		enc.EncodeBytes(v.Bytes())
 		return nil
 	}

--- a/internal/docstore/driver/codec_test.go
+++ b/internal/docstore/driver/codec_test.go
@@ -111,6 +111,7 @@ func TestEncode(t *testing.T) {
 		{seven, int64(seven)},
 		{&seven, int64(seven)},
 		{[]byte{1, 2}, []byte{1, 2}},
+		{[2]byte{3, 4}, []interface{}{uint64(3), uint64(4)}},
 		{[]int(nil), nil},
 		{[]int{}, []interface{}{}},
 		{[]int{1, 2}, []interface{}{int64(1), int64(2)}},

--- a/internal/docstore/driver/driver.go
+++ b/internal/docstore/driver/driver.go
@@ -30,6 +30,9 @@ type Collection interface {
 	// can't generate a missing key, it should return an error.
 	//
 	// The returned key must be comparable.
+	//
+	// The returned key should not be encoded with the provider's codec; it should
+	// be the user-supplied Go value.
 	Key(Document) (interface{}, error)
 
 	// RunActions executes a slice of actions.

--- a/internal/docstore/drivertest/drivertest.go
+++ b/internal/docstore/drivertest/drivertest.go
@@ -244,6 +244,9 @@ func testCreate(t *testing.T, coll *ds.Collection) {
 
 	createThenGet(named)
 	createThenGet(unnamed)
+	if unnamed[KeyField] == nil {
+		t.Error("unnamed[KeyField]: got nil, want a generated key")
+	}
 
 	// Can't create an existing doc.
 	// TODO(jba): test for NotFound code

--- a/internal/docstore/dynamodocstore/dynamo.go
+++ b/internal/docstore/dynamodocstore/dynamo.go
@@ -474,9 +474,6 @@ func (c *collection) delete(ctx context.Context, doc driver.Document, condition 
 }
 
 func (c *collection) update(ctx context.Context, doc driver.Document, mods []driver.Mod, condition *expression.ConditionBuilder) error {
-	if len(mods) == 0 {
-		return nil
-	}
 	av, err := encodeDocKeyFields(doc, c.partitionKey, c.sortKey)
 	if err != nil {
 		return err

--- a/internal/docstore/memdocstore/mem.go
+++ b/internal/docstore/memdocstore/mem.go
@@ -300,10 +300,7 @@ func (c *collection) update(doc map[string]interface{}, mods []driver.Mod) error
 			m.parentMap[m.key] = m.encodedValue
 		}
 	}
-	// TODO(jba): we shouldn't have to check len(mods) because it should never be zero.
-	if len(mods) > 0 {
-		c.changeRevision(doc)
-	}
+	c.changeRevision(doc)
 	return nil
 }
 

--- a/internal/docstore/mongodocstore/codec.go
+++ b/internal/docstore/mongodocstore/codec.go
@@ -62,11 +62,15 @@ func (e *encoder) EncodeString(x string) { e.val = x }
 func (e *encoder) ListIndex(int)         { panic("impossible") }
 func (e *encoder) MapKey(string)         { panic("impossible") }
 
-var typeOfGoTime = reflect.TypeOf(time.Time{})
+var (
+	typeOfGoTime   = reflect.TypeOf(time.Time{})
+	typeOfObjectID = reflect.TypeOf(primitive.ObjectID{})
+)
 
 func (e *encoder) EncodeSpecial(v reflect.Value) (bool, error) {
-	// Treat time "specially" as itself (otherwise its BinaryMarshal method will be called).
-	if v.Type() == typeOfGoTime {
+	// Treat time specially as itself (otherwise its BinaryMarshal method will be called).
+	// Also, ObjectIDs are already encoded.
+	if v.Type() == typeOfGoTime || v.Type() == typeOfObjectID {
 		e.val = v.Interface()
 		return true, nil
 	}


### PR DESCRIPTION
- Fix bug in driver codec where byte arrays are mistakenly encoded as byte slices.

- Distinguish between encoded and unencoded document IDs.

Also, remove driver code for len(mods) == 0 because that can't happen.

And some other minor changes.