### PR TITLE
internal/website: publish secrets how-to guide

### DIFF
--- a/internal/website/content/howto/secrets/_index.md
+++ b/internal/website/content/howto/secrets/_index.md
@@ -2,7 +2,6 @@
 title: "Secrets"
 date: 2019-03-21T17:42:18-07:00
 showInSidenav: true
-draft: true
 ---
 
 Cloud applications frequently need to store sensitive information like web
@@ -15,6 +14,8 @@ encrypt the data, but then you need to worry about rotating the encryption
 keys and distributing them securely to all of your application servers.
 Most cloud providers include a key management service to perform these tasks,
 usually with hardware-level security and audit logging.
+
+<!--more-->
 
 The Go CDK provides access to key management providers in a portable way
 called "secret keepers". These guides show how to work with secret keepers in

--- a/internal/website/content/howto/secrets/crypt.md
+++ b/internal/website/content/howto/secrets/crypt.md
@@ -1,7 +1,6 @@
 ---
 title: "Encrypt & Decrypt Data"
 date: 2019-03-21T17:44:28-07:00
-draft: true
 weight: 2
 ---
 
@@ -10,36 +9,24 @@ you can encrypt and decrypt small messages using the keeper.
 
 [opened a secrets keeper]: {{< ref "./open-keeper.md" >}}
 
-## Encrypting data
+<!--more-->
+
+## Encrypting data {#encrypt}
 
 To encrypt data with a keeper, you call `Encrypt` with the byte slice you
 want to encrypt.
 
-```go
-plainText := []byte("Secrets secrets...")
-cipherText, err := keeper.Encrypt(ctx, plainText)
-if err != nil {
-    return err
-}
-```
+{{< goexample src="gocloud.dev/secrets.ExampleKeeper_Encrypt" imports="0" >}}
 
-## Decrypting data
+## Decrypting data {#decrypt}
 
 To decrypt data with a keeper, you call `Decrypt` with the byte slice you
 want to decrypt. This should be data that you obtained from a previous call
 to `Encrypt` with a keeper that uses the same secret material (e.g. two AWS
 KMS keepers created with the same customer master key ID). The `Decrypt`
-method will return an error if the input data did not come from the same
-secret keeper (**TODO(light)**: verify with @clausti and @shantuo that this
-is correct).
+method will return an error if the input data is corrupted.
 
-```go
-var cipherText []byte // obtained from elsewhere and random-looking
-plainText, err := keeper.Decrypt(ctx, cipherText)
-if err != nil {
-    return err
-}
-```
+{{< goexample src="gocloud.dev/secrets.ExampleKeeper_Decrypt" imports="0" >}}
 
 ## Large Messages
 

--- a/internal/website/content/howto/secrets/open-keeper.md
+++ b/internal/website/content/howto/secrets/open-keeper.md
@@ -1,7 +1,6 @@
 ---
 title: "Open a Secret Keeper"
 date: 2019-03-21T17:43:54-07:00
-draft: true
 weight: 1
 ---
 
@@ -10,6 +9,8 @@ secret keeper provider. Every secret keeper provider is a little different, but 
 lets you interact with all of them using the [`*secrets.Keeper` type][].
 
 [`*secrets.Keeper` type]: https://godoc.org/gocloud.dev/secrets#Keeper
+
+<!--more-->
 
 ## Constructors versus URL openers
 
@@ -25,7 +26,7 @@ both forms for each secret keeper provider.
 ["blank import"]: https://golang.org/doc/effective_go.html#blank_import
 [documentation on URLs]: {{< ref "/concepts/urls.md" >}}
 
-## AWS Key Management Service
+## AWS Key Management Service {#aws}
 
 The Go CDK can use customer master keys from Amazon Web Service's [Key
 Management Service][AWS KMS] (AWS KMS) to keep information secret. AWS KMS
@@ -35,219 +36,86 @@ application connects to the correct region, but otherwise
 `secrets.OpenKeeper` will use the region found in the environment variable
 `AWS_REGION` or your AWS CLI configuration.
 
