### PR TITLE
internal/website: add automatic table of contents

### DIFF
--- a/internal/website/content/howto/blob/data.md
+++ b/internal/website/content/howto/blob/data.md
@@ -2,6 +2,7 @@
 title: "Store and Access Unstructured Data"
 date: 2019-03-21T08:42:51-07:00
 weight: 2
+toc: true
 ---
 
 Once you have [opened a bucket][] for the storage provider you want, you can

--- a/internal/website/content/howto/blob/open-bucket.md
+++ b/internal/website/content/howto/blob/open-bucket.md
@@ -2,6 +2,7 @@
 title: "Open a Bucket"
 date: 2019-03-20T14:51:29-07:00
 weight: 1
+toc: true
 ---
 
 The first step in interacting with unstructured storage is connecting to your

--- a/internal/website/content/howto/pubsub/publish.md
+++ b/internal/website/content/howto/pubsub/publish.md
@@ -2,6 +2,7 @@
 title: "Publish Messages to a Topic"
 date: 2019-03-26T09:44:15-07:00
 weight: 1
+toc: true
 ---
 
 Publishing a message to a topic with the Go CDK takes two steps:

--- a/internal/website/content/howto/pubsub/subscribe.md
+++ b/internal/website/content/howto/pubsub/subscribe.md
@@ -2,6 +2,7 @@
 title: "Subscribe to a Topic's Messages"
 date: 2019-03-26T09:44:33-07:00
 weight: 2
+toc: true
 ---
 
 Subscribing to messages on a topic with the Go CDK takes three steps:

--- a/internal/website/content/howto/runtimevar/_index.md
+++ b/internal/website/content/howto/runtimevar/_index.md
@@ -2,6 +2,7 @@
 title: "Runtime Configuration"
 date: 2019-06-18T14:51:12-07:00
 showInSidenav: true
+toc: true
 ---
 
 Working with runtime variables using the Go CDK takes two steps:

--- a/internal/website/content/howto/runtimevar/_index.md
+++ b/internal/website/content/howto/runtimevar/_index.md
@@ -37,7 +37,7 @@ the `runtimevar.OpenVariable` function as follows.
 {{< goexample
 "gocloud.dev/runtimevar/gcpruntimeconfig.Example_openVariableFromURL" >}}
 
-## GCP Runtime Configurator Constructor {#rc-ctor}
+### GCP Runtime Configurator Constructor {#rc-ctor}
 
 The [`gcpruntimeconfig.OpenVariable`][] constructor opens a Runtime Configurator
 variable.
@@ -58,7 +58,7 @@ To open a variable stored in [AWS Parameter Store][] via a URL, you can use the
 [AWS Parameter Store]:
 https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html
 
-## AWS Parameter Store Constructor {#ps-ctor}
+### AWS Parameter Store Constructor {#ps-ctor}
 
 The [`awsparamstore.OpenVariable`][] constructor opens a Parameter Store
 variable.
@@ -79,7 +79,7 @@ remotely. To open a variable stored in `etcd` via a URL, you can use the
 
 [etcd]: https://etcd.io/
 
-## etcd Constructor
+### etcd Constructor
 
 The [`etcdvar.OpenVariable`][] constructor opens an etcd variable.
 

--- a/internal/website/content/howto/secrets/crypt.md
+++ b/internal/website/content/howto/secrets/crypt.md
@@ -2,6 +2,7 @@
 title: "Encrypt & Decrypt Data"
 date: 2019-03-21T17:44:28-07:00
 weight: 2
+toc: true
 ---
 
 Once you have [opened a secrets keeper][] for the secrets provider you want,

--- a/internal/website/content/howto/secrets/open-keeper.md
+++ b/internal/website/content/howto/secrets/open-keeper.md
@@ -41,7 +41,7 @@ application connects to the correct region, but otherwise
 
 [AWS KMS]: https://aws.amazon.com/kms/
 
-## AWS Key Management Service Constructor {#aws-ctor}
+### AWS Key Management Service Constructor {#aws-ctor}
 
 The [`awskms.OpenKeeper`][] constructor opens a customer master key. You must
 first create an [AWS session][] with the same region as your key and then

--- a/internal/website/content/howto/secrets/open-keeper.md
+++ b/internal/website/content/howto/secrets/open-keeper.md
@@ -2,6 +2,7 @@
 title: "Open a Secret Keeper"
 date: 2019-03-21T17:43:54-07:00
 weight: 1
+toc: true
 ---
 
 The first step in working with your secrets is establishing your

--- a/internal/website/content/howto/secrets/runtimevar.md
+++ b/internal/website/content/howto/secrets/runtimevar.md
@@ -2,7 +2,6 @@
 title: "Keep Secrets in Configuration"
 date: 2019-03-21T17:45:27-07:00
 weight: 3
-toc: true
 ---
 
 Once you have [opened a secrets keeper][] for the secrets provider you want,

--- a/internal/website/content/howto/secrets/runtimevar.md
+++ b/internal/website/content/howto/secrets/runtimevar.md
@@ -2,6 +2,7 @@
 title: "Keep Secrets in Configuration"
 date: 2019-03-21T17:45:27-07:00
 weight: 3
