### PR TITLE
internal/gocdk: reduce duplicate code in "deploy" for generate image refs

### DIFF
--- a/internal/cmd/gocdk/deploy.go
+++ b/internal/cmd/gocdk/deploy.go
@@ -59,11 +59,11 @@ func deploy(ctx context.Context, pctx *processContext, biome, dockerImage string
 
 	// If no image was specified, do a build.
 	if dockerImage == "" {
-		refs, err := build(ctx, pctx, nil)
+		var err error
+		dockerImage, err := build(ctx, pctx, nil)
 		if err != nil {
 			return xerrors.Errorf("gocdk deploy: %w", err)
 		}
-		dockerImage = refs[0]
 		pctx.Logf("Deploying Docker image %q...", dockerImage)
 	}
 


### PR DESCRIPTION
We had more or less the same code to generate a tag in both `build` and `deploy`. This PR changes the `build` function to return the actual tags it uses, so that `deploy` can use them.

I changed the order of the default image refs so that the most specific one (the snapshot tag) would first and be used by `deploy`.