### PR TITLE
internal/cmd/gocdk: generate unique tag per build

### DIFF
--- a/internal/cmd/gocdk/build.go
+++ b/internal/cmd/gocdk/build.go
@@ -17,6 +17,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -31,7 +33,7 @@ const defaultDockerTag = ":latest"
 
 func registerBuildCmd(ctx context.Context, pctx *processContext, rootCmd *cobra.Command) {
 	var list bool
-	var ref string
+	var refs []string
 	buildCmd := &cobra.Command{
 		Use:   "build",
 		Short: "TODO Build a Docker image",
@@ -44,29 +46,46 @@ func registerBuildCmd(ctx context.Context, pctx *processContext, rootCmd *cobra.
 				}
 				return nil
 			}
-			return build(ctx, pctx, ref)
+			return build(ctx, pctx, refs)
 		},
 	}
 	buildCmd.Flags().BoolVar(&list, "list", false, "display Docker images of this project")
-	buildCmd.Flags().StringVarP(&ref, "tag", "t", defaultDockerTag, "name and/or tag in the form `name[:tag] OR :tag`")
+	buildCmd.Flags().StringSliceVarP(&refs, "tag", "t", nil, "name and/or tag in the form `name[:tag] OR :tag`")
 	rootCmd.AddCommand(buildCmd)
 }
 
-// TODO(rvangent): Rename ref and/or dockerTag for consistency?
-// https://github.com/google/go-cloud/pull/2144#discussion_r288625539
-func build(ctx context.Context, pctx *processContext, ref string) error {
+func build(ctx context.Context, pctx *processContext, refs []string) error {
+	if len(refs) == 0 {
+		// No refs given. Use ":latest" and a generated tag.
+		tag, err := generateTag()
+		if err != nil {
+			return xerrors.Errorf("gocdk build: %w", err)
+		}
+		refs = []string{defaultDockerTag, ":" + tag}
+	} else {
+		// Copy to avoid mutating argument.
+		refs = append([]string(nil), refs...)
+	}
 	moduleRoot, err := pctx.ModuleRoot(ctx)
 	if err != nil {
 		return xerrors.Errorf("gocdk build: %w", err)
 	}
-	if strings.HasPrefix(ref, ":") {
-		imageName, err := moduleDockerImageName(moduleRoot)
-		if err != nil {
-			return xerrors.Errorf("gocdk build: %w", err)
+	var imageName string
+	for i := range refs {
+		if !strings.HasPrefix(refs[i], ":") {
+			continue
 		}
-		ref = imageName + ref
+		if imageName == "" {
+			// On first tag shorthand, lookup the module's Docker image name.
+			var err error
+			imageName, err = moduleDockerImageName(moduleRoot)
+			if err != nil {
+				return xerrors.Errorf("gocdk build: %w", err)
+			}
+		}
+		refs[i] = imageName + refs[i]
 	}
-	if err := docker.New(pctx.env).Build(ctx, ref, moduleRoot, pctx.stderr); err != nil {
+	if err := docker.New(pctx.env).Build(ctx, refs, moduleRoot, pctx.stderr); err != nil {
 		return xerrors.Errorf("gocdk build: %w", err)
 	}
 	return nil
@@ -106,6 +125,19 @@ func moduleDockerImageName(moduleRoot string) (string, error) {
 		return "", xerrors.Errorf("finding module Docker image name: parse %s: %w", dockerfilePath, err)
 	}
 	return imageName, nil
+}
+
+// generateTag generates a reasonably unique string that is suitable as a Docker
+// image tag.
+func generateTag() (string, error) {
+	now := time.Now().UTC()
+	var bits [4]byte
+	if _, err := rand.Read(bits[:]); err != nil {
+		return "", xerrors.Errorf("generate tag: %w", err)
+	}
+	year, month, day := now.Date()
+	hour, minute, second := now.Clock()
+	return fmt.Sprintf("%04d%02d%02d%02d%02d%02d_%08x", year, month, day, hour, minute, second, bits[:]), nil
 }
 
 // parseImageNameFromDockerfile finds the magic "# gocdk-image:" comment in a

--- a/internal/cmd/gocdk/build_test.go
+++ b/internal/cmd/gocdk/build_test.go
@@ -81,3 +81,41 @@ func TestParseImageNameFromDockerfile(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateTag(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 10; i++ {
+		tag, err := generateTag()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !isValidDockerTag(tag) {
+			t.Errorf("generateTag() = %q, <nil>; want valid Docker tag", tag)
+			continue
+		}
+		if seen[tag] {
+			t.Errorf("generateTag() = %q, <nil>; already seen", tag)
+		}
+		seen[tag] = true
+	}
+}
+
+func isValidDockerTag(tag string) bool {
+	// Following https://godoc.org/github.com/docker/distribution/reference
+	if len(tag) == 0 || len(tag) > 128 || !isWordChar(tag[0]) {
+		return false
+	}
+	for i := 1; i < len(tag); i++ {
+		if !isWordChar(tag[i]) && tag[i] != '.' && tag[i] != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func isWordChar(b byte) bool {
+	return '0' <= b && b <= '9' ||
+		'A' <= b && b <= 'Z' ||
+		'a' <= b && b <= 'z' ||
+		b == '_'
+}

--- a/internal/cmd/gocdk/internal/docker/docker.go
+++ b/internal/cmd/gocdk/internal/docker/docker.go
@@ -149,9 +149,14 @@ func (c *Client) Start(ctx context.Context, imageRef string, opts *RunOptions) (
 }
 
 // Build builds a Docker image from a source directory, optionally tagging it
-// with the given image reference. Output is streamed to the buildOutput writer.
-func (c *Client) Build(ctx context.Context, imageRef string, dir string, buildOutput io.Writer) error {
-	cmd := exec.CommandContext(ctx, "docker", "build", "-t="+imageRef, "--", dir)
+// with the given image references. Output is streamed to the buildOutput writer.
+func (c *Client) Build(ctx context.Context, imageRefs []string, dir string, buildOutput io.Writer) error {
+	args := []string{"build"}
+	for _, r := range imageRefs {
+		args = append(args, "-t="+r)
+	}
+	args = append(args, "--", dir)
+	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Stdout = buildOutput
 	cmd.Stderr = buildOutput
 	cmd.Env = c.env


### PR DESCRIPTION
This gives an easy-to-reference, immutable tag for each invocation of `gocdk build` (whereas before `gocdk build` would by default override the "latest" tag). This means that `gocdk build --list` will finally yield meaningful output out-of-the-box.

I've updated the deploy command to send the generated tag to launch. I am hoping this reduces flakiness with Cloud Run, since it should be receiving a new image reference each time, making failures more obvious.

Fixes #2350