### PR TITLE
.vscode: use runchecks.sh as default test action

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Test",
             "type": "shell",
-            "command": "go test ./...",
+            "command": "internal/testing/runchecks.sh",
             "group": {
               "kind": "test",
               "isDefault": true


### PR DESCRIPTION
End-effect: Ctrl-Shift-T/Cmd-Shift-T runs all the project tests in VSCode.