### PR TITLE
releasehelper: fix test to be OS-agnostic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
     - go: "1.12.x"
       os: windows
       # Only run Windows build job on master; it's very slow.
-      #if: branch = master AND type = push
+      if: branch = master AND type = push
       # TODO(rvangent): Remove filter_secrets: false once the Travis issue is fixed:
       # https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264/10
       filter_secrets: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
     - go: "1.12.x"
       os: windows
       # Only run Windows build job on master; it's very slow.
-      if: branch = master AND type = push
+      #if: branch = master AND type = push
       # TODO(rvangent): Remove filter_secrets: false once the Travis issue is fixed:
       # https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264/10
       filter_secrets: false

--- a/internal/releasehelper/releasehelper_test.go
+++ b/internal/releasehelper/releasehelper_test.go
@@ -91,8 +91,8 @@ func Test(t *testing.T) {
 	}
 
 	replaceLines := []string{
-		"replace gocloud.dev => ../",
-		"replace gocloud.dev/submod => ../submod"}
+		"replace gocloud.dev => " + filepath.Clean("../"),
+		"replace gocloud.dev/submod => " + filepath.Clean("../submod")}
 
 	for _, line := range replaceLines {
 		if !strings.Contains(string(c), line) {


### PR DESCRIPTION
 Fix releasehelper test to be OS-agnostic w.r.t. path separators
    
Fixes #2264
