### PR TITLE
internal/gocdk: don't use 'go list' to find the project root dir

### DIFF
--- a/internal/cmd/gocdk/main.go
+++ b/internal/cmd/gocdk/main.go
@@ -163,8 +163,7 @@ func (pctx *processContext) Println(a ...interface{}) {
 // ModuleRoot searches the given directory and those above it for the project
 // root, based on the existence of a "go.mod" file and a "biomes" directory.
 func (pctx *processContext) ModuleRoot(ctx context.Context) (string, error) {
-	var prevDir string
-	for dir := pctx.workdir; ; dir = filepath.Dir(dir) {
+	for dir, prevDir := pctx.workdir, ""; ; dir = filepath.Dir(dir) {
 		if dir == prevDir {
 			return "", xerrors.Errorf("couldn't find a Go CDK project root at or above %s", pctx.workdir)
 		}

--- a/internal/cmd/gocdk/testdata/biome.ct
+++ b/internal/cmd/gocdk/testdata/biome.ct
@@ -1,7 +1,7 @@
 # Add fails when we're not in a module.
 $ gocdk biome add mybiome --> FAIL
 gocdk: Adding biome "mybiome"...
-Error: biome add: couldn't find a Go module root at or above ${ROOTDIR}
+Error: biome add: couldn't find a Go CDK project root at or above ${ROOTDIR}
 
 $ gocdk init myproj
 gocdk: Project created at ${ROOTDIR}/myproj with:

--- a/internal/cmd/gocdk/testdata/build.ct
+++ b/internal/cmd/gocdk/testdata/build.ct
@@ -1,6 +1,6 @@
 # Build fails when we're not in a module.
 $ gocdk build --> FAIL
-Error: gocdk build: couldn't find a Go module root at or above ${ROOTDIR}
+Error: gocdk build: couldn't find a Go CDK project root at or above ${ROOTDIR}
 
 $ gocdk init myproj
 gocdk: Project created at ${ROOTDIR}/myproj with:

--- a/internal/cmd/gocdk/testdata/demo.ct
+++ b/internal/cmd/gocdk/testdata/demo.ct
@@ -7,7 +7,7 @@ secrets
 
 # Add fails when we're not in a module.
 $ gocdk demo add blob --> FAIL
-Error: demo add: couldn't find a Go module root at or above ${ROOTDIR}
+Error: demo add: couldn't find a Go CDK project root at or above ${ROOTDIR}
 
 $ gocdk init myproj
 gocdk: Project created at ${ROOTDIR}/myproj with:

--- a/internal/cmd/gocdk/testdata/deploy.ct
+++ b/internal/cmd/gocdk/testdata/deploy.ct
@@ -1,3 +1,3 @@
 # Deploy fails when we're not in a module.
 $ gocdk deploy dev --> FAIL
-Error: gocdk deploy: couldn't find a Go module root at or above ${ROOTDIR}
+Error: gocdk deploy: couldn't find a Go CDK project root at or above ${ROOTDIR}

--- a/internal/cmd/gocdk/testdata/init.ct
+++ b/internal/cmd/gocdk/testdata/init.ct
@@ -25,6 +25,5 @@ myproj/
     README.md
   Dockerfile
   go.mod
-  go.sum
   main.go
   README.md

--- a/internal/cmd/gocdk/testdata/resource.ct
+++ b/internal/cmd/gocdk/testdata/resource.ct
@@ -19,7 +19,7 @@ secrets/gcpkms
 # Add fails when we're not in a module.
 $ gocdk resource add dev blob/fileblob --> FAIL
 gocdk: Adding "blob/fileblob" to "dev"...
-Error: resource add: couldn't find a Go module root at or above ${ROOTDIR}
+Error: resource add: couldn't find a Go CDK project root at or above ${ROOTDIR}
 
 $ gocdk init myproj
 gocdk: Project created at ${ROOTDIR}/myproj with:

--- a/internal/cmd/gocdk/testdata/serve.ct
+++ b/internal/cmd/gocdk/testdata/serve.ct
@@ -1,6 +1,6 @@
 # Serve fails when we're not in a module.
 $ gocdk serve --> FAIL
-Error: gocdk serve: couldn't find a Go module root at or above ${ROOTDIR}
+Error: gocdk serve: couldn't find a Go CDK project root at or above ${ROOTDIR}
 
 $ gocdk init myproj
 gocdk: Project created at ${ROOTDIR}/myproj with:


### PR DESCRIPTION
Fixes #2544.

Instead of exec'ing `go list` to find the root module, just start at the current directory and look for a `go.mod` file and a `biomes` directory. If not found, move up one.

This reduces the time needed for CLI tests from ~1 minute to ~2 seconds.