### PR TITLE
memdocstore: give collections names in URLs

### DIFF
--- a/docstore/memdocstore/mem_test.go
+++ b/docstore/memdocstore/mem_test.go
@@ -118,26 +118,6 @@ func TestUpdateAtomic(t *testing.T) {
 	}
 }
 
-func TestOpenCollectionFromURL(t *testing.T) {
-	tests := []struct {
-		URL     string
-		WantErr bool
-	}{
-		// OK.
-		{"mem://_id", false},
-		{"mem://foo.bar", false},
-		{"mem://", true},             // missing key
-		{"mem://?param=value", true}, // invalid parameter
-	}
-	ctx := context.Background()
-	for _, test := range tests {
-		_, err := docstore.OpenCollection(ctx, test.URL)
-		if (err != nil) != test.WantErr {
-			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
-		}
-	}
-}
-
 func TestMissingKeyCreateFailsWithKeyFunc(t *testing.T) {
 	dc, err := newCollection("", func(docstore.Document) interface{} { return nil }, nil)
 	if err != nil {

--- a/docstore/memdocstore/urls.go
+++ b/docstore/memdocstore/urls.go
@@ -62,7 +62,7 @@ func (o *URLOpener) OpenCollectionURL(ctx context.Context, u *url.URL) (*docstor
 		keyName = keyName[1:]
 	}
 	if keyName == "" || strings.ContainsRune(keyName, '/') {
-		return nil, fmt.Errorf("open collection %v: invalid key name %q (must be non-empty and slash-free)", u, keyName)
+		return nil, fmt.Errorf("open collection %v: invalid key name %q (must be non-empty and have no slashes)", u, keyName)
 	}
 	o.mu.Lock()
 	defer o.mu.Unlock()

--- a/docstore/memdocstore/urls_test.go
+++ b/docstore/memdocstore/urls_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memdocstore
+
+import (
+	"context"
+	"testing"
+
+	"gocloud.dev/docstore"
+)
+
+func TestOpenCollectionFromURL(t *testing.T) {
+	tests := []struct {
+		URL     string
+		wantErr bool
+	}{
+		// OK.
+		{"mem://coll/_id", false},
+		{"mem://coll/foo.bar", true}, // "coll" already has key "_id"
+		{"mem://coll2/foo.bar", false},
+		{"mem://", true},                     // missing collection
+		{"mem://coll", true},                 // missing key
+		{"mem://coll/my/key", true},          // key with slash
+		{"mem://coll/key?param=value", true}, // invalid parameter
+	}
+	ctx := context.Background()
+	for _, test := range tests {
+		_, err := docstore.OpenCollection(ctx, test.URL)
+		if (err != nil) != test.wantErr {
+			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.wantErr)
+		}
+	}
+}


### PR DESCRIPTION
Mimic what mempubsub does: URLs have collection names, which are
remembered in the URLOpener.