### PR TITLE
docstore/mongodocstore: clarify lowercase takes effect on all fields

### DIFF
--- a/docstore/mongodocstore/mongo.go
+++ b/docstore/mongodocstore/mongo.go
@@ -108,10 +108,10 @@ type Options struct {
 	// MongoDB document field "F". This setting matches the behavior of other
 	// docstore providers, making code portable across providers.
 	//
-	// If true, struct fields correspond to lower-cased MongoDB document fields. The
-	// struct field F will correspond to the MongoDB document field "f", for
-	// instance. Use this to make code that uses this package interoperate with code
-	// that uses the official Go client for MongoDB,
+	// If true, all fields correspond to lower-cased MongoDB document fields. The
+	// field name F will correspond to the MongoDB document field "f", for
+	// instance. Use this to make code that uses this package interoperate with
+	// code that uses the official Go client for MongoDB,
 	// go.mongodb.org/mongo-driver/mongo, which lowercases field names.
 	LowercaseFields bool
 	// The name of the field holding the document revision.

--- a/docstore/mongodocstore/mongo_test.go
+++ b/docstore/mongodocstore/mongo_test.go
@@ -274,8 +274,15 @@ func TestLowercaseFields(t *testing.T) {
 	check(got4, map[string]interface{}{"id": int64(1), "f": int64(4), "g": int64(3),
 		"docstorerevision": udoc.DocstoreRevision})
 
-	// // Query filters.
+	// Query filters.
 	var got5 S
 	must(coll.Query().Where("ID", "=", 1).Where("G", ">", 2).Get(ctx).Next(ctx, &got5))
 	check(got5, S{ID: 1, F: 4, G: 3, DocstoreRevision: udoc.DocstoreRevision})
+
+	// Query orders.
+	sdoc2 := &S{ID: 2, F: 5, G: 6}
+	must(coll.Put(ctx, sdoc2))
+	var got6 S
+	must(coll.Query().OrderBy("G", docstore.Descending).Get(ctx).Next(ctx, &got6))
+	check(got6, *sdoc2)
 }


### PR DESCRIPTION
Fixes #2456 