### PR TITLE
internal/cmd/gocdk: validate implicit image name

### DIFF
--- a/internal/cmd/gocdk/build.go
+++ b/internal/cmd/gocdk/build.go
@@ -124,5 +124,8 @@ func parseImageNameFromDockerfile(dockerfile []byte) (string, error) {
 		lenName = len(dockerfile) - nameStart
 	}
 	name := string(dockerfile[nameStart : nameStart+lenName])
+	if _, tag, digest := docker.ParseImageRef(name); tag != "" || digest != "" {
+		return "", xerrors.Errorf("image name %q must not contain a tag or digest")
+	}
 	return strings.TrimSpace(name), nil
 }

--- a/internal/cmd/gocdk/build_test.go
+++ b/internal/cmd/gocdk/build_test.go
@@ -53,6 +53,18 @@ func TestParseImageNameFromDockerfile(t *testing.T) {
 				"# gocdk-image: hello-world\n",
 			want: "hello-world",
 		},
+		{
+			name: "ImageContainsTag",
+			dockerfile: "# gocdk-image: hello-world:bar\n" +
+				"FROM scratch\n",
+			wantErr: true,
+		},
+		{
+			name: "ImageCustomRegistry",
+			dockerfile: "# gocdk-image: example.com:8080/hello-world\n" +
+				"FROM scratch\n",
+			want: "example.com:8080/hello-world",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Prevents potential bugs where a tag may be added in a surprising context.