### PR TITLE
internal/gocdk: add CLI tests for commands that require stdin

### DIFF
--- a/internal/cmd/gocdk/internal/prompt/prompt.go
+++ b/internal/cmd/gocdk/internal/prompt/prompt.go
@@ -88,7 +88,7 @@ const AWSRegionTfLocalName = "aws_region"
 
 // AWSRegion prompts the user for an AWS region.
 func AWSRegion(reader *bufio.Reader, out io.Writer) (string, error) {
-	return String(reader, out, "Please enter an AWS region.\n  See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html for more information.", "us-east-1")
+	return String(reader, out, "Please enter an AWS region.\n  See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html for more information.", "us-west-1")
 }
 
 // AWSRegionIfNeeded prompts the user for an AWS region if needed.

--- a/internal/cmd/gocdk/testdata/biome.ct
+++ b/internal/cmd/gocdk/testdata/biome.ct
@@ -19,21 +19,76 @@ $ cd myproj
 $ gocdk biome list
 dev
 
-$ gocdk biome add mybiome --launcher local
-gocdk: Adding biome "mybiome"...
+# "biome add" prompts for a biome name.
+$ echof stdin
+$ gocdk biome add localbiomeprompt < stdin
+gocdk: Adding biome "localbiomeprompt"...
+
+Please enter a launcher to use (local, cloudrun, ecs)
+  default: local
+Enter a value, or "cancel": gocdk: Success!
+
+# Local launcher; no inputs needed.
+$ gocdk biome add localbiome --launcher local
+gocdk: Adding biome "localbiome"...
 gocdk: Success!
+
+# Cloudrun launcher; requires projectID and service name.
+$ echof stdin myprojectid\n
+$ gocdk biome add cloudrunbiome --launcher cloudrun < stdin
+gocdk: Adding biome "cloudrunbiome"...
+gocdk: 
+gocdk: To launch on cloudrun, we need a few pieces of information.
+
+Please enter your Google Cloud project ID (e.g. "example-project-123456")
+Enter a value, or "cancel": 
+Please enter a service name
+  default: myservice
+Enter a value, or "cancel": gocdk: Success!
+
+# ECS launcher; requires region.
+$ echof stdin
+$ gocdk biome add ecsbiome --launcher ecs < stdin
+gocdk: Adding biome "ecsbiome"...
+gocdk: 
+gocdk: To launch on ECS, we need a few pieces of information.
+
+Please enter an AWS region.
+  See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html for more information.
+  default: us-west-1
+Enter a value, or "cancel": gocdk: Success!
 
 $ cd biomes
 
-$ ls mybiome
-mybiome/
+$ gocdk biome list
+cloudrunbiome
+dev
+ecsbiome
+localbiome
+localbiomeprompt
+
+$ ls cloudrunbiome
+cloudrunbiome/
   biome.json
   main.tf
   outputs.tf
   secrets.auto.tfvars
   variables.tf
 
-$ gocdk biome list
-dev
-mybiome
+$ ls ecsbiome
+ecsbiome/
+  biome.json
+  ecs.tf
+  main.tf
+  outputs.tf
+  secrets.auto.tfvars
+  variables.tf
+
+$ ls localbiome
+localbiome/
+  biome.json
+  main.tf
+  outputs.tf
+  secrets.auto.tfvars
+  variables.tf
 

--- a/internal/cmd/gocdk/testdata/resource.ct
+++ b/internal/cmd/gocdk/testdata/resource.ct
@@ -44,13 +44,99 @@ $ gocdk resource add dev blob/foo --> FAIL
 gocdk: Adding "blob/foo" to "dev"...
 Error: resource add: "blob/foo" is not a supported type; use 'gocdk resource list' to see available types
 
-# Provision types that don't need any stdin.
-# TODO(rvangent): Add the other types once they work without input.
+$ echof stdin
+$ gocdk resource add dev blob/azureblob < stdin
+gocdk: Adding "blob/azureblob" to "dev"...
+
+Please enter an Azure location.
+  See https://azure.microsoft.com/en-us/global-infrastructure/locations for more information.
+  default: westus
+Enter a value, or "cancel": gocdk:   added a Terraform provider "azurerm" to "main.tf"
+gocdk:   added a Terraform provider "random" to "main.tf"
+gocdk:   added an output variable "BLOB_BUCKET_URL" to "outputs.tf"
+gocdk:   added an output variable "AZURE_STORAGE_ACCOUNT" to "outputs.tf"
+gocdk:   added an output variable "AZURE_STORAGE_KEY" to "outputs.tf"
+gocdk:   added a new file "azureblob.tf"
+gocdk: Success!
+
 $ gocdk resource add dev blob/fileblob
 gocdk: Adding "blob/fileblob" to "dev"...
 gocdk:   added a Terraform provider "local" to "main.tf"
 gocdk:   added an output variable "BLOB_BUCKET_URL" to "outputs.tf"
 gocdk:   added a new file "fileblob.tf"
