### PR TITLE
internal/cmd/gocdk/internal/launcher: create launcher that calls to a subprocess

### DIFF
--- a/internal/cmd/gocdk/internal/launcher/exec.go
+++ b/internal/cmd/gocdk/internal/launcher/exec.go
@@ -1,0 +1,62 @@
+// Copyright 2019 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package launcher
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/url"
+	"os/exec"
+
+	"golang.org/x/xerrors"
+)
+
+// Exec runs an arbitrary subprocess to launch.
+type Exec struct {
+	// Stderr is where the subprocess's stderr will be written to.
+	Stderr io.Writer
+
+	// Dir is the directory the subprocess should be run from. For now, this
+	// should always be the module root.
+	Dir string
+}
+
+// Launch implements Launcher.Launch.
+func (e *Exec) Launch(ctx context.Context, input *Input) (*url.URL, error) {
+	argv := specifierStringArrayValue(input.Specifier, "argv")
+	if len(argv) == 0 {
+		return nil, xerrors.Errorf("exec launch: specifier argv must be an array of strings with at least one element")
+	}
+	c := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	c.Stderr = e.Stderr
+	c.Dir = e.Dir
+	stdin := new(bytes.Buffer)
+	if err := json.NewEncoder(stdin).Encode(input); err != nil {
+		return nil, xerrors.Errorf("exec launch: %w", err)
+	}
+	c.Stdin = stdin
+	out, err := c.Output()
+	if err != nil {
+		return nil, xerrors.Errorf("exec launch: %w", err)
+	}
+	out = bytes.TrimSuffix(out, []byte("\n"))
+	u, err := url.Parse(string(out))
+	if err != nil {
+		return nil, xerrors.Errorf("exec launch: parse output: %w", err)
+	}
+	return u, nil
+}

--- a/internal/cmd/gocdk/internal/launcher/launcher.go
+++ b/internal/cmd/gocdk/internal/launcher/launcher.go
@@ -32,15 +32,15 @@ type Input struct {
 	// DockerImage specifies the image name and tag of the local Docker image to
 	// deploy. If the local image does not exist, then the launcher should return
 	// an error.
-	DockerImage string
+	DockerImage string `json:"docker_image"`
 
 	// env is the set of additional environment variables to set. It should not
 	// include PORT nor should it contain multiple entries for the same variable
 	// name.
-	Env []string
+	Env []string `json:"env"`
 
 	// specifier is the set of arguments passed from a biome's Terraform module.
-	Specifier map[string]interface{}
+	Specifier map[string]interface{} `json:"specifier"`
 }
 
 // Local starts local Docker containers.
@@ -121,4 +121,21 @@ func specifierBoolValue(spec map[string]interface{}, key string) bool {
 	default:
 		return false
 	}
+}
+
+// specifierStringArrayValue returns the specifier's value for a key if it is an array of strings.
+func specifierStringArrayValue(spec map[string]interface{}, key string) []string {
+	arr, _ := spec[key].([]interface{})
+	if len(arr) == 0 {
+		return nil
+	}
+	sarr := make([]string, 0, len(arr))
+	for _, v := range arr {
+		s, ok := v.(string)
+		if !ok {
+			return nil
+		}
+		sarr = append(sarr, s)
+	}
+	return sarr
 }

--- a/internal/cmd/gocdk/launch.go
+++ b/internal/cmd/gocdk/launch.go
@@ -140,6 +140,15 @@ func newLauncher(ctx context.Context, pctx *processContext, launcherName string)
 			ConfigProvider: sess,
 			DockerClient:   docker.New(pctx.env),
 		}, nil
+	case "exec":
+		dir, err := pctx.ModuleRoot(ctx)
+		if err != nil {
+			return nil, xerrors.Errorf("prepare exec launcher: %w", err)
+		}
+		return &launcher.Exec{
+			Stderr: pctx.stderr,
+			Dir:    dir,
+		}, nil
 	default:
 		return nil, xerrors.Errorf("prepare launcher: unknown launcher %q", launcherName)
 	}


### PR DESCRIPTION
This is primarily a proof-of-concept. The launch input is sent as stdin to the subprocess and the subprocess must print out a valid URL on success. The process to execute is given as the `argv` key in launch specifier, so this could also use `go run` or the like to run an arbitrary Go "script".

As an example, the following script implements the same functionality as `launcher.Local`:

  ```bash
  #!/bin/bash
  set -euo pipefail

  log() {
    echo "$@" 1>&2
  }

  # Save stdin to $launch_input.
  launch_input="$(cat)"
  log "Got launch input: $launch_input"

  # Convert environment variables into Docker argument list.
  mapfile -t docker_env < <(echo "$launch_input" | jq -r '.env[]')
  docker_env_args=()
  for e in "${docker_env[@]}"; do
    docker_env_args+=( "-e" "$e" )
  done
  docker_env_args+=( "-e" "PORT=8080" )

  # Start Docker image.
  docker_image="$(echo "$launch_input" | jq -r '.docker_image')"
  host_port="$(echo "$launch_input" | jq -r '.specifier.host_port')"
  container_id="$(docker run -d -p "$host_port":8080 "${docker_env_args[@]}" "$docker_image")"
  log "Container running, stop it with docker stop $container_id"

  # Print URL back to CDK.
  echo "http://localhost:$host_port/"
  ```

Updates #2376