### PR TITLE
all: add missing calls to Close/Shutdown where needed

### DIFF
--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -288,7 +288,10 @@ func TestOpenBucket(t *testing.T) {
 				t.Errorf("got %q want %q", drv.name, test.want)
 			}
 			// Create portable type.
-			_, err = OpenBucket(ctx, p, test.accountName, test.containerName, nil)
+			b, err := OpenBucket(ctx, p, test.accountName, test.containerName, nil)
+			if b != nil {
+				defer b.Close()
+			}
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)
 			}
@@ -373,7 +376,10 @@ func TestOpenBucketFromURL(t *testing.T) {
 
 	ctx := context.Background()
 	for _, test := range tests {
-		_, err := blob.OpenBucket(ctx, test.URL)
+		b, err := blob.OpenBucket(ctx, test.URL)
+		if b != nil {
+			defer b.Close()
+		}
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
 		}

--- a/blob/blob_test.go
+++ b/blob/blob_test.go
@@ -66,6 +66,7 @@ func TestExists(t *testing.T) {
 		t.Run(test.Description, func(t *testing.T) {
 			drv := &fakeAttributes{attributesErr: test.Err}
 			b := NewBucket(drv)
+			defer b.Close()
 			got, gotErr := b.Exists(context.Background(), "key")
 			if got != test.Want {
 				t.Errorf("got %v want %v", got, test.Want)
@@ -98,6 +99,8 @@ func (b *fakeAttributes) ErrorCode(err error) gcerrors.ErrorCode {
 	return gcerrors.Unknown
 }
 
+func (b *fakeAttributes) Close() error { return nil }
+
 // Verify that ListIterator works even if driver.ListPaged returns empty pages.
 func TestListIterator(t *testing.T) {
 	ctx := context.Background()
@@ -111,6 +114,7 @@ func TestListIterator(t *testing.T) {
 		{},
 	}}
 	b := NewBucket(db)
+	defer b.Close()
 	iter := b.List(nil)
 	var got []string
 	for {
@@ -147,6 +151,8 @@ func (b *fakeLister) ListPaged(ctx context.Context, opts *driver.ListOptions) (*
 	}
 	return &driver.ListPage{Objects: objs, NextPageToken: []byte{1}}, nil
 }
+
+func (b *fakeLister) Close() error { return nil }
 
 // erroringBucket implements driver.Bucket. All interface methods that return
 // errors are implemented, and return errFake.

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -79,6 +79,7 @@ func (h *harness) serveSignedURL(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer bucket.Close()
 	reader, err := bucket.NewReader(r.Context(), objKey, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
@@ -235,6 +236,9 @@ func TestOpenBucketFromURL(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range tests {
 		b, err := blob.OpenBucket(ctx, test.URL)
+		if b != nil {
+			defer b.Close()
+		}
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
 		}

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -301,7 +301,10 @@ func TestOpenBucket(t *testing.T) {
 			}
 
 			// Create portable type.
-			_, err = OpenBucket(ctx, client, test.bucketName, nil)
+			b, err := OpenBucket(ctx, client, test.bucketName, nil)
+			if b != nil {
+				defer b.Close()
+			}
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)
 			}
@@ -577,7 +580,10 @@ func TestOpenBucketFromURL(t *testing.T) {
 
 	ctx := context.Background()
 	for _, test := range tests {
-		_, err := blob.OpenBucket(ctx, test.URL)
+		b, err := blob.OpenBucket(ctx, test.URL)
+		if b != nil {
+			defer b.Close()
+		}
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
 		}

--- a/blob/memblob/memblob_test.go
+++ b/blob/memblob/memblob_test.go
@@ -80,7 +80,10 @@ func TestOpenBucketFromURL(t *testing.T) {
 
 	ctx := context.Background()
 	for _, test := range tests {
-		_, err := blob.OpenBucket(ctx, test.URL)
+		b, err := blob.OpenBucket(ctx, test.URL)
+		if b != nil {
+			defer b.Close()
+		}
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
 		}

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -248,7 +248,10 @@ func TestOpenBucket(t *testing.T) {
 			}
 
 			// Create portable type.
-			_, err = OpenBucket(ctx, sess, test.bucketName, nil)
+			b, err := OpenBucket(ctx, sess, test.bucketName, nil)
+			if b != nil {
+				defer b.Close()
+			}
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)
 			}
@@ -271,7 +274,10 @@ func TestOpenBucketFromURL(t *testing.T) {
 
 	ctx := context.Background()
 	for _, test := range tests {
-		_, err := blob.OpenBucket(ctx, test.URL)
+		b, err := blob.OpenBucket(ctx, test.URL)
+		if b != nil {
+			defer b.Close()
+		}
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
 		}

--- a/docstore/docstore_test.go
+++ b/docstore/docstore_test.go
@@ -123,7 +123,7 @@ func TestToDriverActionsErrors(t *testing.T) {
 func TestClosedErrors(t *testing.T) {
 	// Check that all collection methods return errClosed if the collection is closed.
 	ctx := context.Background()
-	c := &Collection{driver: fakeDriverCollection{}}
+	c := newCollection(fakeDriverCollection{})
 	if err := c.Close(); err != nil {
 		t.Fatalf("got %v, want nil", err)
 	}
@@ -154,7 +154,7 @@ func TestClosedErrors(t *testing.T) {
 
 	// Check that DocumentIterator.Next returns errClosed if Close is called
 	// in the middle of the iteration.
-	c = &Collection{driver: fakeDriverCollection{}}
+	c = newCollection(fakeDriverCollection{})
 	iter = c.Query().Get(ctx)
 	c.Close()
 	check(iter.Next(ctx, doc))

--- a/docstore/firedocstore/urls_test.go
+++ b/docstore/firedocstore/urls_test.go
@@ -22,7 +22,7 @@ import (
 	"gocloud.dev/internal/testing/setup"
 )
 
-func TestOpenCollection(t *testing.T) {
+func TestOpenCollectionFromURL(t *testing.T) {
 	cleanup := setup.FakeGCPDefaultCredentials(t)
 	defer cleanup()
 
@@ -46,7 +46,10 @@ func TestOpenCollection(t *testing.T) {
 
 	ctx := context.Background()
 	for _, test := range tests {
-		_, err := docstore.OpenCollection(ctx, test.URL)
+		d, err := docstore.OpenCollection(ctx, test.URL)
+		if d != nil {
+			defer d.Close()
+		}
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
 		}

--- a/docstore/memdocstore/urls_test.go
+++ b/docstore/memdocstore/urls_test.go
@@ -37,7 +37,10 @@ func TestOpenCollectionFromURL(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, test := range tests {
-		_, err := docstore.OpenCollection(ctx, test.URL)
+		d, err := docstore.OpenCollection(ctx, test.URL)
+		if d != nil {
+			defer d.Close()
+		}
 		if (err != nil) != test.wantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.wantErr)
 		}

--- a/docstore/mongodocstore/urls_test.go
+++ b/docstore/mongodocstore/urls_test.go
@@ -52,7 +52,10 @@ func TestOpenCollectionURL(t *testing.T) {
 
 	ctx := context.Background()
 	for _, test := range tests {
-		_, err := docstore.OpenCollection(ctx, test.URL)
+		d, err := docstore.OpenCollection(ctx, test.URL)
+		if d != nil {
+			defer d.Close()
+		}
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
 		}

--- a/pubsub/kafkapubsub/kafka_test.go
+++ b/pubsub/kafkapubsub/kafka_test.go
@@ -332,9 +332,12 @@ func TestOpenTopicFromURL(t *testing.T) {
 
 	ctx := context.Background()
 	for _, test := range tests {
-		_, err := pubsub.OpenTopic(ctx, test.URL)
+		topic, err := pubsub.OpenTopic(ctx, test.URL)
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
+		}
+		if topic != nil {
+			topic.Shutdown(ctx)
 		}
 	}
 }
@@ -355,9 +358,12 @@ func TestOpenSubscriptionFromURL(t *testing.T) {
 
 	ctx := context.Background()
 	for _, test := range tests {
-		_, err := pubsub.OpenSubscription(ctx, test.URL)
+		sub, err := pubsub.OpenSubscription(ctx, test.URL)
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
+		}
+		if sub != nil {
+			sub.Shutdown(ctx)
 		}
 	}
 }

--- a/pubsub/natspubsub/nats_test.go
+++ b/pubsub/natspubsub/nats_test.go
@@ -181,6 +181,7 @@ func TestInteropWithDirectNATS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer pt.Shutdown(ctx)
 	nsub, _ := conn.SubscribeSync(topic)
 	if err = pt.Send(ctx, &pubsub.Message{Body: body}); err != nil {
 		t.Fatal(err)
@@ -198,6 +199,7 @@ func TestInteropWithDirectNATS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ps.Shutdown(ctx)
 	if err := conn.Publish(topic, body); err != nil {
 		t.Fatal(err)
 	}
@@ -292,6 +294,7 @@ func TestBadSubjects(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer sub.Shutdown(ctx)
 	if _, err = sub.Receive(ctx); err == nil {
 		t.Fatal("Expected an error with bad subject")
 	}
@@ -300,6 +303,7 @@ func TestBadSubjects(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer pt.Shutdown(ctx)
 	if err = pt.Send(ctx, &pubsub.Message{}); err == nil {
 		t.Fatal("Expected an error with bad subject")
 	}

--- a/runtimevar/blobvar/blobvar_test.go
+++ b/runtimevar/blobvar/blobvar_test.go
@@ -151,11 +151,19 @@ func TestOpenVariable(t *testing.T) {
 			os.Setenv("BLOBVAR_BUCKET_URL", test.BucketURL)
 
 			opener := &defaultOpener{}
+			defer func() {
+				if opener.opener != nil && opener.opener.Bucket != nil {
+					opener.opener.Bucket.Close()
+				}
+			}()
 			u, err := url.Parse(test.URL)
 			if err != nil {
 				t.Error(err)
 			}
 			v, err := opener.OpenVariableURL(ctx, u)
+			if v != nil {
+				defer v.Close()
+			}
 			if (err != nil) != test.WantErr {
 				t.Errorf("BucketURL %s URL %s: got error %v, want error %v", test.BucketURL, test.URL, err, test.WantErr)
 			}

--- a/runtimevar/example_openvariable_test.go
+++ b/runtimevar/example_openvariable_test.go
@@ -37,6 +37,7 @@ func Example_openVariableFromURL() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer v.Close()
 
 	// Now we can use the Variable as normal.
 	snapshot, err := v.Latest(ctx)

--- a/runtimevar/gcpruntimeconfig/gcpruntimeconfig_test.go
+++ b/runtimevar/gcpruntimeconfig/gcpruntimeconfig_test.go
@@ -179,6 +179,7 @@ func TestNoConnectionError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer v.Close()
 	_, err = v.Watch(context.Background())
 	if err == nil {
 		t.Error("got nil want error")
@@ -219,7 +220,10 @@ func TestOpenVariable(t *testing.T) {
 
 	ctx := context.Background()
 	for _, test := range tests {
-		_, err := runtimevar.OpenVariable(ctx, test.URL)
+		v, err := runtimevar.OpenVariable(ctx, test.URL)
+		if v != nil {
+			defer v.Close()
+		}
 		if (err != nil) != test.WantErr {
 			t.Errorf("%s: got error %v, want error %v", test.URL, err, test.WantErr)
 		}

--- a/runtimevar/oc_test.go
+++ b/runtimevar/oc_test.go
@@ -31,6 +31,7 @@ func TestOpenCensus(t *testing.T) {
 	defer te.Unregister()
 
 	v := constantvar.New(1)
+	defer v.Close()
 	if _, err := v.Watch(ctx); err != nil {
 		t.Fatal(err)
 	}

--- a/secrets/awskms/testdata/TestConformance/TestDecryptMalformedError.replay
+++ b/secrets/awskms/testdata/TestConformance/TestDecryptMalformedError.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7Um2KoCIMfeP5c",
+  "Initial": "AQAAAA7UpE7CIT3K0/5c",
   "Version": "0.2",
   "Converter": {
     "ClearHeaders": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "5344e5bf9490f4c9",
+      "ID": "74889cf27f6dd810",
       "Request": {
         "Method": "POST",
         "URL": "https://kms.us-east-2.amazonaws.com/",
@@ -79,14 +79,14 @@
             "application/x-amz-json-1.1"
           ],
           "X-Amzn-Requestid": [
-            "561436a9-5aea-4beb-8037-70a8f5525013"
+            "651f5782-c873-4780-a175-f6b4fb90a29c"
           ]
         },
-        "Body": "eyJDaXBoZXJ0ZXh0QmxvYiI6IkFRSUNBSGdQQW1zd3FjSzVYM3VEUG9BUUdyaVdRbHRjWHdFek9wMkJPZHd4bzU3Y1Z3RThQZGhTUFF0SW1aczJWNG5HRWk1S0FBQUFjekJ4QmdrcWhraUc5dzBCQndhZ1pEQmlBZ0VBTUYwR0NTcUdTSWIzRFFFSEFUQWVCZ2xnaGtnQlpRTUVBUzR3RVFRTVVjR2tBSzd0NTlCams1OTNBZ0VRZ0RCbXNpTGZXUWdEWDJXRVk0VEl6SHlWUHhjVlZzZktHZFVhYVRyQVRpM1NIWHhkaVN2d0t6SnBrMk01cFJTbU9sdz0iLCJLZXlJZCI6ImFybjphd3M6a21zOnVzLWVhc3QtMjo0NjIzODAyMjU3MjI6a2V5Lzg5Mzg4YTdlLTUxYWMtNGZhNS1hMWU1LTA0MjE0MWVmMDI2YyJ9"
+        "Body": "eyJDaXBoZXJ0ZXh0QmxvYiI6IkFRSUNBSGdQQW1zd3FjSzVYM3VEUG9BUUdyaVdRbHRjWHdFek9wMkJPZHd4bzU3Y1Z3Rzgxbkc3cnFzZUs2VG9FOGc3SXVWd0FBQUFjekJ4QmdrcWhraUc5dzBCQndhZ1pEQmlBZ0VBTUYwR0NTcUdTSWIzRFFFSEFUQWVCZ2xnaGtnQlpRTUVBUzR3RVFRTTdWamx5NDhUMnIxQW5HM01BZ0VRZ0RCWmpBY0c0NVlOZ29NaGhtWmp4VDl6U2YvcDNMVnBGZERQMW9JeHhuZ0JmUlV1aVBNQzRyYmtpbUtheVduNXZ6bz0iLCJLZXlJZCI6ImFybjphd3M6a21zOnVzLWVhc3QtMjo0NjIzODAyMjU3MjI6a2V5Lzg5Mzg4YTdlLTUxYWMtNGZhNS1hMWU1LTA0MjE0MWVmMDI2YyJ9"
       }
     },
     {
-      "ID": "a2740283e4c5952a",
+      "ID": "9e6c88771021e7e2",
       "Request": {
         "Method": "POST",
         "URL": "https://kms.us-east-2.amazonaws.com/",
@@ -109,7 +109,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJDaXBoZXJ0ZXh0QmxvYiI6IkFnSUNBSGdQQW1zd3FjSzVYM3VEUG9BUUdyaVdRbHRjWHdFek9wMkJPZHd4bzU3Y1Z3RThQZGhTUFF0SW1aczJWNG5HRWk1S0FBQUFjekJ4QmdrcWhraUc5dzBCQndhZ1pEQmlBZ0VBTUYwR0NTcUdTSWIzRFFFSEFUQWVCZ2xnaGtnQlpRTUVBUzR3RVFRTVVjR2tBSzd0NTlCams1OTNBZ0VRZ0RCbXNpTGZXUWdEWDJXRVk0VEl6SHlWUHhjVlZzZktHZFVhYVRyQVRpM1NIWHhkaVN2d0t6SnBrMk01cFJTbU9sdz0ifQ=="
+          "eyJDaXBoZXJ0ZXh0QmxvYiI6IkFnSUNBSGdQQW1zd3FjSzVYM3VEUG9BUUdyaVdRbHRjWHdFek9wMkJPZHd4bzU3Y1Z3Rzgxbkc3cnFzZUs2VG9FOGc3SXVWd0FBQUFjekJ4QmdrcWhraUc5dzBCQndhZ1pEQmlBZ0VBTUYwR0NTcUdTSWIzRFFFSEFUQWVCZ2xnaGtnQlpRTUVBUzR3RVFRTTdWamx5NDhUMnIxQW5HM01BZ0VRZ0RCWmpBY0c0NVlOZ29NaGhtWmp4VDl6U2YvcDNMVnBGZERQMW9JeHhuZ0JmUlV1aVBNQzRyYmtpbUtheVduNXZ6bz0ifQ=="
         ]
       },
       "Response": {
@@ -125,14 +125,14 @@
             "application/x-amz-json-1.1"
           ],
           "X-Amzn-Requestid": [
-            "f57b6d91-4d38-491c-a31b-23cdc14ddaf4"
+            "f5ab21ec-cf4e-4a2c-b557-db2882cf9fb4"
           ]
         },
         "Body": "eyJfX3R5cGUiOiJJbnZhbGlkQ2lwaGVydGV4dEV4Y2VwdGlvbiJ9"
       }
     },
     {
-      "ID": "d4d990f22c6eee66",
+      "ID": "5e5afd9d42808ebc",
       "Request": {
         "Method": "POST",
         "URL": "https://kms.us-east-2.amazonaws.com/",
@@ -155,7 +155,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJDaXBoZXJ0ZXh0QmxvYiI6IkFRSUFlQThDYXpDcHdybGZlNE0rZ0JBYXVKWkNXMXhmQVRNNm5ZRTUzREdqbnR4WEFUdzkyRkk5QzBpWm16WlhpY1lTTGtvQUFBQnpNSEVHQ1NxR1NJYjNEUUVIQnFCa01HSUNBUUF3WFFZSktvWklodmNOQVFjQk1CNEdDV0NHU0FGbEF3UUJMakFSQkF4UndhUUFydTNuMEdPVG4zY0NBUkNBTUdheUl0OVpDQU5mWllSamhNak1mSlUvRnhWV3g4b1oxUnBwT3NCT0xkSWRmRjJKSy9Bck1tbVRZem1sRktZNld3PT0ifQ=="
+          "eyJDaXBoZXJ0ZXh0QmxvYiI6IkFRSUFlQThDYXpDcHdybGZlNE0rZ0JBYXVKWkNXMXhmQVRNNm5ZRTUzREdqbnR4WEFieldjYnV1cXg0cnBPZ1R5RHNpNVhBQUFBQnpNSEVHQ1NxR1NJYjNEUUVIQnFCa01HSUNBUUF3WFFZSktvWklodmNOQVFjQk1CNEdDV0NHU0FGbEF3UUJMakFSQkF6dFdPWExqeFBhdlVDY2Jjd0NBUkNBTUZtTUJ3YmpsZzJDZ3lHR1ptUEZQM05KLytuY3RXa1YwTS9XZ2pIR2VBRjlGUzZJOHdMaXR1U0tZcHJKYWZtL09nPT0ifQ=="
         ]
       },
       "Response": {
@@ -171,14 +171,14 @@
             "application/x-amz-json-1.1"
           ],
           "X-Amzn-Requestid": [
-            "59fd6596-aad5-469b-869f-22678e79013a"
+            "5ef98130-09b6-4bcf-9f3b-354a8e4c5d5f"
           ]
         },
         "Body": "eyJfX3R5cGUiOiJJbnZhbGlkQ2lwaGVydGV4dEV4Y2VwdGlvbiJ9"
       }
     },
     {
-      "ID": "12a6ca7993b26e04",
+      "ID": "a5dff0d987ee0bf1",
       "Request": {
         "Method": "POST",
         "URL": "https://kms.us-east-2.amazonaws.com/",
@@ -201,7 +201,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJDaXBoZXJ0ZXh0QmxvYiI6IkFRSUFlQThDYXpDcHdybGZlNE0rZ0JBYXVKWkNXMXhmQVRNNm5ZRTUzREdqbnR4WEFUdzkyRkk5QzBpWm16WlhpY1lTTGtvQUFBQnpNSEVHQ1NxR1NJYjNEUUVIQnFCa01HSUNBUUF3WFFZSktvWklodmNOQVFjQk1CNEdDV0NHU0FGbEF3UUJMakFSQkF4UndhUUFydTNuMEdPVG4zY0NBUkNBTUdheUl0OVpDQU5mWllSamhNak1mSlUvRnhWV3g4b1oxUnBwT3NCT0xkSWRmRjJKSy9Bck1tbVRZem1sRktZNld3PT0ifQ=="
+          "eyJDaXBoZXJ0ZXh0QmxvYiI6IkFRSUNBSGdQQW1zd3FjSzVYM3VEUG9BUUdyaVdRbHRjWHdFek9wMkJPZHd4bzU3Y1Z3Rzgxbkc3cnFzZUs2VG9FOGc3SXVWd0FBQUFjekJ4QmdrcWhraUc5dzBCQndhZ1pEQmlBZ0VBTUYwR0NTcUdTSWIzRFFFSEFUQWVCZ2xnaGtnQlpRTUVBUzR3RVFRTTdWamx5NDhUMnIxQW5HM01BZ0VRZ0RCWmpBY0c0NVlOZ29NaGhtWmp4VDl6U2YvcDNMVnBGZERQMW9JeHhuZ0JmUlV1aVBNQzRyYmtpbUtheVduNU9RPT0ifQ=="
         ]
       },
       "Response": {
@@ -217,14 +217,14 @@
             "application/x-amz-json-1.1"
           ],
           "X-Amzn-Requestid": [
-            "abdd7b1a-f0db-4eb6-9621-3fe0e8108a23"
+            "7f89debc-0eda-4e5f-bcb1-815ce6142614"
           ]
         },
         "Body": "eyJfX3R5cGUiOiJJbnZhbGlkQ2lwaGVydGV4dEV4Y2VwdGlvbiJ9"
       }
     },
     {
-      "ID": "1307b362eb06c849",
+      "ID": "6cdbaabe3850b255",
       "Request": {
         "Method": "POST",
         "URL": "https://kms.us-east-2.amazonaws.com/",
@@ -247,7 +247,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJDaXBoZXJ0ZXh0QmxvYiI6IkFRSUFlQThDYXpDcHdybGZlNE0rZ0JBYXVKWkNXMXhmQVRNNm5ZRTUzREdqbnR4WEFUdzkyRkk5QzBpWm16WlhpY1lTTGtvQUFBQnpNSEVHQ1NxR1NJYjNEUUVIQnFCa01HSUNBUUF3WFFZSktvWklodmNOQVFjQk1CNEdDV0NHU0FGbEF3UUJMakFSQkF4UndhUUFydTNuMEdPVG4zY0NBUkNBTUdheUl0OVpDQU5mWllSamhNak1mSlUvRnhWV3g4b1oxUnBwT3NCT0xkSWRmRjJKSy9Bck1tbVRZem1sRktZNlcxd0UifQ=="
+          "eyJDaXBoZXJ0ZXh0QmxvYiI6IkFRSUNBSGdQQW1zd3FjSzVYM3VEUG9BUUdyaVdRbHRjWHdFek9wMkJPZHd4bzU3Y1Z3Rzgxbkc3cnFzZUs2VG9FOGc3SXVWd0FBQUFjekJ4QmdrcWhraUc5dzBCQndhZ1pEQmlBZ0VBTUYwR0NTcUdTSWIzRFFFSEFUQWVCZ2xnaGtnQlpRTUVBUzR3RVFRTTdWamx5NDhUMnIxQW5HM01BZ0VRZ0RCWmpBY0c0NVlOZ29NaGhtWmp4VDl6U2YvcDNMVnBGZERQMW9JeHhuZ0JmUlV1aVBNQzRyYmtpbUtheVduNXZ6b0UifQ=="
         ]
       },
       "Response": {
@@ -263,7 +263,7 @@
             "application/x-amz-json-1.1"
           ],
           "X-Amzn-Requestid": [
-            "5ce8bc75-def4-488d-9ebb-8e65b432e02b"
+            "836d56a0-5f9b-4ac3-90da-ee2ac8f18c45"
           ]
         },
         "Body": "eyJfX3R5cGUiOiJJbnZhbGlkQ2lwaGVydGV4dEV4Y2VwdGlvbiJ9"

--- a/secrets/drivertest/drivertest.go
+++ b/secrets/drivertest/drivertest.go
@@ -108,6 +108,7 @@ func testEncryptDecrypt(t *testing.T, newHarness HarnessMaker) {
 		t.Fatal(err)
 	}
 	keeper := secrets.NewKeeper(drv)
+	defer keeper.Close()
 
 	msg := []byte("I'm a secret message!")
 	encryptedMsg, err := keeper.Encrypt(ctx, msg)
@@ -142,6 +143,7 @@ func testMultipleEncryptionsNotEqual(t *testing.T, newHarness HarnessMaker) {
 		t.Fatal(err)
 	}
 	keeper := secrets.NewKeeper(drv)
+	defer keeper.Close()
 
 	msg := []byte("I'm a secret message!")
 	encryptedMsg1, err := keeper.Encrypt(ctx, msg)
@@ -186,7 +188,9 @@ func testMultipleKeys(t *testing.T, newHarness HarnessMaker) {
 		t.Fatal(err)
 	}
 	keeper1 := secrets.NewKeeper(drv1)
+	defer keeper1.Close()
 	keeper2 := secrets.NewKeeper(drv2)
+	defer keeper2.Close()
 
 	msg := []byte("I'm a secret message!")
 	encryptedMsg1, err := keeper1.Encrypt(ctx, msg)
@@ -237,6 +241,7 @@ func testDecryptMalformedError(t *testing.T, newHarness HarnessMaker) {
 		t.Fatal(err)
 	}
 	keeper := secrets.NewKeeper(drv)
+	defer keeper.Close()
 
 	msg := []byte("I'm a secret message!")
 	encryptedMsg, err := keeper.Encrypt(ctx, msg)
@@ -290,6 +295,7 @@ func testAs(t *testing.T, newHarness HarnessMaker, tc AsTest) {
 		t.Fatal(err)
 	}
 	keeper := secrets.NewKeeper(drv)
+	defer keeper.Close()
 
 	_, gotErr := keeper.Decrypt(ctx, []byte("malformed cipher message"))
 	if gotErr == nil {


### PR DESCRIPTION
Fixes #2400.

I found a bunch more places where we were missing `Close`/`Shutdown` calls by just printing a refcount and running the tests.

Note: I also re-recorded a `awskms` golden file that was printing an error; I suspect the test passes anyway because it's expecting an error, but it's not the "right" error.