### PR TITLE
docstore/internal/fields: support both case-sensitive and case-insensitive matching

### DIFF
--- a/docstore/driver/codec.go
+++ b/docstore/driver/codec.go
@@ -658,7 +658,7 @@ func decodeStruct(v reflect.Value, d Decoder) error {
 		if err != nil {
 			return false
 		}
-		f := fields.Match(key)
+		f := fields.MatchFold(key)
 		if f == nil {
 			err = gcerr.Newf(gcerr.InvalidArgument, nil, "no field matching %q in %s", key, v.Type())
 			return false

--- a/docstore/driver/document.go
+++ b/docstore/driver/document.go
@@ -110,7 +110,7 @@ func (d Document) Get(fp []string) (interface{}, error) {
 }
 
 func (d Document) structField(name string) (reflect.Value, error) {
-	f := d.fields.Match(name)
+	f := d.fields.MatchFold(name)
 	if f == nil {
 		return reflect.Value{}, gcerr.Newf(gcerr.NotFound, nil, "field %q not found in struct type %s", name, d.s.Type())
 	}

--- a/docstore/internal/fields/fields.go
+++ b/docstore/internal/fields/fields.go
@@ -178,16 +178,32 @@ func (c *Cache) Fields(t reflect.Type) (List, error) {
 // A List is a list of Fields.
 type List []Field
 
-// Match returns the field in the list whose name best matches the supplied
+// MatchExact returns the field in the list with the given name, or nil if there is
+// none.
+func (l List) MatchExact(name string) *Field {
+	return l.MatchExactBytes([]byte(name))
+}
+
+// MatchExactBytes is identical to MatchExact, except that the argument is a byte slice.
+func (l List) MatchExactBytes(name []byte) *Field {
+	for _, f := range l {
+		if bytes.Equal(f.nameBytes, name) {
+			return &f
+		}
+	}
+	return nil
+}
+
+// MatchFold returns the field in the list whose name best matches the supplied
 // name, nor nil if no field does. If there is a field with the exact name, it
 // is returned. Otherwise the first field (sorted by index) whose name matches
 // case-insensitively is returned.
-func (l List) Match(name string) *Field {
-	return l.MatchBytes([]byte(name))
+func (l List) MatchFold(name string) *Field {
+	return l.MatchFoldBytes([]byte(name))
 }
 
-// MatchBytes is identical to Match, except that the argument is a byte slice.
-func (l List) MatchBytes(name []byte) *Field {
+// MatchFoldBytes is identical to MatchFold, except that the argument is a byte slice.
+func (l List) MatchFoldBytes(name []byte) *Field {
 	var f *Field
 	for i := range l {
 		ff := &l[i]


### PR DESCRIPTION
This is something we would want if this package were ever made available for general use.

I did it so we could easily experiment with having docstore do case-sensitive field matching.