### PR TITLE
pubsub/tests: ensure tests fail faster by using a ctx with timeout

### DIFF
--- a/pubsub/drivertest/drivertest.go
+++ b/pubsub/drivertest/drivertest.go
@@ -408,9 +408,12 @@ func testNack(t *testing.T, newHarness HarnessMaker) {
 	// Get the messages, but nack them.
 	// Make sure to nack after receiving all of them; otherwise, we could
 	// receive one of the messages twice instead of receiving all nMessages.
+	// The test will hang here if the messages aren't redelivered, so use a shorter timeout.
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 	var got []*pubsub.Message
 	for i := 0; i < nMessages; i++ {
-		m, err := sub.Receive(ctx)
+		m, err := sub.Receive(ctx2)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -424,7 +427,7 @@ func testNack(t *testing.T, newHarness HarnessMaker) {
 		t.Error(diff)
 	}
 	// The test will hang here if the messages aren't redelivered, so use a shorter timeout.
-	ctx2, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx2, cancel = context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	got = nil
@@ -505,9 +508,12 @@ func testBatching(t *testing.T, newHarness HarnessMaker) {
 	}
 
 	// Get the messages.
+	// The test will hang here if the messages aren't delivered, so use a shorter timeout.
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 	var got []*pubsub.Message
 	for i := 0; i < nMessages; i++ {
-		m, err := sub.Receive(ctx)
+		m, err := sub.Receive(ctx2)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -547,9 +553,12 @@ func testDoubleAck(t *testing.T, newHarness HarnessMaker) {
 	}
 
 	// Retrieve the messages.
+	// The test will hang here if the messages aren't delivered, so use a shorter timeout.
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 	var dms []*driver.Message
 	for len(dms) != 3 {
-		curdms, err := ds.ReceiveBatch(ctx, 3)
+		curdms, err := ds.ReceiveBatch(ctx2, 3)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -584,7 +593,7 @@ func testDoubleAck(t *testing.T, newHarness HarnessMaker) {
 	}
 
 	// The test will hang here if the message isn't redelivered, so use a shorter timeout.
-	ctx2, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx2, cancel = context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	// We're looking to re-receive dms[2].
@@ -779,7 +788,10 @@ func testMetadata(t *testing.T, newHarness HarnessMaker) {
 			t.Fatal(err)
 		}
 
-		m, err = sub.Receive(ctx)
+		// The test will hang here if the messages aren't delivered, so use a shorter timeout.
+		ctx2, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		m, err = sub.Receive(ctx2)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -837,7 +849,10 @@ func testNonUTF8MessageBody(t *testing.T, newHarness HarnessMaker) {
 	if err := topic.Send(ctx, m); err != nil {
 		t.Fatal(err)
 	}
-	m, err = sub.Receive(ctx)
+	// The test will hang here if the messages aren't delivered, so use a shorter timeout.
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	m, err = sub.Receive(ctx2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -912,7 +927,10 @@ func testAs(t *testing.T, newHarness HarnessMaker, st AsTest) {
 	if err := topic.Send(ctx, msg); err != nil {
 		t.Fatal(err)
 	}
-	m, err := sub.Receive(ctx)
+	// The test will hang here if the messages aren't delivered, so use a shorter timeout.
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	m, err := sub.Receive(ctx2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -954,7 +972,7 @@ func testAs(t *testing.T, newHarness HarnessMaker, st AsTest) {
 	}()
 
 	// The test will hang here if Receive doesn't fail quickly, so set a shorter timeout.
-	ctx2, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx2, cancel = context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	_, subErr := nonExistentSub.Receive(ctx2)
 	if subErr == nil || ctx2.Err() != nil || gcerrors.Code(subErr) != gcerrors.NotFound {

--- a/pubsub/kafkapubsub/kafka_test.go
+++ b/pubsub/kafkapubsub/kafka_test.go
@@ -385,7 +385,6 @@ func TestMultiplePartionsWithRebalancing(t *testing.T) {
 	}
 	defer func() {
 		if err := sub2.Shutdown(ctx); err != nil {
-			fmt.Printf("shutting down sub2\n")
 			t.Error(err)
 		}
 	}()

--- a/pubsub/kafkapubsub/kafka_test.go
+++ b/pubsub/kafkapubsub/kafka_test.go
@@ -253,7 +253,7 @@ func TestKafkaKey(t *testing.T) {
 	}
 
 	// The test will hang here if the message isn't available, so use a shorter timeout.
-	ctx2, cancel := context.WithTimeout(ctx, 15*time.Second)
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	got, err := sub.Receive(ctx2)
 	if err != nil {
@@ -285,7 +285,7 @@ func TestMultiplePartionsWithRebalancing(t *testing.T) {
 	}
 	const (
 		keyName   = "kafkakey"
-		nMessages = 50
+		nMessages = 10
 	)
 	uniqueID := rand.Int()
 	ctx := context.Background()
@@ -340,30 +340,41 @@ func TestMultiplePartionsWithRebalancing(t *testing.T) {
 
 	// Receive the messages via the subscription.
 	got := make(chan struct{})
-	done := make(chan struct{})
+	done := make(chan error)
 	read := func(ctx context.Context, sub *pubsub.Subscription) {
 		for {
 			m, err := sub.Receive(ctx)
-			if err == context.Canceled {
-				break
-			}
 			if err != nil {
-				t.Fatal(err)
+				if err == context.Canceled {
+					// Expected after all messages are received, no error.
+					done <- nil
+				} else {
+					done <- err
+				}
+				return
 			}
-			got <- struct{}{}
 			m.Ack()
+			got <- struct{}{}
 		}
-		done <- struct{}{}
 	}
 	// The test will hang here if the messages aren't available, so use a shorter
 	// timeout.
-	ctx2, cancel := context.WithTimeout(ctx, 15*time.Second)
+	ctx2, cancel := context.WithTimeout(ctx, 30*time.Second)
 	go read(ctx2, sub)
 	for i := 0; i < nMessages; i++ {
-		<-got
+		select {
+		case <-got:
+		case err := <-done:
+			// Premature error.
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
 	}
 	cancel()
-	<-done
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
 
 	// Add another subscription to the same group. Kafka will rebalance the
 	// consumer group, causing the Cleanup/Setup/ConsumeClaim loop. Each of the
@@ -374,6 +385,7 @@ func TestMultiplePartionsWithRebalancing(t *testing.T) {
 	}
 	defer func() {
 		if err := sub2.Shutdown(ctx); err != nil {
+			fmt.Printf("shutting down sub2\n")
 			t.Error(err)
 		}
 	}()
@@ -383,15 +395,25 @@ func TestMultiplePartionsWithRebalancing(t *testing.T) {
 	send()
 
 	// The test will hang here if the message isn't available, so use a shorter timeout.
-	ctx3, cancel := context.WithTimeout(ctx, 15*time.Second)
+	ctx3, cancel := context.WithTimeout(ctx, 30*time.Second)
 	go read(ctx3, sub)
 	go read(ctx3, sub2)
 	for i := 0; i < nMessages; i++ {
-		<-got
+		select {
+		case <-got:
+		case err := <-done:
+			// Premature error.
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
 	}
 	cancel()
-	<-done
-	<-done
+	for i := 0; i < 2; i++ {
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+	}
 }
 
 func sanitize(testName string) string {


### PR DESCRIPTION
Updates #2481.

This PR makes sure that the `ctx` we pass to `Receive` in tests always has a 30 second timeout.

It also makes sure that `kafkapubsub`'s `TestMultiplePartionsWithRebalancing` doesn't hang when the `ctx` times out.