+gocdk: Success!
+
+$ echof stdin myprojectid\n
+$ gocdk resource add dev blob/gcsblob < stdin
+gocdk: Adding "blob/gcsblob" to "dev"...
+
+Please enter your Google Cloud project ID (e.g. "example-project-123456")
+Enter a value, or "cancel": 
+Please enter a GCP storage location.
+  See https://cloud.google.com/storage/docs/locations for more information.
+  default: US
+Enter a value, or "cancel": gocdk:   added a Terraform provider "google" to "main.tf"
+gocdk:   added an output variable "BLOB_BUCKET_URL" to "outputs.tf"
+gocdk:   added a new file "gcsblob.tf"
+gocdk: Success!
+
+$ echof stdin
+$ gocdk resource add dev blob/s3blob < stdin
+gocdk: Adding "blob/s3blob" to "dev"...
+
+Please enter an AWS region.
+  See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html for more information.
+  default: us-west-1
+Enter a value, or "cancel": gocdk:   added a Terraform provider "aws" to "main.tf"
+gocdk:   added an output variable "BLOB_BUCKET_URL" to "outputs.tf"
+gocdk:   added a new file "s3blob.tf"
+gocdk: Success!
+
+$ gocdk resource add dev docstore/awsdynamodb
+gocdk: Adding "docstore/awsdynamodb" to "dev"...
+gocdk:   added an output variable "DOCSTORE_COLLECTION_URL" to "outputs.tf"
+gocdk:   added a new file "awsdynamodb.tf"
+gocdk: Success!
+
+$ gocdk resource add dev docstore/azurecosmos
+gocdk: Adding "docstore/azurecosmos" to "dev"...
+gocdk:   added an output variable "DOCSTORE_COLLECTION_URL" to "outputs.tf"
+gocdk:   added an output variable "MONGO_SERVER_URL" to "outputs.tf"
+gocdk:   added a new file "azurecosmos.tf"
+gocdk: Success!
+
+$ gocdk resource add dev docstore/gcpfirestore
+gocdk: Adding "docstore/gcpfirestore" to "dev"...
+gocdk:   added an output variable "DOCSTORE_COLLECTION_URL" to "outputs.tf"
+gocdk:   added a new file "gcpfirestore.tf"
+gocdk: Success!
+
+$ gocdk resource add dev pubsub/awssnssqs
+gocdk: Adding "pubsub/awssnssqs" to "dev"...
+gocdk:   added an output variable "PUBSUB_SUBSCRIPTION_URL" to "outputs.tf"
+gocdk:   added an output variable "PUBSUB_TOPIC_URL" to "outputs.tf"
+gocdk:   added a new file "awssnssqs.tf"
+gocdk: Success!
+
+$ gocdk resource add dev pubsub/azuresb
+gocdk: Adding "pubsub/azuresb" to "dev"...
+gocdk:   added an output variable "PUBSUB_SUBSCRIPTION_URL" to "outputs.tf"
+gocdk:   added an output variable "PUBSUB_TOPIC_URL" to "outputs.tf"
+gocdk:   added an output variable "SERVICEBUS_CONNECTION_STRING" to "outputs.tf"
+gocdk:   added a new file "azuresb.tf"
+gocdk: Success!
+
+$ gocdk resource add dev pubsub/gcppubsub
+gocdk: Adding "pubsub/gcppubsub" to "dev"...
+gocdk:   added an output variable "PUBSUB_SUBSCRIPTION_URL" to "outputs.tf"
+gocdk:   added an output variable "PUBSUB_TOPIC_URL" to "outputs.tf"
+gocdk:   added a new file "gcppubsub.tf"
+gocdk: Success!
+
+$ gocdk resource add dev runtimevar/awsparamstore
+gocdk: Adding "runtimevar/awsparamstore" to "dev"...
+gocdk:   added an output variable "RUNTIMEVAR_VARIABLE_URL" to "outputs.tf"
+gocdk:   added a new file "awsparamstore.tf"
 gocdk: Success!
 
 $ gocdk resource add dev runtimevar/filevar
@@ -59,13 +145,53 @@ gocdk:   added an output variable "RUNTIMEVAR_VARIABLE_URL" to "outputs.tf"
 gocdk:   added a new file "filevar.tf"
 gocdk: Success!
 
