### PR TITLE
samples/gocdk-runtimevar: fix broken build on go 1.11

### DIFF
--- a/samples/gocdk-runtimevar/main_test.go
+++ b/samples/gocdk-runtimevar/main_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -72,9 +71,6 @@ func Test(t *testing.T) {
 		cancel()
 		res := <-outc
 		if res.err == context.Canceled {
-			res.err = nil
-		}
-		if ee, ok := res.err.(*exec.ExitError); ok && ee.ExitCode() == -1 { // killed by signal
 			res.err = nil
 		}
 


### PR DESCRIPTION
Fixes #2511 

I just removed the code that doesn't compile on Go 1.11 and it still seems to work fine :-).