### PR TITLE
pubsub: remove flaky test

### DIFF
--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -31,7 +30,6 @@ import (
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/driver"
 	"gocloud.dev/pubsub/mempubsub"
-	"golang.org/x/sync/errgroup"
 )
 
 type driverTopic struct {

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -454,57 +454,6 @@ func TestOpenCensus(t *testing.T) {
 	}
 }
 
-func TestShutdownsDoNotLeakGoroutines(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	ng0 := runtime.NumGoroutine()
-	topic := mempubsub.NewTopic()
-	sub := mempubsub.NewSubscription(topic, time.Second)
-
-	// Send a bunch of messages at roughly the same time to make the batcher's work more difficult.
-	var eg errgroup.Group
-	n := 1000
-	for i := 0; i < n; i++ {
-		eg.Go(func() error {
-			return topic.Send(ctx, &pubsub.Message{})
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Receive the messages.
-	var eg2 errgroup.Group
-	for i := 0; i < n; i++ {
-		eg2.Go(func() error {
-			m, err := sub.Receive(ctx)
-			if err != nil {
-				return err
-			}
-			m.Ack()
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		t.Fatal(err)
-	}
-
-	// The Shutdown methods each spawn a goroutine so we want to make sure those don't
-	// keep running indefinitely after the Shutdowns return.
-	cancel()
-	topic.Shutdown(ctx)
-	sub.Shutdown(ctx)
-
-	// Wait for number of goroutines to return to normal.
-	// Otherwise the test hangs.
-	for {
-		ng := runtime.NumGoroutine()
-		if ng == ng0 {
-			break
-		}
-		time.Sleep(time.Millisecond)
-	}
-}
-
 var (
 	testOpenOnce sync.Once
 	testOpenGot  *url.URL


### PR DESCRIPTION
Fixes #2395.

This test is flaky because it captures the number of running goroutines and then expects to return to that value; sometimes there are goroutines running that have nothing to do with us (maybe GC?). I added some `Printf`s and saw:

Usually:

```
START: 3
  NOW: 5
  NOW: 3
```

but sometimes:

```
START: 3
  NOW: 491
  NOW: 3
```

I think the test flakes if you happen to get that `491` while the test is starting.

I don't think the test is adding much value, so I'm just going to remove it.