+$ gocdk resource add dev runtimevar/gcpruntimeconfig
+gocdk: Adding "runtimevar/gcpruntimeconfig" to "dev"...
+gocdk:   added an output variable "RUNTIMEVAR_VARIABLE_URL" to "outputs.tf"
+gocdk:   added a new file "gcpruntimeconfig.tf"
+gocdk: Success!
+
+$ gocdk resource add dev secrets/awskms
+gocdk: Adding "secrets/awskms" to "dev"...
+gocdk:   added an output variable "SECRETS_KEEPER_URL" to "outputs.tf"
+gocdk:   added a new file "awskms.tf"
+gocdk: Success!
+
+$ gocdk resource add dev secrets/azurekeyvault
+gocdk: Adding "secrets/azurekeyvault" to "dev"...
+gocdk:   added a Terraform provider "external" to "main.tf"
+gocdk:   added an output variable "SECRETS_KEEPER_URL" to "outputs.tf"
+gocdk:   added an output variable "AZURE_KEYVAULT_AUTH_VIA_CLI" to "outputs.tf"
+gocdk:   added a new file "azurekeyvault.tf"
+gocdk: Success!
+
+$ gocdk resource add dev secrets/gcpkms
+gocdk: Adding "secrets/gcpkms" to "dev"...
+gocdk:   added an output variable "SECRETS_KEEPER_URL" to "outputs.tf"
+gocdk:   added a new file "gcpkms.tf"
+gocdk: Success!
+
 $ cd biomes
 $ ls dev
 dev/
+  awsdynamodb.tf
+  awskms.tf
+  awsparamstore.tf
+  awssnssqs.tf
+  azureblob.tf
+  azurecosmos.tf
+  azurekeyvault.tf
+  azuresb.tf
   biome.json
   fileblob.tf
   filevar.tf
+  gcpfirestore.tf
+  gcpkms.tf
+  gcppubsub.tf
+  gcpruntimeconfig.tf
+  gcsblob.tf
   main.tf
   outputs.tf
+  s3blob.tf
   secrets.auto.tfvars
   variables.tf

--- a/internal/testing/cmdtest/cmdtest.go
+++ b/internal/testing/cmdtest/cmdtest.go
@@ -712,15 +712,24 @@ func cdCmd(args []string) ([]byte, error) {
 
 // echo ARG1 ARG2 ...
 // write args to stdout
+//
+// \n is added at the end of the input.
+// Also, literal "\n" in the input will be replaced by \n.
 func echoCmd(args []string, inputFile string) ([]byte, error) {
 	if inputFile != "" {
 		return nil, fatal{errors.New("input redirection not supported")}
 	}
-	return []byte(strings.Join(args, " ") + "\n"), nil
+	s := strings.Join(args, " ")
+	s = strings.Replace(s, "\\n", "\n", -1)
+	s += "\n"
+	return []byte(s), nil
 }
 
 // echof FILE ARG1 ARG2 ...
 // write args to FILE
+//
+// \n is added at the end of the input.
+// Also, literal "\n" in the input will be replaced by \n.
 func echofCmd(args []string, inputFile string) ([]byte, error) {
 	if len(args) < 1 {
 		return nil, fatal{errors.New("need at least 1 argument")}
@@ -731,7 +740,10 @@ func echofCmd(args []string, inputFile string) ([]byte, error) {
 	if err := checkPath(args[0]); err != nil {
 		return nil, err
 	}
-	return nil, ioutil.WriteFile(args[0], []byte(strings.Join(args[1:], " ")+"\n"), 0600)
+	s := strings.Join(args[1:], " ")
+	s = strings.Replace(s, "\\n", "\n", -1)
+	s += "\n"
+	return nil, ioutil.WriteFile(args[0], []byte(s), 0600)
 }
 
 // cat FILE

--- a/internal/testing/cmdtest/testdata/good-without-output/good-without-output.ct
+++ b/internal/testing/cmdtest/testdata/good-without-output/good-without-output.ct
@@ -8,6 +8,7 @@ $ echo hello world
 $ echo now
 $ echo is
 $ echo the time
+$ echo when\nwe\ndance
 
 # Let's make a directory.
 
@@ -34,4 +35,7 @@ $ echoStdin < bar
 # its redirections.
 
 $ echof bar line three
+$ cat bar
+
+$ echof bar line\nfour
 $ cat bar

--- a/internal/testing/cmdtest/testdata/good/good.ct
+++ b/internal/testing/cmdtest/testdata/good/good.ct
@@ -9,9 +9,13 @@ hello world
 $ echo now
 $ echo is
 $ echo the time
+$ echo when\nwe\ndance
 now
 is
 the time
+when
+we
+dance
 
 # Let's make a directory.
 
@@ -48,3 +52,8 @@ line two
 $ echof bar line three
 $ cat bar
 line three
+
+$ echof bar line\nfour
+$ cat bar
+line
+four


### PR DESCRIPTION
When I created these CLI tests, there was no way to run commands that required input from the user. @jba added support for doing so; thus, this PR is now fleshing out the CLI tests with a bunch of commands that require user input.

I made one change to `internal/testing/cmdtest`, which is to have its `echo` and `echof` commands (which write a string to stdout or to a file) replace a literal `\n` in the input with an actual `\n` character. This allows a test to write a file with contents something like "foo\nbar", which you can use as stdin in order to answer two prompts (the first with `foo`, the second with `bar`.

In a bunch of cases, the file piped to stdin is empty; since `echof` adds a `\n` to the input, this simulates the user hitting Enter once, which works for commands that require input but supply a default.

Note: I also changed the default AWS region to `us-west-1` to match our other defaults.