### PR TITLE
internal/website: add draft news section

### DIFF
--- a/internal/website/config.toml
+++ b/internal/website/config.toml
@@ -11,6 +11,9 @@ section = ["HTML"]
 taxonomy = ["HTML"]
 taxonomyTerm = ["HTML", "RSS"]
 
+[permalinks]
+news = "/news/:year/:month/:filename/"
+
 [[menu.footer]]
 identifier = "github"
 name = "GitHub"

--- a/internal/website/content/concepts/_index.md
+++ b/internal/website/content/concepts/_index.md
@@ -3,7 +3,7 @@ title: "Concepts"
 date: 2019-05-06T09:52:00-07:00
 showInSidenav: true
 pagesInSidenav: true
-weight: 4
+weight: 5
 ---
 
 The documents in this section describe higher level concepts in the Go CDK.

--- a/internal/website/content/howto/_index.md
+++ b/internal/website/content/howto/_index.md
@@ -3,7 +3,7 @@ title: "How-To Guides"
 date: 2019-03-20T14:50:56-07:00
 showInSidenav: true
 pagesInSidenav: true
-weight: 2
+weight: 3
 ---
 
 The guides in this section are aimed to help you solve common tasks with

--- a/internal/website/content/news/_index.md
+++ b/internal/website/content/news/_index.md
@@ -1,0 +1,10 @@
+---
+title: "News"
+date: 2019-06-07T14:23:54-07:00
+draft: true
+showInSidenav: true
+pagesInSidenav: false
+weight: 1
+outputs: ["html", "rss"]
+---
+

--- a/internal/website/content/news/wire-beta.md
+++ b/internal/website/content/news/wire-beta.md
@@ -1,0 +1,26 @@
+---
+title: Wire is now Beta!
+date: 2019-06-07T14:24:00-07:00
+draft: true
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at leo
+rhoncus, tempor nisi sed, gravida elit. Orci varius natoque penatibus et
+magnis dis parturient montes, nascetur ridiculus mus. Fusce at vehicula diam.
+Pellentesque id vehicula mauris. Duis congue placerat congue. Ut et enim
+libero. Vestibulum felis turpis, hendrerit molestie luctus quis, fringilla ut
+ante. In non diam ac nibh vestibulum cursus. Fusce malesuada, sapien non
+commodo euismod, quam diam bibendum libero, vel ultricies mi quam ut leo.
+
+<!--more-->
+
+Quisque justo diam, viverra vestibulum vulputate a, porttitor sed nisi. Sed
+gravida ex lectus, ac semper ex commodo vitae. Quisque luctus vestibulum
+fringilla. Nulla sed velit id sem fermentum hendrerit. Orci varius natoque
+penatibus et magnis dis parturient montes, nascetur ridiculus mus. Maecenas
+eleifend, odio vel bibendum lacinia, est velit posuere ex, in posuere mauris
+mi et diam. Proin at congue libero. Vivamus diam justo, ullamcorper non
+turpis id, cursus tincidunt libero. Duis in arcu accumsan erat pellentesque
+finibus suscipit sit amet lacus. Sed vehicula nisl vitae libero eleifend
+tincidunt. Ut at maximus diam, ac cursus lectus. Nulla semper leo aliquet
+imperdiet imperdiet.

--- a/internal/website/content/ref/_index.md
+++ b/internal/website/content/ref/_index.md
@@ -3,7 +3,7 @@ title: Reference
 date: 2019-03-15T12:45:41-07:00
 showInSidenav: true
 pagesInSidenav: true
-weight: 3
+weight: 4
 ---
 
 <!--more-->

--- a/internal/website/content/tutorials/_index.md
+++ b/internal/website/content/tutorials/_index.md
@@ -3,6 +3,6 @@ title: "Tutorials"
 date: 2019-03-19T18:45:15-07:00
 showInSidenav: true
 pagesInSidenav: true
-weight: 1
+weight: 2
 ---
 

--- a/internal/website/layouts/news/li.html
+++ b/internal/website/layouts/news/li.html
@@ -1,0 +1,6 @@
+<article class="NewsList-item">
+  <a href="{{.RelPermalink}}"><h2 class="NewsList-itemTitle">{{ .LinkTitle }}</h2></a>
+  <div class="NewsList-postInfo">Posted on <time datetime="{{.Date.UTC.Format "2006-01-02T15:04:05Z"}}">{{ .Date.Format "2006-01-02" }}</time></div>
+  <div class="NewsList-summary">{{.Summary}}</div>
+  <div class="NewsList-readMore"><a href="{{.RelPermalink}}">Read more&hellip;</a></div>
+</article>

--- a/internal/website/layouts/news/list.html
+++ b/internal/website/layouts/news/list.html
@@ -1,0 +1,11 @@
+{{ define "main" -}}
+<h1>{{ .Title }}</h1>
+{{ .Content }}
+{{ with .Data.Pages }}
+<div class="NewsList">
+{{- range .}}
+  {{.Render "li"}}
+{{- end }}
+</div>
+{{end}}
+{{- end }}

--- a/internal/website/layouts/news/single.html
+++ b/internal/website/layouts/news/single.html
@@ -1,0 +1,5 @@
+{{ define "main" -}}
+<h1>{{ .Title }}</h1>
+<div class="NewsPostInfo">Posted on <time datetime="{{.Date.UTC.Format "2006-01-02T15:04:05Z"}}">{{ .Date.Format "2006-01-02" }}</time></div>
+{{ .Content }}
+{{- end }}

--- a/internal/website/static/css/style.css
+++ b/internal/website/static/css/style.css
@@ -207,7 +207,20 @@ body {
   margin: 0.5rem 0 0.5rem 2rem;
   padding: 0;
 }
-
+/* News {{{1 */
+.NewsList-itemTitle {
+  color: #000;
+}
+.NewsList-postInfo {
+  font-size: 0.9rem;
+}
+.NewsList-readMore {
+  margin: 1rem 0 0;
+  padding: 0;
+}
+.NewsPostInfo {
+  font-size: 0.9rem;
+}
 /* Content styling {{{1 */
 /* Headings */
 .MainContent h1 {


### PR DESCRIPTION
Not visible in end site, but can be previewed locally by enabling drafts.

Creates a separate RSS feed for news content.

/cc @vangent @eliben FYI