### PR TITLE
internal/cmd/gocdk: factor out WaitForHealthy to a separate package

### DIFF
--- a/internal/cmd/gocdk/internal/probe/probe.go
+++ b/internal/cmd/gocdk/internal/probe/probe.go
@@ -1,0 +1,67 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package probe provides a function for waiting for a server endpoint to
+// become available.
+package probe
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/xerrors"
+)
+
+// WaitForHealthy polls a URL repeatedly until the server responds with a
+// non-server-error status, the context is canceled, or the context's deadline
+// is met. WaitForHealthy returns an error in the latter two cases.
+func WaitForHealthy(ctx context.Context, u *url.URL) error {
+	// Create health request.
+	// (Avoiding http.NewRequest to not reparse the URL.)
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    u,
+	}
+	req = req.WithContext(ctx)
+
+	// Poll for healthy.
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		// Check response. Allow 200-level (success) or 400-level (client error)
+		// status codes. The latter is permitted for the case where the application
+		// doesn't serve explicit health checks.
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil && (statusCodeInRange(resp.StatusCode, 200) || statusCodeInRange(resp.StatusCode, 400)) {
+			return nil
+		}
+		// Wait for the next tick.
+		select {
+		case <-tick.C:
+		case <-ctx.Done():
+			return xerrors.Errorf("wait for healthy: %w", ctx.Err())
+		}
+	}
+}
+
+// statusCodeInRange reports whether the given HTTP status code is in the range
+// [start, start+100).
+func statusCodeInRange(statusCode, start int) bool {
+	if start < 100 || start%100 != 0 {
+		panic("statusCodeInRange start must be a multiple of 100")
+	}
+	return start <= statusCode && statusCode < start+100
+}

--- a/internal/cmd/gocdk/internal/probe/probe_test.go
+++ b/internal/cmd/gocdk/internal/probe/probe_test.go
@@ -1,0 +1,111 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package probe provides a function for waiting for a server endpoint to
+// become available.
+package probe
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"gocloud.dev/health"
+	"golang.org/x/xerrors"
+)
+
+func TestWaitForHealthy(t *testing.T) {
+	t.Run("ImmediateHealthy", func(t *testing.T) {
+		srv := httptest.NewServer(new(health.Handler))
+		defer srv.Close()
+		u, err := url.Parse(srv.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := WaitForHealthy(context.Background(), u); err != nil {
+			t.Error("waitForHealthy returned error:", err)
+		}
+	})
+	t.Run("404", func(t *testing.T) {
+		srv := httptest.NewServer(http.NotFoundHandler())
+		defer srv.Close()
+		u, err := url.Parse(srv.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := WaitForHealthy(context.Background(), u); err != nil {
+			t.Error("waitForHealthy returned error:", err)
+		}
+	})
+	t.Run("SecondTimeHealthy", func(t *testing.T) {
+		handler := new(health.Handler)
+		handler.Add(new(secondTimeHealthy))
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
+		u, err := url.Parse(srv.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := WaitForHealthy(context.Background(), u); err != nil {
+			t.Error("waitForHealthy returned error:", err)
+		}
+	})
+	t.Run("ContextCancelled", func(t *testing.T) {
+		handler := new(health.Handler)
+		handler.Add(constHealthChecker{xerrors.New("bad")})
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
+		u, err := url.Parse(srv.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+
+		err = WaitForHealthy(ctx, u)
+		cancel()
+		if err == nil {
+			t.Error("waitForHealthy did not return error")
+		}
+	})
+}
+
+type constHealthChecker struct {
+	err error
+}
+
+func (c constHealthChecker) CheckHealth() error {
+	return c.err
+}
+
+type secondTimeHealthy struct {
+	mu            sync.Mutex
+	firstReported bool
+}
+
+func (c *secondTimeHealthy) CheckHealth() error {
+	defer c.mu.Unlock()
+	c.mu.Lock()
+	if !c.firstReported {
+		c.firstReported = true
+		return xerrors.New("check again later")
+	}
+	return nil
+}

--- a/internal/cmd/gocdk/launch.go
+++ b/internal/cmd/gocdk/launch.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 	"gocloud.dev/gcp"
 	"gocloud.dev/internal/cmd/gocdk/internal/docker"
+	"gocloud.dev/internal/cmd/gocdk/internal/probe"
 	"golang.org/x/xerrors"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
@@ -190,7 +191,7 @@ func (local *localLauncher) Launch(ctx context.Context, input *LaunchInput) (*ur
 		Host:   serveURL.Host,
 		Path:   "/healthz/readiness",
 	}
-	if err := waitForHealthy(ctx, healthCheckURL); err != nil {
+	if err := probe.WaitForHealthy(ctx, healthCheckURL); err != nil {
 		// TODO(light): Run `docker stop`.
 		return nil, xerrors.Errorf("local launch: %w", err)
 	}

--- a/internal/website/content/internal/cmd/gocdk/internal/probe/_index.md
+++ b/internal/website/content/internal/cmd/gocdk/internal/probe/_index.md
@@ -1,0 +1,4 @@
+---
+title: gocloud.dev/internal/cmd/gocdk/internal/probe
+type: pkg
+---


### PR DESCRIPTION
Needed for launchers to be in a separate package.

Updates #2046