### PR TITLE
memdocstore: support saving to a file

### DIFF
--- a/docstore/memdocstore/mem.go
+++ b/docstore/memdocstore/mem.go
@@ -64,7 +64,7 @@ type Options struct {
 	// The filename associated with this collection.
 	// When a collection is opened with a non-nil filename, the collection
 	// is loaded from the file if it exists. Otherwise, an empty collection is created.
-	// When the collection is closed, is contents are saved to the file.
+	// When the collection is closed, its contents are saved to the file.
 	Filename string
 }
 
@@ -431,8 +431,8 @@ func (c *collection) As(i interface{}) bool { return false }
 func (c *collection) ErrorAs(err error, i interface{}) bool { return false }
 
 // Close implements driver.Collection.Close.
-// If the collection was created with  Filename option, Close writes the collection's
-// documents to the file.
+// If the collection was created with a Filename option, Close writes the
+// collection's documents to the file.
 func (c *collection) Close() error {
 	return saveDocs(c.opts.Filename, c.docs)
 }

--- a/docstore/memdocstore/mem.go
+++ b/docstore/memdocstore/mem.go
@@ -39,6 +39,8 @@ package memdocstore // import "gocloud.dev/docstore/memdocstore"
 
 import (
 	"context"
+	"encoding/gob"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -58,6 +60,12 @@ type Options struct {
 	// The maximum number of concurrent goroutines started for a single call to
 	// ActionList.Do. If less than 1, there is no limit.
 	MaxOutstandingActions int
+
+	// The filename associated with this collection.
+	// When a collection is opened with a non-nil filename, the collection
+	// is loaded from the file if it exists. Otherwise, an empty collection is created.
+	// When the collection is closed, is contents are saved to the file.
+	Filename string
 }
 
 // TODO(jba): make this package thread-safe.
@@ -94,11 +102,15 @@ func newCollection(keyField string, keyFunc func(docstore.Document) interface{},
 	if opts.RevisionField == "" {
 		opts.RevisionField = docstore.DefaultRevisionField
 	}
+	docs, err := loadDocs(opts.Filename)
+	if err != nil {
+		return nil, err
+	}
 	return &collection{
 		keyField:    keyField,
 		keyFunc:     keyFunc,
+		docs:        docs,
 		opts:        opts,
-		docs:        map[interface{}]map[string]interface{}{},
 		curRevision: 0,
 	}, nil
 }
@@ -419,4 +431,48 @@ func (c *collection) As(i interface{}) bool { return false }
 func (c *collection) ErrorAs(err error, i interface{}) bool { return false }
 
 // Close implements driver.Collection.Close.
-func (c *collection) Close() error { return nil }
+// If the collection was created with  Filename option, Close writes the collection's
+// documents to the file.
+func (c *collection) Close() error {
+	return saveDocs(c.opts.Filename, c.docs)
+}
+
+type mapOfDocs = map[interface{}]map[string]interface{}
+
+// Read a map from the filename if is is not empty and the file exists.
+// Otherwise return an empty (not nil) map.
+func loadDocs(filename string) (mapOfDocs, error) {
+	if filename == "" {
+		return mapOfDocs{}, nil
+	}
+	f, err := os.Open(filename)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		// If the file doesn't exist, return an empty map without error.
+		return mapOfDocs{}, nil
+	}
+	defer f.Close()
+	var m mapOfDocs
+	if err := gob.NewDecoder(f).Decode(&m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// saveDocs saves m to filename if filename is not empty.
+func saveDocs(filename string, m mapOfDocs) error {
+	if filename == "" {
+		return nil
+	}
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	if err := gob.NewEncoder(f).Encode(m); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}

--- a/docstore/memdocstore/mem_test.go
+++ b/docstore/memdocstore/mem_test.go
@@ -16,6 +16,8 @@ package memdocstore
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -202,5 +204,27 @@ func TestExampleInDoc(t *testing.T) {
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Error(diff)
+	}
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	f, err := ioutil.TempFile("", "testSaveAndLoad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	docs := map[interface{}]map[string]interface{}{
+		"k1": {"key": "k1", "a": 1},
+		"k2": {"key": "k2", "b": 2},
+	}
+	if err := saveDocs(f.Name(), docs); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadDocs(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cmp.Equal(got, docs) {
+		t.Errorf("\ngot  %v\nwant %v", got, docs)
 	}
 }

--- a/docstore/memdocstore/urls.go
+++ b/docstore/memdocstore/urls.go
@@ -37,11 +37,10 @@ const Scheme = "mem"
 // The URL's host is the name of the collection.
 // The URL's path is used as the keyField.
 //
-// The revision_field query parameter specifies the name of the revision field.
-// See Options.RevisionField for details.
+// The following query parameters are supported:
 //
-// The filename query parameter specifies a filename to use when opening
-// and closing the collection. See Options.Filename for details.
+//  - revision_field (optional): the name of the revision field.
+//  - filename (optional): the filename to store the collection in.
 type URLOpener struct {
 	mu          sync.Mutex
 	collections map[string]urlColl

--- a/docstore/memdocstore/urls.go
+++ b/docstore/memdocstore/urls.go
@@ -37,7 +37,11 @@ const Scheme = "mem"
 // The URL's host is the name of the collection.
 // The URL's path is used as the keyField.
 //
-// No query parameters are supported.
+// The revision_field query parameter specifies the name of the revision field.
+// See Options.RevisionField for details.
+//
+// The filename query parameter specifies a filename to use when opening
+// and closing the collection. See Options.Filename for details.
 type URLOpener struct {
 	mu          sync.Mutex
 	collections map[string]urlColl
@@ -53,8 +57,10 @@ func (o *URLOpener) OpenCollectionURL(ctx context.Context, u *url.URL) (*docstor
 	q := u.Query()
 	options := &Options{
 		RevisionField: q.Get("revision_field"),
+		Filename:      q.Get("filename"),
 	}
 	q.Del("revision_field")
+	q.Del("filename")
 	for param := range q {
 		return nil, fmt.Errorf("open collection %v: invalid query parameter %q", u, param)
 	}

--- a/docstore/memdocstore/urls_test.go
+++ b/docstore/memdocstore/urls_test.go
@@ -39,6 +39,8 @@ func TestOpenCollectionFromURL(t *testing.T) {
 		{"mem://coll/my/key", true},
 		// Passing revision field.
 		{"mem://coll/_id?revision_field=123", false},
+		// Passing filename.
+		{"mem://coll/_id?filename=foo.out", false},
 		// Invalid parameter.
 		{"mem://coll/key?param=value", true},
 	}


### PR DESCRIPTION
Add a Filename option that will load a collection from a filename if it exists, and save it
when the collection is closed.

Fixes #1760.