-```go
-import (
-    "gocloud.dev/secrets"
-    _ "gocloud.dev/secrets/awskms"
-)
-
-// ...
-
-// Use one of the following:
-
-// 1. By ID.
-keeperByID, err := secrets.OpenKeeper(ctx,
-    "awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1")
-if err != nil {
-    return err
-}
-defer keeperByID.Close()
-
-// 2. By alias.
-keeperByAlias, err := secrets.OpenKeeper(ctx,
-    "awskms://alias/ExampleAlias?region=us-east-1")
-if err != nil {
-    return err
-}
-defer keeperByAlias.Close()
-
-// 2. By ARN.
-const arn = "arn:aws:kms:us-east-1:111122223333:key/" +
-    "1234abcd-12ab-34bc-56ef-1234567890ab"
-keeperByARN, err := secrets.OpenKeeper(ctx,
-    "awskms://" + arn + "?region=us-east-1")
-if err != nil {
-    return err
-}
-defer keeperByARN.Close()
-```
+{{< goexample "gocloud.dev/secrets/awskms.Example_openFromURL" >}}
 
 [AWS KMS]: https://aws.amazon.com/kms/
 
-## AWS Key Management Service Constructor
+## AWS Key Management Service Constructor {#aws-ctor}
 
 The [`awskms.OpenKeeper`][] constructor opens a customer master key. You must
 first create an [AWS session][] with the same region as your key and then
 connect to KMS:
 
-```go
-import (
-    "github.com/aws/aws-sdk-go/aws"
-    "github.com/aws/aws-sdk-go/aws/session"
-    "gocloud.dev/secrets/awskms"
-)
-
-// ...
-
-// Establish an AWS session.
-// The region must match the region for "master-key-test".
-sess, err := session.NewSession(&aws.Config{
-    Region: aws.String("us-east-1"),
-})
-if err != nil {
-    return err
-}
-
-// Connect to KMS.
-kmsClient, err := awskms.Dial(sess)
-if err != nil {
-    return err
-}
-
-// Create a *secrets.Keeper.
-keeper, err := awskms.OpenKeeper(kmsClient, "alias/master-key-test", nil)
-if err != nil {
-    return err
-}
-defer keeper.Close()
-```
+{{< goexample "gocloud.dev/secrets/awskms.ExampleOpenKeeper" >}}
 
 [`awskms.OpenKeeper`]: https://godoc.org/gocloud.dev/secrets/awskms#OpenKeeper
 [AWS session]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
 
-## Google Cloud Key Management Service
+## Google Cloud Key Management Service {#gcp}
 
 The Go CDK can use keys from Google Cloud Platform's [Key Management
 Service][GCP KMS] (GCP KMS) to keep information secret. `secrets.OpenKeeper`
 will use [Application Default Credentials][GCP credentials]. GCP KMS URLs are
 similar to [key resource IDs][]:
 
-```go
-import (
-    "gocloud.dev/secrets"
-    _ "gocloud.dev/secrets/gcpkms"
-)
-
-// ...
-
-keeper, err := secrets.OpenKeeper(ctx,
-    "gcpkms://projects/MYPROJECT/" +
-    "locations/MYLOCATION/" +
-    "keyRings/MYKEYRING/" +
-    "cryptoKeys/MYKEY")
-if err != nil {
-    return err
-}
-defer keeper.Close()
-```
+{{< goexample "gocloud.dev/secrets/gcpkms.Example_openFromURL" >}}
 
 [GCP KMS]: https://cloud.google.com/kms/
 [key resource IDs]: https://cloud.google.com/kms/docs/object-hierarchy#key
 
-### Google Cloud Key Management Service Constructor
+### Google Cloud Key Management Service Constructor {#gcp-ctor}
 
 The [`gcpkms.OpenKeeper`][] constructor opens a GCP KMS key. You must first
 obtain [GCP credentials][] and then create a gRPC connection to GCP KMS.
 
