### PR TITLE
pubsub/kafkapubsub: one more fix to TestMultiplePartionsWithRebalancing

### DIFF
--- a/pubsub/kafkapubsub/kafka_test.go
+++ b/pubsub/kafkapubsub/kafka_test.go
@@ -391,6 +391,7 @@ func TestMultiplePartionsWithRebalancing(t *testing.T) {
 	}
 	cancel()
 	<-done
+	<-done
 }
 
 func sanitize(testName string) string {


### PR DESCRIPTION
Still raced, need to verify both goroutines are closed before exiting the test, since exiting the test shuts down the subscription.