### PR TITLE
mongodocstore: add cosmos test

### DIFF
--- a/internal/docstore/mongodocstore/cosmos_test.go
+++ b/internal/docstore/mongodocstore/cosmos_test.go
@@ -16,26 +16,33 @@ package mongodocstore
 
 import (
 	"context"
-	"flag"
+	"os"
 	"testing"
 
 	"gocloud.dev/internal/docstore/drivertest"
+	"gocloud.dev/internal/testing/setup"
 )
 
 // Run conformance tests on Azure Cosmos.
-// We cannot record this interaction, so this test must be enabled with a flag.
 
-var cosmosConnectionString = flag.String("cosmos", "", "connection string for Azure Cosmos")
+var (
+	// See https://docs.microsoft.com/en-us/azure/cosmos-db/connect-mongodb-account
+	// on how to get a MongoDB connection string for Azure Cosmos.
+	cosmosConnString = os.Getenv("COSMOS_CONNECTION_STRING")
+)
 
 func TestConformanceCosmos(t *testing.T) {
-	if *cosmosConnectionString == "" {
-		t.Skip("no -cosmos flag")
+	if !*setup.Record {
+		t.Skip("replaying is not yet supported for Azure Cosmos")
+	}
+	if cosmosConnString == "" {
+		t.Fatal("test harness requires COSMOS_CONNECTION_STRING environment variable to run")
 	}
 
 	ctx := context.Background()
-	client, err := Dial(ctx, *cosmosConnectionString)
+	client, err := Dial(ctx, cosmosConnString)
 	if err != nil {
-		t.Fatalf("dialing to %s: %v", *cosmosConnectionString, err)
+		t.Fatalf("dialing to %s: %v", cosmosConnString, err)
 	}
 	if err := client.Ping(ctx, nil); err != nil {
 		t.Fatalf("connecting to %s: %v", serverURI, err)

--- a/internal/docstore/mongodocstore/cosmos_test.go
+++ b/internal/docstore/mongodocstore/cosmos_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodocstore
+
+import (
+	"context"
+	"flag"
+	"testing"
+
+	"gocloud.dev/internal/docstore/drivertest"
+)
+
+// Run conformance tests on Azure Cosmos.
+// We cannot record this interaction, so this test must be enabled with a flag.
+
+var cosmosConnectionString = flag.String("cosmos", "", "connection string for Azure Cosmos")
+
+func TestConformanceCosmos(t *testing.T) {
+	if *cosmosConnectionString == "" {
+		t.Skip("no -cosmos flag")
+	}
+
+	ctx := context.Background()
+	client, err := Dial(ctx, *cosmosConnectionString)
+	if err != nil {
+		t.Fatalf("dialing to %s: %v", *cosmosConnectionString, err)
+	}
+	if err := client.Ping(ctx, nil); err != nil {
+		t.Fatalf("connecting to %s: %v", serverURI, err)
+	}
+	defer client.Disconnect(context.Background())
+
+	newHarness := func(context.Context, *testing.T) (drivertest.Harness, error) {
+		return &harness{client.Database(dbName)}, nil
+	}
+	drivertest.RunConformanceTests(t, newHarness, codecTester{}, []drivertest.AsTest{verifyAs{}})
+}

--- a/internal/docstore/mongodocstore/mongo_test.go
+++ b/internal/docstore/mongodocstore/mongo_test.go
@@ -155,7 +155,7 @@ func (verifyAs) ErrorCheck(c *docstore.Collection, err error) error {
 
 func TestConformance(t *testing.T) {
 	client := newTestClient(t)
-	defer func() { client.Disconnect(context.Background()) }()
+	defer client.Disconnect(context.Background())
 
 	newHarness := func(context.Context, *testing.T) (drivertest.Harness, error) {
 		return &harness{client.Database(dbName)}, nil

--- a/internal/docstore/mongodocstore/testdata/README
+++ b/internal/docstore/mongodocstore/testdata/README
@@ -1,0 +1,2 @@
+This directory is here just so that the prerelease script (internal/testing/prereleasechecks.sh)
+will run this package's tests with -record.

--- a/pubsub/azuresb/testdata/README
+++ b/pubsub/azuresb/testdata/README
@@ -1,0 +1,2 @@
+This directory is here just so that the prerelease script (internal/testing/prereleasechecks.sh)
+will run this package's tests with -record.


### PR DESCRIPTION
To enable the test, pass the -cosmos flag to `go test` with a connection string.

Fixes #2088.