### PR TITLE
docstore: fix references to docstore.RevisionField

### DIFF
--- a/docstore/doc.go
+++ b/docstore/doc.go
@@ -131,8 +131,8 @@
 // Docstore supports document revisions to distinguish different versions of a
 // document and enable optimistic locking. By default, Docstore stores the revision
 // in the field named "DocstoreRevision" (stored in the constant
-// docstore.RevisionField). Providers give you the option of changing that field
-// name.
+// docstore.DefaultRevisionField). Providers give you the option of changing
+// that field name.
 //
 // Docstore gives every document a revision when it is created, and changes that
 // revision whenever the document is modified. If a struct doesn't have a revision

--- a/docstore/driver/driver.go
+++ b/docstore/driver/driver.go
@@ -39,7 +39,7 @@ type Collection interface {
 	Key(Document) (interface{}, error)
 
 	// RevisionField returns the name of the field used to hold revisions.
-	// If the empty string is returned, docstore.RevisionField will be used.
+	// If the empty string is returned, docstore.DefaultRevisionField will be used.
 	RevisionField() string
 
 	// RunActions executes a slice of actions.

--- a/docstore/dynamodocstore/dynamo.go
+++ b/docstore/dynamodocstore/dynamo.go
@@ -177,7 +177,7 @@ type Options struct {
 	AllowScans bool
 
 	// The name of the field holding the document revision.
-	// Defaults to docstore.RevisionField.
+	// Defaults to docstore.DefaultRevisionField.
 	RevisionField string
 
 	// If set, call this function on queries that we cannot execute at all (for

--- a/docstore/firedocstore/fs.go
+++ b/docstore/firedocstore/fs.go
@@ -84,7 +84,7 @@ type Options struct {
 	// to run.
 	AllowLocalFilters bool
 	// The name of the field holding the document revision.
-	// Defaults to docstore.RevisionField.
+	// Defaults to docstore.DefaultRevisionField.
 	RevisionField string
 
 	// The maximum number of RPCs that can be in progress for a single call to

--- a/docstore/memdocstore/mem.go
+++ b/docstore/memdocstore/mem.go
@@ -52,7 +52,7 @@ import (
 // Options are optional arguments to the OpenCollection functions.
 type Options struct {
 	// The name of the field holding the document revision.
-	// Defaults to docstore.RevisionField.
+	// Defaults to docstore.DefaultRevisionField.
 	RevisionField string
 
 	// The maximum number of concurrent goroutines started for a single call to

--- a/docstore/mongodocstore/mongo.go
+++ b/docstore/mongodocstore/mongo.go
@@ -115,7 +115,7 @@ type Options struct {
 	// go.mongodb.org/mongo-driver/mongo, which lowercases field names.
 	LowercaseFields bool
 	// The name of the field holding the document revision.
-	// Defaults to docstore.RevisionField.
+	// Defaults to docstore.DefaultRevisionField.
 	RevisionField string
 }
 


### PR DESCRIPTION
The constant is actually called "docstore.DefaultRevisionField".