-```go
-import (
-    "gocloud.dev/gcp"
-    "gocloud.dev/secrets/gcpkms"
-)
-
-// ...
-
-// Your GCP credentials.
-// See https://cloud.google.com/docs/authentication/production
-// for more info on alternatives.
-creds, err := gcp.DefaultCredentials(ctx)
-if err != nil {
-    return err
-}
-
-// Create a KMS client.
-kmsClient, err := gcpkms.Dial(ctx, gcp.CredentialsTokenSource(creds))
-if err != nil {
-    return err
-}
-
-// Create a *secrets.Keeper.
-const keyID = gcpkms.KeyResourceID(
-    "MYPROJECT", "MYLOCATION", "MYKEYRING", "MYKEY")
-keeper, err := gcpkms.OpenKeeper(client, keyID, nil)
-if err != nil {
-    return err
-}
-defer keeper.Close()
-```
+{{< goexample "gocloud.dev/secrets/gcpkms.ExampleOpenKeeper" >}}
 
 [GCP credentials]: https://cloud.google.com/docs/authentication/production
 [`gcpkms.OpenKeeper`]: https://godoc.org/gocloud.dev/secrets/gcpkms#OpenKeeper
 
-## HashiCorp Vault
+## HashiCorp Vault {#vault}
 
 The Go CDK can use the [transit secrets engine][] in [Vault][] to keep
 information secret. Vault URLs only specify the key ID. The Vault server
 endpoint and authentication token are specified using the environment
 variables `VAULT_SERVER_URL` and `VAULT_SERVER_TOKEN`, respectively.
 
-```go
-import (
-    "gocloud.dev/secrets"
-    _ "gocloud.dev/secrets/vault"
-)
-
-// ...
-
-keeper, err := secrets.OpenKeeper(ctx, "vault://my-key")
-if err != nil {
-    return err
-}
-defer keeper.Close()
-```
+{{< goexample "gocloud.dev/secrets/vault.Example_openFromURL" >}}
 
 [Vault]: https://www.vaultproject.io/
 [transit secrets engine]: https://www.vaultproject.io/docs/secrets/transit/index.html
 
-### HashiCorp Vault Constructor
+### HashiCorp Vault Constructor {#vault-ctor}
 
 The [`vault.OpenKeeper`][] constructor opens a transit secrets engine key. You
 must first connect to your Vault instance.
 
-```go
-import (
-    "github.com/hashicorp/vault/api"
-    "gocloud.dev/secrets/vault"
-)
-
-// ...
-
-vaultClient, err := vault.Dial(ctx, &vault.Config{
-    Token: "CLIENT_TOKEN",
-    APIConfig: api.Config{
-        Address: "http://127.0.0.1:8200",
-    },
-})
-if err != nil {
-    return err
-}
-keeper := vault.OpenKeeper(vaultClient, "my-key", nil)
-defer keeper.Close()
-```
+{{< goexample "gocloud.dev/secrets/vault.ExampleOpenKeeper" >}}
 
 [`vault.OpenKeeper`]: https://godoc.org/gocloud.dev/secrets/vault#OpenKeeper
 
-## Local Secrets
+## Local Secrets {#local}
 
-**TODO(light):** Document https://godoc.org/gocloud.dev/secrets/localsecrets
+The Go CDK can use local encryption for keeping secrets. Internally, it uses
+the [NaCl secret box][] algorithm to perform encryption and authentication.
 
-**Blocked on https://github.com/google/go-cloud/issues/1664**
+{{< goexample "gocloud.dev/secrets/localsecrets.Example_openFromURL" >}}
+
+[NaCl secret box]: https://godoc.org/golang.org/x/crypto/nacl/secretbox
+
+### Local Secrets Constructor {#local-ctor}
+
+The [`localsecrets.NewKeeper`][] constructor takes in its secret material as
+a `[]byte`.
+
+{{< goexample "gocloud.dev/secrets/localsecrets.ExampleNewKeeper" >}}
+
+[`localsecrets.NewKeeper`]: https://godoc.org/gocloud.dev/secrets/localsecrets#NewKeeper
 
 ## What's Next
 
 Now that you have opened a secrets keeper, you can [encrypt and decrypt
-data][] and [access secret configuration data][] using portable operations.
+data][] using portable operations.
 
-[access secret configuration data]: {{< ref "./runtimevar.md" >}}
 [encrypt and decrypt data]: {{< ref "./crypt.md" >}}
 

