### PR TITLE
pubsub/natspubsub: upgrade deps and enable previously-flaky test

### DIFF
--- a/internal/testing/alldeps
+++ b/internal/testing/alldeps
@@ -61,6 +61,7 @@ github.com/mitchellh/go-homedir
 github.com/mitchellh/go-testing-interface
 github.com/mitchellh/mapstructure
 github.com/nats-io/go-nats
+github.com/nats-io/nats.go
 github.com/nats-io/nkeys
 github.com/nats-io/nuid
 github.com/oklog/run

--- a/internal/website/data/examples.json
+++ b/internal/website/data/examples.json
@@ -160,11 +160,11 @@
 		"code": "topic, err := pubsub.OpenTopic(ctx, \"mem://topicA\")\nif err != nil {\n\treturn err\n}\ndefer topic.Shutdown(ctx)"
 	},
 	"gocloud.dev/pubsub/natspubsub.ExampleOpenSubscription": {
-		"imports": "import (\n\t\"context\"\n\n\t\"github.com/nats-io/go-nats\"\n\t\"gocloud.dev/pubsub/natspubsub\"\n)",
+		"imports": "import (\n\t\"context\"\n\n\t\"github.com/nats-io/nats.go\"\n\t\"gocloud.dev/pubsub/natspubsub\"\n)",
 		"code": "natsConn, err := nats.Connect(\"nats://nats.example.com\")\nif err != nil {\n\treturn err\n}\ndefer natsConn.Close()\n\nsubscription, err := natspubsub.OpenSubscription(\n\tnatsConn,\n\t\"example.mysubject\",\n\tnil)\nif err != nil {\n\treturn err\n}\ndefer subscription.Shutdown(ctx)"
 	},
 	"gocloud.dev/pubsub/natspubsub.ExampleOpenTopic": {
-		"imports": "import (\n\t\"context\"\n\n\t\"github.com/nats-io/go-nats\"\n\t\"gocloud.dev/pubsub/natspubsub\"\n)",
+		"imports": "import (\n\t\"context\"\n\n\t\"github.com/nats-io/nats.go\"\n\t\"gocloud.dev/pubsub/natspubsub\"\n)",
 		"code": "natsConn, err := nats.Connect(\"nats://nats.example.com\")\nif err != nil {\n\treturn err\n}\ndefer natsConn.Close()\n\ntopic, err := natspubsub.OpenTopic(natsConn, \"example.mysubject\", nil)\nif err != nil {\n\treturn err\n}\ndefer topic.Shutdown(ctx)"
 	},
 	"gocloud.dev/pubsub/natspubsub.Example_openSubscriptionFromURL": {

--- a/pubsub/natspubsub/example_test.go
+++ b/pubsub/natspubsub/example_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/natspubsub"
 )

--- a/pubsub/natspubsub/go.mod
+++ b/pubsub/natspubsub/go.mod
@@ -16,9 +16,7 @@ module gocloud.dev/pubsub/natspubsub
 
 require (
 	github.com/google/go-cmp v0.3.0
-	github.com/nats-io/gnatsd v1.4.1
-	github.com/nats-io/go-nats v1.7.2
-	github.com/nats-io/nkeys v0.0.2 // indirect
-	github.com/nats-io/nuid v1.0.1 // indirect
+	github.com/nats-io/nats-server/v2 v2.0.0
+	github.com/nats-io/nats.go v1.8.1
 	gocloud.dev v0.15.0
 )

