### PR TITLE
internal/gocdk: fix flaky record/replay tests

### DIFF
--- a/internal/cmd/gocdk/main.go
+++ b/internal/cmd/gocdk/main.go
@@ -166,7 +166,7 @@ func (pctx *processContext) ModuleRoot(ctx context.Context) (string, error) {
 	c.Dir = pctx.workdir
 	output, err := c.Output()
 	if err != nil {
-		return "", xerrors.Errorf("couldn't find a Go module root at or above %s: %w", pctx.workdir, err)
+		return "", xerrors.Errorf("couldn't find a Go module root at or above %s", pctx.workdir)
 	}
 	output = bytes.TrimSuffix(output, []byte("\n"))
 	if len(output) == 0 {

--- a/internal/cmd/gocdk/main_test.go
+++ b/internal/cmd/gocdk/main_test.go
@@ -300,7 +300,7 @@ func doList(dir string, out io.Writer, arg, indent string) error {
 func scrub(rootDir string, b []byte) []byte {
 	const scrubbedRootDir = "[ROOTDIR]"
 	rootDirWithSeparator := rootDir + string(filepath.Separator)
-	scrubbedRootDirWithSeparator := scrubbedRootDir + string(filepath.Separator)
+	scrubbedRootDirWithSeparator := scrubbedRootDir + "/"
 	b = bytes.Replace(b, []byte(rootDirWithSeparator), []byte(scrubbedRootDirWithSeparator), -1)
 	b = bytes.Replace(b, []byte(rootDir), []byte(scrubbedRootDir), -1)
 	return b


### PR DESCRIPTION
1. We emit a different error if you're not in the right directory depending on `GO111MODULE` and what version of Go you're using; the exit "exit code 1" is not useful so I just trimmed the error message.

2. I tried to fix Windows in a previous PR but scrubbed using the `\', it should always be `/` so the replay file works on all platforms.