### PR TITLE
blob/drivertests: fix some missed calls to bucket.Close

### DIFF
--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -404,6 +404,7 @@ func testList(t *testing.T, newHarness HarnessMaker) {
 
 		// Insert a key "0a" in the middle of the page we already retrieved.
 		b := blob.NewBucket(drv)
+		defer b.Close()
 		key := page.Objects[0].Key + "a"
 		if err := b.WriteAll(ctx, key, content, nil); err != nil {
 			t.Fatal(err)
@@ -449,6 +450,7 @@ func testList(t *testing.T, newHarness HarnessMaker) {
 
 		// Delete key "1".
 		b := blob.NewBucket(drv)
+		defer b.Close()
 		key := page.Objects[1].Key
 		if err := b.Delete(ctx, key); err != nil {
 			t.Fatal(err)
@@ -1264,16 +1266,15 @@ func testWrite(t *testing.T, newHarness HarnessMaker) {
 				t.Fatal(err)
 			}
 			b := blob.NewBucket(drv)
+			defer b.Close()
 
 			// If the test wants the blob to already exist, write it.
 			if tc.exists {
 				if err := b.WriteAll(ctx, key, []byte(existingContent), nil); err != nil {
-					b.Close()
 					t.Fatal(err)
 				}
 				defer func() {
 					_ = b.Delete(ctx, key)
-					b.Close()
 				}()
 			}
 


### PR DESCRIPTION
Updates #2400.

I found these by adding a finalizer for `blob.Bucket` in `blob.NewBucket`. It seemed to find missing `Close`s in `drivertest`, but not in examples or package-level tests; I suspect the GC only cleans up local variables in sub-tests or something like that.

I tried the same for `runtimevar.Variable` and `pubsub.Topic/Subscription` with less success; both of those create references (e.g., `runtimevar.Variable` starts a goroutine, `pubsub` creates batchers) that make it harder for the garbage collector to notice that it's OK to cleanup right away.