--- a/pubsub/natspubsub/go.sum
+++ b/pubsub/natspubsub/go.sum
@@ -96,10 +96,12 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nats-io/gnatsd v1.4.1 h1:RconcfDeWpKCD6QIIwiVFcvForlXpWeJP7i5/lDLy44=
-github.com/nats-io/gnatsd v1.4.1/go.mod h1:nqco77VO78hLCJpIcVfygDP2rPGfsEHkGTUk94uh5DQ=
-github.com/nats-io/go-nats v1.7.2 h1:cJujlwCYR8iMz5ofZSD/p2WLW8FabhkQ2lIEVbSvNSA=
-github.com/nats-io/go-nats v1.7.2/go.mod h1:+t7RHT5ApZebkrQdnn6AhQJmhJJiKAvJUio1PiiCtj0=
+github.com/nats-io/jwt v0.2.6 h1:eAyoYvGgGLXR2EpnsBUvi/FcFrBqN6YKFVbOoEfPN4k=
+github.com/nats-io/jwt v0.2.6/go.mod h1:mQxQ0uHQ9FhEVPIcTSKwx2lqZEpXWWcCgA7R6NrWvvY=
+github.com/nats-io/nats-server/v2 v2.0.0 h1:rbFV7gfUPErVdKImVMOlW8Qb1V22nlcpqup5cb9rYa8=
+github.com/nats-io/nats-server/v2 v2.0.0/go.mod h1:RyVdsHHvY4B6c9pWG+uRLpZ0h0XsqiuKp2XCTurP5LI=
+github.com/nats-io/nats.go v1.8.1 h1:6lF/f1/NN6kzUDBz6pyvQDEXO39jqXcWRLu/tKjtOUQ=
+github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
 github.com/nats-io/nkeys v0.0.2 h1:+qM7QpgXnvDDixitZtQUBDY9w/s9mu1ghS+JIbsrx6M=
 github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
@@ -148,6 +150,8 @@ golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd h1:sMHc2rZHuzQmrbVoSpt9HgerkXPyIeCSO6k0zUMGfFk=
 golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5 h1:8dUaAV7K4uHsF56JQWkprecIQKdPHtR9jCHF5nB8uzc=
+golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=

--- a/pubsub/natspubsub/nats.go
+++ b/pubsub/natspubsub/nats.go
@@ -55,7 +55,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"gocloud.dev/gcerrors"
 	"gocloud.dev/internal/batcher"
 	"gocloud.dev/pubsub"

--- a/pubsub/natspubsub/nats_test.go
+++ b/pubsub/natspubsub/nats_test.go
@@ -27,9 +27,9 @@ import (
 	"gocloud.dev/pubsub/drivertest"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/nats-io/gnatsd/server"
-	gnatsd "github.com/nats-io/gnatsd/test"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats-server/v2/server"
+	gnatsd "github.com/nats-io/nats-server/v2/test"
+	"github.com/nats-io/nats.go"
 )
 
 const (
@@ -202,6 +202,10 @@ func TestInteropWithDirectNATS(t *testing.T) {
 		t.Fatal(err)
 	}
 	msg, err := ps.Receive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer msg.Ack()
 	if !bytes.Equal(msg.Body, body) {
 		t.Fatalf("Data did not match. %q vs %q\n", m.Data, body)
 	}
@@ -275,8 +279,6 @@ func TestErrorCode(t *testing.T) {
 	}
 }
 
-/* Temporarily disabled due to #1556, a data race in NATS.
-
 func TestBadSubjects(t *testing.T) {
 	ctx := context.Background()
 	dh, err := newHarness(ctx, t)
@@ -286,7 +288,7 @@ func TestBadSubjects(t *testing.T) {
 	defer dh.Close()
 	h := dh.(*harness)
 
-	sub, err := CreateSubscription(h.nc, "..bad", func() { t.Fatal("ack called unexpectedly") }, nil)
+	sub, err := OpenSubscription(h.nc, "..bad", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +296,7 @@ func TestBadSubjects(t *testing.T) {
 		t.Fatal("Expected an error with bad subject")
 	}
 
-	pt, err := CreateTopic(h.nc, "..bad", nil)
+	pt, err := OpenTopic(h.nc, "..bad", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,7 +304,6 @@ func TestBadSubjects(t *testing.T) {
 		t.Fatal("Expected an error with bad subject")
 	}
 }
-*/
 
 func BenchmarkNatsPubSub(b *testing.B) {
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #1556.

NATS also renamed their repo, so I had to update the `import` paths. Strangely, they chose a repo name that ends with `.go`.