### PR TITLE
docstore: add option to limit outstanding RPCs for action lists

### DIFF
--- a/internal/docstore/memdocstore/mem.go
+++ b/internal/docstore/memdocstore/mem.go
@@ -36,8 +36,6 @@ package memdocstore // import "gocloud.dev/internal/docstore/memdocstore"
 
 import (
 	"context"
-	"fmt"
-	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -48,35 +46,15 @@ import (
 	"gocloud.dev/internal/gcerr"
 )
 
-func init() {
-	docstore.DefaultURLMux().RegisterCollection(Scheme, &URLOpener{})
-}
-
-// Scheme is the URL scheme memdocstore registers its URLOpener under on
-// docstore.DefaultMux.
-const Scheme = "mem"
-
-// URLOpener opens URLs like "mem://_id".
-//
-// The URL's host is used as the keyField.
-// The URL's path is ignored.
-//
-// No query parameters are supported.
-type URLOpener struct{}
-
-// OpenCollectionURL opens a docstore.Collection based on u.
-func (*URLOpener) OpenCollectionURL(ctx context.Context, u *url.URL) (*docstore.Collection, error) {
-	for param := range u.Query() {
-		return nil, fmt.Errorf("open collection %v: invalid query parameter %q", u, param)
-	}
-	return OpenCollection(u.Host, nil)
-}
-
 // Options are optional arguments to the OpenCollection functions.
 type Options struct {
 	// The name of the field holding the document revision.
 	// Defaults to docstore.RevisionField.
 	RevisionField string
+
+	// The maximum number of concurrent goroutines started for a single call to
+	// ActionList.Do. If less than 1, there is no limit.
+	MaxOutstandingActionRPCs int
 }
 
 // TODO(jba): make this package thread-safe.
@@ -161,16 +139,16 @@ func (c *collection) RunActions(ctx context.Context, actions []*driver.Action, o
 
 	// Run the actions concurrently with each other.
 	run := func(as []*driver.Action) {
-		var wg sync.WaitGroup
+		t := driver.NewThrottle(c.opts.MaxOutstandingActionRPCs)
 		for _, a := range as {
 			a := a
-			wg.Add(1)
+			t.Acquire()
 			go func() {
-				defer wg.Done()
+				defer t.Release()
 				errs[a.Index] = c.runAction(ctx, a)
 			}()
 		}
-		wg.Wait()
+		t.Wait()
 	}
 
 	beforeGets, gets, writes, afterGets := driver.GroupActions(actions)

--- a/internal/docstore/memdocstore/urls.go
+++ b/internal/docstore/memdocstore/urls.go
@@ -1,0 +1,47 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memdocstore
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"gocloud.dev/internal/docstore"
+)
+
+func init() {
+	docstore.DefaultURLMux().RegisterCollection(Scheme, &URLOpener{})
+}
+
+// Scheme is the URL scheme memdocstore registers its URLOpener under on
+// docstore.DefaultMux.
+const Scheme = "mem"
+
+// URLOpener opens URLs like "mem://_id".
+//
+// The URL's host is used as the keyField.
+// The URL's path is ignored.
+//
+// No query parameters are supported.
+type URLOpener struct{}
+
+// OpenCollectionURL opens a docstore.Collection based on u.
+func (*URLOpener) OpenCollectionURL(ctx context.Context, u *url.URL) (*docstore.Collection, error) {
+	for param := range u.Query() {
+		return nil, fmt.Errorf("open collection %v: invalid query parameter %q", u, param)
+	}
+	return OpenCollection(u.Host, nil)
+}


### PR DESCRIPTION
This does everything but dynamo, which is forthcoming.

See #2133.