--- a/internal/website/data/examples.json
+++ b/internal/website/data/examples.json
@@ -272,7 +272,7 @@
 		"code": "plainText := []byte(\"Secrets secrets...\")\ncipherText, err := keeper.Encrypt(ctx, plainText)\nif err != nil {\n\treturn err\n}"
 	},
 	"gocloud.dev/secrets/awskms.ExampleOpenKeeper": {
-		"imports": "import (\n\t\"context\"\n\n\t\"github.com/aws/aws-sdk-go/aws/session\"\n\t\"gocloud.dev/secrets/awskms\"\n)",
+		"imports": "import (\n\t\"github.com/aws/aws-sdk-go/aws/session\"\n\t\"gocloud.dev/secrets/awskms\"\n)",
 		"code": "// Establish an AWS session.\n// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more info.\nsess, err := session.NewSession(nil)\nif err != nil {\n\treturn err\n}\n\n// Get a client to use with the KMS API.\nclient, err := awskms.Dial(sess)\nif err != nil {\n\treturn err\n}\n\n// Construct a *secrets.Keeper.\nkeeper := awskms.OpenKeeper(client, \"alias/test-secrets\", nil)\ndefer keeper.Close()"
 	},
 	"gocloud.dev/secrets/awskms.Example_openFromURL": {

--- a/internal/website/data/examples.json
+++ b/internal/website/data/examples.json
@@ -262,5 +262,45 @@
 	"gocloud.dev/pubsub/rabbitpubsub.Example_openTopicFromURL": {
 		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/pubsub\"\n\t_ \"gocloud.dev/pubsub/rabbitpubsub\"\n)",
 		"code": "// pubsub.OpenTopic creates a *pubsub.Topic from a URL.\n// This URL will Dial the RabbitMQ server at the URL in the environment\n// variable RABBIT_SERVER_URL and open the exchange \"myexchange\".\ntopic, err := pubsub.OpenTopic(ctx, \"rabbit://myexchange\")\nif err != nil {\n\treturn err\n}\ndefer topic.Shutdown(ctx)"
+	},
+	"gocloud.dev/secrets.ExampleKeeper_Decrypt": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/secrets\"\n)",
+		"code": "var cipherText []byte // obtained from elsewhere and random-looking\nplainText, err := keeper.Decrypt(ctx, cipherText)\nif err != nil {\n\treturn err\n}"
+	},
+	"gocloud.dev/secrets.ExampleKeeper_Encrypt": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/secrets\"\n)",
+		"code": "plainText := []byte(\"Secrets secrets...\")\ncipherText, err := keeper.Encrypt(ctx, plainText)\nif err != nil {\n\treturn err\n}"
+	},
+	"gocloud.dev/secrets/awskms.ExampleOpenKeeper": {
+		"imports": "import (\n\t\"context\"\n\n\t\"github.com/aws/aws-sdk-go/aws/session\"\n\t\"gocloud.dev/secrets/awskms\"\n)",
+		"code": "// Establish an AWS session.\n// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more info.\nsess, err := session.NewSession(nil)\nif err != nil {\n\treturn err\n}\n\n// Get a client to use with the KMS API.\nclient, err := awskms.Dial(sess)\nif err != nil {\n\treturn err\n}\n\n// Construct a *secrets.Keeper.\nkeeper := awskms.OpenKeeper(client, \"alias/test-secrets\", nil)\ndefer keeper.Close()"
+	},
+	"gocloud.dev/secrets/awskms.Example_openFromURL": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/secrets\"\n\t_ \"gocloud.dev/secrets/awskms\"\n)",
+		"code": "// Use one of the following:\n\n// 1. By ID.\nkeeperByID, err := secrets.OpenKeeper(ctx,\n\t\"awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1\")\nif err != nil {\n\treturn err\n}\ndefer keeperByID.Close()\n\n// 2. By alias.\nkeeperByAlias, err := secrets.OpenKeeper(ctx,\n\t\"awskms://alias/ExampleAlias?region=us-east-1\")\nif err != nil {\n\treturn err\n}\ndefer keeperByAlias.Close()\n\n// 3. By ARN.\nconst arn = \"arn:aws:kms:us-east-1:111122223333:key/\" +\n\t\"1234abcd-12ab-34bc-56ef-1234567890ab\"\nkeeperByARN, err := secrets.OpenKeeper(ctx,\n\t\"awskms://\"+arn+\"?region=us-east-1\")\nif err != nil {\n\treturn err\n}\ndefer keeperByARN.Close()"
+	},
+	"gocloud.dev/secrets/gcpkms.ExampleOpenKeeper": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/secrets/gcpkms\"\n)",
+		"code": "// Get a client to use with the KMS API.\nclient, done, err := gcpkms.Dial(ctx, nil)\nif err != nil {\n\treturn err\n}\n// Close the connection when done.\ndefer done()\n\n// You can also use gcpkms.KeyResourceID to construct this string.\nconst keyID = \"projects/MYPROJECT/\" +\n\t\"locations/MYLOCATION/\" +\n\t\"keyRings/MYKEYRING/\" +\n\t\"cryptoKeys/MYKEY\"\n\n// Construct a *secrets.Keeper.\nkeeper := gcpkms.OpenKeeper(client, keyID, nil)\ndefer keeper.Close()"
+	},
+	"gocloud.dev/secrets/gcpkms.Example_openFromURL": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/secrets\"\n\t_ \"gocloud.dev/secrets/gcpkms\"\n)",
+		"code": "keeper, err := secrets.OpenKeeper(ctx,\n\t\"gcpkms://projects/MYPROJECT/\"+\n\t\t\"locations/MYLOCATION/\"+\n\t\t\"keyRings/MYKEYRING/\"+\n\t\t\"cryptoKeys/MYKEY\")\nif err != nil {\n\treturn err\n}\ndefer keeper.Close()"
+	},
+	"gocloud.dev/secrets/localsecrets.ExampleNewKeeper": {
+		"imports": "import \"gocloud.dev/secrets/localsecrets\"",
+		"code": "secretKey, err := localsecrets.NewRandomKey()\nif err != nil {\n\treturn err\n}\nkeeper := localsecrets.NewKeeper(secretKey)\ndefer keeper.Close()"
+	},
+	"gocloud.dev/secrets/localsecrets.Example_openFromURL": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/secrets\"\n\t_ \"gocloud.dev/secrets/localsecrets\"\n)",
+		"code": "// Using \"base64key://\", a new random key will be generated.\nrandomKeyKeeper, err := secrets.OpenKeeper(ctx, \"base64key://\")\nif err != nil {\n\treturn err\n}\ndefer randomKeyKeeper.Close()\n\n// Otherwise, the URL hostname must be a base64-encoded key, of length 32 bytes when decoded.\nsavedKeyKeeper, err := secrets.OpenKeeper(ctx, \"base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=\")\nif err != nil {\n\treturn err\n}\ndefer savedKeyKeeper.Close()"
+	},
+	"gocloud.dev/secrets/vault.ExampleOpenKeeper": {
+		"imports": "import (\n\t\"context\"\n\n\t\"github.com/hashicorp/vault/api\"\n\t\"gocloud.dev/secrets/vault\"\n)",
+		"code": "// Get a client to use with the Vault API.\nclient, err := vault.Dial(ctx, \u0026vault.Config{\n\tToken: \"CLIENT_TOKEN\",\n\tAPIConfig: api.Config{\n\t\tAddress: \"http://127.0.0.1:8200\",\n\t},\n})\nif err != nil {\n\treturn err\n}\n\n// Construct a *secrets.Keeper.\nkeeper := vault.OpenKeeper(client, \"my-key\", nil)\ndefer keeper.Close()"
+	},
+	"gocloud.dev/secrets/vault.Example_openFromURL": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/secrets\"\n\t_ \"gocloud.dev/secrets/vault\"\n)",
+		"code": "keeper, err := secrets.OpenKeeper(ctx, \"vault://mykey\")\nif err != nil {\n\treturn err\n}\ndefer keeper.Close()"
 	}
 }

