### PR TITLE
testing: Add option to have extra fields in allmodules

### DIFF
--- a/internal/testing/check_api_change.sh
+++ b/internal/testing/check_api_change.sh
@@ -87,7 +87,7 @@ while read -r path || [[ -n "$path" ]]; do
     fi
   done
   popd &> /dev/null
-done < <( sed -e '/^#/d' -e '/^$/d' allmodules )
+done < <( sed -e '/^#/d' -e '/^$/d' allmodules | awk '{print $1}' )
 
 if [ ${#incompatible_change_pkgs[@]} -eq 0 ]; then
   # No incompatible changes, we are good.

--- a/internal/testing/gomodcleanup.sh
+++ b/internal/testing/gomodcleanup.sh
@@ -19,7 +19,7 @@
 # form that Travis will verify (see check_mod_tidy.sh).
 set -euo pipefail
 
-sed -e '/^#/d' -e '/^$/d' allmodules | while read -r path || [[ -n "$path" ]]; do
+sed -e '/^#/d' -e '/^$/d' allmodules | awk '{print $1}' | while read -r path || [[ -n "$path" ]]; do
   echo "cleaning up $path"
   ( cd "$path" && go mod tidy && go list -deps ./... &> /dev/null || echo "  FAILED!")
 done

--- a/internal/testing/listdeps.sh
+++ b/internal/testing/listdeps.sh
@@ -29,7 +29,7 @@ function cleanup() {
 trap cleanup EXIT
 
 
-sed -e '/^#/d' -e '/^$/d' allmodules | while read -r path || [[ -n "$path" ]]; do
+sed -e '/^#/d' -e '/^$/d' allmodules | awk '{print $1}' | while read -r path || [[ -n "$path" ]]; do
   ( cd "$path" && go list -mod=readonly -deps -f '{{with .Module}}{{.Path}}{{end}}' ./... >> "$tmpfile")
 done
 

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -112,11 +112,12 @@ while read -r path || [[ -n "$path" ]]; do
     echo "Running go mod tidy:"
     ( "$rootdir"/internal/testing/check_mod_tidy.sh && echo "  OK" ) || { echo "FAIL: please run ./internal/testing/gomodcleanup.sh" && result=1; }
     echo "Running wire diff:"
-    ( wire diff ./... && echo "  OK " ) || { echo "FAIL: wire diff found diffs!" && result=1; }
+    ( wire diff ./... && echo "  OK" ) || { echo "FAIL: wire diff found diffs!" && result=1; }
   fi
   popd &> /dev/null
-done < <( sed -e '/^#/d' -e '/^$/d' allmodules )
-# The above filters out comments and empty lines from allmodules.
+done < <( sed -e '/^#/d' -e '/^$/d' allmodules | awk '{print $1}' )
+# The above filters out comments and empty lines from allmodules and only takes
+# the first (whitespace-separated) field from each line.
 
 # Upload cumulative coverage data if we generated it.
 if [ -f coverage.out ] && [ $result -eq 0 ]; then

--- a/internal/website/gatherexamples/run.sh
+++ b/internal/website/gatherexamples/run.sh
@@ -16,4 +16,4 @@
 # Run gatherexamples for the project.
 
 set -eo pipefail
-sed -e '/^#/d' -e '/^$/d' allmodules | xargs go run internal/website/gatherexamples/gatherexamples.go
+sed -e '/^#/d' -e '/^$/d' allmodules | awk '{print $1}' | xargs go run internal/website/gatherexamples/gatherexamples.go


### PR DESCRIPTION
This PR teaches all our shell scripts that procses allmodules to ignore
any additional whitespace-separated fields.

The next step will be to add special purpose fields for selective
tagging -- #2284

Updates #2111
