### PR TITLE
internal/cmd/gocdk: infer module path if multiple GOPATH entries exist

### DIFF
--- a/internal/cmd/gocdk/init.go
+++ b/internal/cmd/gocdk/init.go
@@ -17,7 +17,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	slashpath "path"
@@ -149,10 +148,6 @@ func inferModulePath(ctx context.Context, pctx *processContext, projectDir strin
 	// so Output can collect stdout.
 	cmd.Stdout = nil
 	gopath, err := cmd.Output()
-	fmt.Println("FROM PCTX-- " + pctx.env[0])
-	fmt.Println("FROM CMD-- " + cmd.Env[0])
-	fmt.Println("WHAT IS HAPPENING HERE-- " + string(gopath))
-	fmt.Println(err)
 	if err != nil {
 		return "", xerrors.Errorf("infer module path: %w", err)
 	}

--- a/internal/cmd/gocdk/init.go
+++ b/internal/cmd/gocdk/init.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	slashpath "path"
@@ -149,6 +150,10 @@ func inferModulePath(ctx context.Context, pctx *processContext, projectDir strin
 	// so Output can collect stdout.
 	cmd.Stdout = nil
 	gopath, err := cmd.Output()
+	fmt.Println("FROM PCTX-- " + pctx.env[0])
+	fmt.Println("FROM CMD-- " + cmd.Env[0])
+	fmt.Println("WHAT IS HAPPENING HERE-- " + string(gopath))
+	fmt.Println(err)
 	if err != nil {
 		return "", xerrors.Errorf("infer module path: %w", err)
 	}

--- a/internal/cmd/gocdk/init.go
+++ b/internal/cmd/gocdk/init.go
@@ -144,7 +144,6 @@ func materializeTemplateDir(dst string, srcRoot string, data interface{}) error 
 // inferModulePath will check the default GOPATH to attempt to infer the module
 // import path for the project.
 func inferModulePath(ctx context.Context, pctx *processContext, projectDir string) (string, error) {
-	// TODO(issue #2016): Add tests for init behavior when module-path is not given.
 	cmd := pctx.NewCommand(ctx, "", "go", "env", "GOPATH")
 	// Since we're going to call Output, we need to make sure cmd.Stdout is nil
 	// so Output can collect stdout.

--- a/internal/cmd/gocdk/init_test.go
+++ b/internal/cmd/gocdk/init_test.go
@@ -198,15 +198,8 @@ func TestInferModulePath(t *testing.T) {
 
 			err = run(ctx, pctx, []string{"init", "myspecialproject"})
 
-			switch tc.wantErr {
-			case true:
-				if err == nil {
-					t.Errorf("got nil error, want non-nil error")
-				}
-			case false:
-				if err != nil {
-					t.Errorf("inferModulePath errored: %+v", err)
-				}
+			if (err != nil) != tc.wantErr {
+				t.Errorf("got err %v but wantErr is %v", err, tc.wantErr)
 			}
 		})
 	}

--- a/internal/cmd/gocdk/init_test.go
+++ b/internal/cmd/gocdk/init_test.go
@@ -186,6 +186,7 @@ func TestInferModulePath(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir, err := ioutil.TempDir("", testTempDirPrefix)
@@ -198,9 +199,7 @@ func TestInferModulePath(t *testing.T) {
 				}
 			}()
 
-			ctx := context.Background()
 			pctx := newTestProcessContext(dir)
-
 			gopath, cleanup := tc.testGOPATH(dir)
 			defer cleanup()
 			pctx.env = []string{gopath}

--- a/internal/cmd/gocdk/init_test.go
+++ b/internal/cmd/gocdk/init_test.go
@@ -171,7 +171,7 @@ func TestInferModulePath(t *testing.T) {
 		{
 			"multiple GOPATH entries",
 			func(dir string) string {
-				multiPath := "GOPATH=" + dir + ":" + filepath.Join("", "some", "other", "path")
+				multiPath := "GOPATH=" + dir + string(filepath.ListSeparator) + filepath.Join("", "some", "other", "path")
 				fmt.Println("INSIDE--" + multiPath)
 				return multiPath
 			},


### PR DESCRIPTION
fixes #2157 
fixes #2016 