+toc: true
 ---
 
 Once you have [opened a secrets keeper][] for the secrets provider you want,

--- a/internal/website/content/howto/sql/_index.md
+++ b/internal/website/content/howto/sql/_index.md
@@ -2,6 +2,7 @@
 title: "MySQL/PostgreSQL"
 date: 2019-06-21T09:26:56-07:00
 showInSidenav: true
+toc: true
 ---
 
 Connecting to cloud providers' hosted database services requires additional

--- a/internal/website/layouts/_default/list.html
+++ b/internal/website/layouts/_default/list.html
@@ -1,5 +1,6 @@
 {{ define "main" -}}
 <h1>{{ .Title }}</h1>
+{{ partial "page-toc.html" . }}
 {{ partial "header-link.html" .Content }}
 {{ with .Data.Pages.GroupBy "Weight" }}
 <div class="PageList">

--- a/internal/website/layouts/_default/single.html
+++ b/internal/website/layouts/_default/single.html
@@ -1,4 +1,5 @@
 {{ define "main" -}}
 <h1>{{ .Title }}</h1>
+{{ partial "page-toc.html" . }}
 {{ partial "header-link.html" .Content }}
 {{- end }}

--- a/internal/website/layouts/howto/list.html
+++ b/internal/website/layouts/howto/list.html
@@ -1,5 +1,6 @@
 {{ define "main" -}}
 <h1>{{ .Title }}</h1>
+{{ partial "page-toc.html" . }}
 {{ partial "header-link.html" .Content }}
 {{ if or .Data.Pages .Sections }}
 <ul class="HowtoList">

--- a/internal/website/layouts/partials/page-toc.html
+++ b/internal/website/layouts/partials/page-toc.html
@@ -1,0 +1,6 @@
+{{if .Page.Params.toc}}
+<nav class="PageTOC">
+  <div class="PageTOC-heading">In this article</div>
+  {{ .Page.TableOfContents }}
+</nav>
+{{end -}}

--- a/internal/website/static/css/style.css
+++ b/internal/website/static/css/style.css
@@ -75,7 +75,6 @@ body {
 }
 .MainContent-bounds {
   box-sizing: border-box;
-  grid-area: main;
   margin: 0;
   padding: 0;
   max-width: 50rem;
@@ -125,6 +124,39 @@ body {
 .Sidenav-pageLink:hover,
 .Sidenav-pageLink:active {
   text-decoration: underline;
+}
+.PageTOC {
+  border-left: 2px solid #dbd9d6;
+  float: right;
+  margin: 0.25rem 0 1rem 2rem;
+  max-width: 25%;
+  min-width: 15%;
+  padding: 0.5rem 0 0.5rem 1rem;
+}
+@media (max-width: 1024px) {
+  .PageTOC {
+    border: none;
+    float: none;
+    margin: 1.5rem 0 0.5rem;
+    max-width: none;
+    min-width: none;
+    padding: 0;
+  }
+}
+.PageTOC-heading {
+  font: 700 1rem/1.25 'Work Sans', 'Roboto', sans-serif;
+  margin: 0 0 0.5rem;
+  text-rendering: optimizeLegibility;
+}
+.PageTOC ul {
+  display: block;
+  margin: 0;
+  padding: 0;
+}
+.PageTOC li {
+  display: block;
+  margin: 0.3rem 0;
+  padding: 0;
 }
 .PageFooter {
   background: #555759;

--- a/internal/website/static/css/style.css
+++ b/internal/website/static/css/style.css
@@ -143,19 +143,39 @@ body {
     padding: 0;
   }
 }
+.PageTOC {
+  font-size: 0.85rem;
+}
 .PageTOC-heading {
   font: 700 1rem/1.25 'Work Sans', 'Roboto', sans-serif;
   margin: 0 0 0.5rem;
   text-rendering: optimizeLegibility;
 }
+.PageTOC>nav>ul>li>ul {
+  /* Don't indent top-level list. */
+  margin: 0;
+}
 .PageTOC ul {
+  list-style: none;
+  margin: 0 0 0 1rem;
+  padding: 0;
+}
+.PageTOC li {
+  margin: 0.3rem 0;
+  padding: 0;
+}
+.PageTOC>nav>ul {
+  /* CSS trick to remove h1 level from TOC.
+   * https://github.com/gohugoio/hugo/issues/1778 */
   display: block;
   margin: 0;
   padding: 0;
 }
-.PageTOC li {
+.PageTOC>nav>ul>li {
+  /* CSS trick to remove h1 level from TOC.
+   * https://github.com/gohugoio/hugo/issues/1778 */
   display: block;
-  margin: 0.3rem 0;
+  margin: 0;
   padding: 0;
 }
 .PageFooter {


### PR DESCRIPTION
This is enabled per-page using `toc: true` in the front matter. It will float a sidebar to the right on desktop and show the list inline with content after the title on tablet and smaller screens.