--- a/secrets/awskms/example_test.go
+++ b/secrets/awskms/example_test.go
@@ -26,9 +26,6 @@ import (
 func ExampleOpenKeeper() {
 	// This example is used in https://gocloud.dev/howto/secrets/open-keeper/#aws-ctor
 
-	// Variables set up elsewhere:
-	ctx := context.Background()
-
 	// Establish an AWS session.
 	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more info.
 	sess, err := session.NewSession(nil)

--- a/secrets/awskms/example_test.go
+++ b/secrets/awskms/example_test.go
@@ -24,6 +24,11 @@ import (
 )
 
 func ExampleOpenKeeper() {
+	// This example is used in https://gocloud.dev/howto/secrets/open-keeper/#aws-ctor
+
+	// Variables set up elsewhere:
+	ctx := context.Background()
+
 	// Establish an AWS session.
 	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/session/ for more info.
 	sess, err := session.NewSession(nil)
@@ -38,40 +43,43 @@ func ExampleOpenKeeper() {
 	}
 
 	// Construct a *secrets.Keeper.
-	keeper := awskms.OpenKeeper(
-		client,
-		// Get the key ID. Here is an example of using an alias. See
-		// https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn
-		// for more details.
-		"alias/test-secrets",
-		nil,
-	)
+	keeper := awskms.OpenKeeper(client, "alias/test-secrets", nil)
 	defer keeper.Close()
-
-	// Now we can use keeper to encrypt or decrypt.
-	ctx := context.Background()
-	plaintext := []byte("Hello, Secrets!")
-	ciphertext, err := keeper.Encrypt(ctx, plaintext)
-	if err != nil {
-		log.Fatal(err)
-	}
-	decrypted, err := keeper.Decrypt(ctx, ciphertext)
-	if err != nil {
-		log.Fatal(err)
-	}
-	_ = decrypted
 }
 
 func Example_openFromURL() {
+	// This example is used in https://gocloud.dev/howto/secrets/open-keeper/#aws
+
+	// import _ "gocloud.dev/secrets/awskms"
+
+	// Variables set up elsewhere:
 	ctx := context.Background()
 
-	// secrets.OpenKeeper creates a *secrets.Keeper from a URL.
-	// The host + path are the key ID; this example uses an alias. See
-	// https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn
-	// for more details.
-	keeper, err := secrets.OpenKeeper(ctx, "awskms://alias/my-key")
+	// Use one of the following:
+
+	// 1. By ID.
+	keeperByID, err := secrets.OpenKeeper(ctx,
+		"awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer keeper.Close()
+	defer keeperByID.Close()
+
+	// 2. By alias.
+	keeperByAlias, err := secrets.OpenKeeper(ctx,
+		"awskms://alias/ExampleAlias?region=us-east-1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer keeperByAlias.Close()
+
+	// 3. By ARN.
+	const arn = "arn:aws:kms:us-east-1:111122223333:key/" +
+		"1234abcd-12ab-34bc-56ef-1234567890ab"
+	keeperByARN, err := secrets.OpenKeeper(ctx,
+		"awskms://"+arn+"?region=us-east-1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer keeperByARN.Close()
 }

--- a/secrets/example_test.go
+++ b/secrets/example_test.go
@@ -104,11 +104,11 @@ func ExampleKeeper_Decrypt() {
 	ctx := context.Background()
 	var keeper *secrets.Keeper
 
-  var cipherText []byte // obtained from elsewhere and random-looking
-  plainText, err := keeper.Decrypt(ctx, cipherText)
-  if err != nil {
+	var cipherText []byte // obtained from elsewhere and random-looking
+	plainText, err := keeper.Decrypt(ctx, cipherText)
+	if err != nil {
 		log.Fatal(err)
-  }
+	}
 
 	// Ignore unused variables in example:
 	_ = plainText

--- a/secrets/example_test.go
+++ b/secrets/example_test.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func ExampleNewKeeper() {
+func Example() {
 	ctx := context.Background()
 
 	// Construct a *secrets.Keeper from one of the secrets subpackages.
@@ -78,4 +78,38 @@ func Example_errorAs() {
 			fmt.Println(s.Code())
 		}
 	}
+}
+
+func ExampleKeeper_Encrypt() {
+	// This example is used in https://gocloud.dev/howto/secrets/crypt/
+
+	// Variables set up elsewhere:
+	ctx := context.Background()
+	var keeper *secrets.Keeper
+
+	plainText := []byte("Secrets secrets...")
+	cipherText, err := keeper.Encrypt(ctx, plainText)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Ignore unused variables in example:
+	_ = cipherText
+}
+
+func ExampleKeeper_Decrypt() {
+	// This example is used in https://gocloud.dev/howto/secrets/crypt/
+
+	// Variables set up elsewhere:
+	ctx := context.Background()
+	var keeper *secrets.Keeper
+
+  var cipherText []byte // obtained from elsewhere and random-looking
+  plainText, err := keeper.Decrypt(ctx, cipherText)
+  if err != nil {
+		log.Fatal(err)
+  }
+
+	// Ignore unused variables in example:
+	_ = plainText
 }

--- a/secrets/gcpkms/example_test.go
+++ b/secrets/gcpkms/example_test.go
@@ -56,10 +56,10 @@ func Example_openFromURL() {
 	ctx := context.Background()
 
 	keeper, err := secrets.OpenKeeper(ctx,
-		"gcpkms://projects/MYPROJECT/" +
-		"locations/MYLOCATION/" +
-		"keyRings/MYKEYRING/" +
-		"cryptoKeys/MYKEY")
+		"gcpkms://projects/MYPROJECT/"+
+			"locations/MYLOCATION/"+
+			"keyRings/MYKEYRING/"+
+			"cryptoKeys/MYKEY")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/secrets/gcpkms/example_test.go
+++ b/secrets/gcpkms/example_test.go
@@ -23,8 +23,12 @@ import (
 )
 
 func ExampleOpenKeeper() {
-	// Get a client to use with the KMS API.
+	// This example is used in https://gocloud.dev/howto/secrets/open-keeper/#gcp-ctor
+
+	// Variables set up elsewhere:
 	ctx := context.Background()
+
+	// Get a client to use with the KMS API.
 	client, done, err := gcpkms.Dial(ctx, nil)
 	if err != nil {
 		log.Fatal(err)
@@ -32,39 +36,30 @@ func ExampleOpenKeeper() {
 	// Close the connection when done.
 	defer done()
 
-	// Construct a *secrets.Keeper.
-	keeper := gcpkms.OpenKeeper(
-		client,
-		// Get the key resource ID.
-		// See https://cloud.google.com/kms/docs/object-hierarchy#key for more
-		// information.
-		// You can also use gcpkms.KeyResourceID to construct the string.
-		"projects/MYPROJECT/locations/MYLOCATION/keyRings/MYKEYRING/cryptoKeys/MYKEY",
-		nil,
-	)
-	defer keeper.Close()
+	// You can also use gcpkms.KeyResourceID to construct this string.
+	const keyID = "projects/MYPROJECT/" +
+		"locations/MYLOCATION/" +
+		"keyRings/MYKEYRING/" +
+		"cryptoKeys/MYKEY"
 
-	// Now we can use keeper to encrypt or decrypt.
-	plaintext := []byte("Hello, Secrets!")
-	ciphertext, err := keeper.Encrypt(ctx, plaintext)
-	if err != nil {
-		log.Fatal(err)
-	}
-	decrypted, err := keeper.Decrypt(ctx, ciphertext)
-	if err != nil {
-		log.Fatal(err)
-	}
-	_ = decrypted
+	// Construct a *secrets.Keeper.
+	keeper := gcpkms.OpenKeeper(client, keyID, nil)
+	defer keeper.Close()
 }
 
 func Example_openFromURL() {
+	// This example is used in https://gocloud.dev/howto/secrets/open-keeper/#gcp
+
+	// import _ "gocloud.dev/secrets/gcpkms"
+
+	// Variables set up elsewhere:
 	ctx := context.Background()
 
-	// secrets.OpenKeeper creates a *secrets.Keeper from a URL.
-	// The host + path are the key resourceID; see
-	// https://cloud.google.com/kms/docs/object-hierarchy#key
-	// for more information.
-	keeper, err := secrets.OpenKeeper(ctx, "gcpkms://projects/MYPROJECT/locations/MYLOCATION/keyRings/MYKEYRING/cryptoKeys/MYKEY")
+	keeper, err := secrets.OpenKeeper(ctx,
+		"gcpkms://projects/MYPROJECT/" +
+		"locations/MYLOCATION/" +
+		"keyRings/MYKEYRING/" +
+		"cryptoKeys/MYKEY")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/secrets/localsecrets/example_test.go
+++ b/secrets/localsecrets/example_test.go
@@ -16,7 +16,6 @@ package localsecrets_test
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"gocloud.dev/secrets"

--- a/secrets/localsecrets/example_test.go
+++ b/secrets/localsecrets/example_test.go
@@ -24,48 +24,35 @@ import (
 )
 
 func ExampleNewKeeper() {
-	// localsecrets.Keeper utilizes the golang.org/x/crypto/nacl/secretbox package
-	// for the crypto implementation, and secretbox requires a secret key
-	// that is a [32]byte. localsecrets
+	// This example is used in https://gocloud.dev/howto/secrets/open-keeper/#local-ctor
+
 	secretKey, err := localsecrets.NewRandomKey()
 	if err != nil {
 		log.Fatal(err)
 	}
 	keeper := localsecrets.NewKeeper(secretKey)
 	defer keeper.Close()
-
-	// Now we can use keeper to encrypt or decrypt.
-	plaintext := []byte("Hello, Secrets!")
-	ctx := context.Background()
-	ciphertext, err := keeper.Encrypt(ctx, plaintext)
-	if err != nil {
-		log.Fatal(err)
-	}
-	decrypted, err := keeper.Decrypt(ctx, ciphertext)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(string(decrypted))
-
-	// Output:
-	// Hello, Secrets!
 }
 
 func Example_openFromURL() {
+	// This example is used in https://gocloud.dev/howto/secrets/open-keeper/#local
+
+	// import _ "gocloud.dev/secrets/localsecrets"
+
+	// Variables set up elsewhere:
 	ctx := context.Background()
 
-	// secrets.OpenKeeper creates a *secrets.Keeper from a URL.
 	// Using "base64key://", a new random key will be generated.
-	keeper, err := secrets.OpenKeeper(ctx, "base64key://")
+	randomKeyKeeper, err := secrets.OpenKeeper(ctx, "base64key://")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer keeper.Close()
+	defer randomKeyKeeper.Close()
 
-	// The URL hostname must be a base64-encoded key, of length 32 bytes when decoded.
-	keeper, err = secrets.OpenKeeper(ctx, "base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=")
+	// Otherwise, the URL hostname must be a base64-encoded key, of length 32 bytes when decoded.
+	savedKeyKeeper, err := secrets.OpenKeeper(ctx, "base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer keeper.Close()
+	defer savedKeyKeeper.Close()
 }

--- a/secrets/vault/example_test.go
+++ b/secrets/vault/example_test.go
@@ -24,11 +24,16 @@ import (
 )
 
 func ExampleOpenKeeper() {
+	// This example is used in https://gocloud.dev/howto/secrets/open-keeper/#vault-ctor
+
+	// import _ "gocloud.dev/secrets/vault"
+
+	// Variables set up elsewhere:
+	ctx := context.Background()
 
 	// Get a client to use with the Vault API.
-	ctx := context.Background()
 	client, err := vault.Dial(ctx, &vault.Config{
-		Token: "<Client (Root) Token>",
+		Token: "CLIENT_TOKEN",
 		APIConfig: api.Config{
 			Address: "http://127.0.0.1:8200",
 		},
@@ -40,26 +45,16 @@ func ExampleOpenKeeper() {
 	// Construct a *secrets.Keeper.
 	keeper := vault.OpenKeeper(client, "my-key", nil)
 	defer keeper.Close()
-
-	// Now we can use keeper to encrypt or decrypt.
-	plaintext := []byte("Hello, Secrets!")
-	ciphertext, err := keeper.Encrypt(ctx, plaintext)
-	if err != nil {
-		log.Fatal(err)
-	}
-	decrypted, err := keeper.Decrypt(ctx, ciphertext)
-	if err != nil {
-		log.Fatal(err)
-	}
-	_ = decrypted
 }
 
 func Example_openFromURL() {
+	// This example is used in https://gocloud.dev/howto/secrets/open-keeper/#vault
+
+	// import _ "gocloud.dev/secrets/vault"
+
+	// Variables set up elsewhere:
 	ctx := context.Background()
 
-	// secrets.OpenKeeper creates a *secrets.Keeper from a URL.
-	// The default opener dials a default Vault server based on the environment
-	// variables VAULT_SERVER_URL and VAULT_SERVER_TOKEN.
 	keeper, err := secrets.OpenKeeper(ctx, "vault://mykey")
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Moved prose examples into godoc examples. Kept runtimevar page draft, since there is no runtimevar guide to point to.

Fixes #2363

/cc @cnguyen83 for doc review