### PR TITLE
internal/gocdk: remove explicit wire support from serve

### DIFF
--- a/internal/cmd/gocdk/serve.go
+++ b/internal/cmd/gocdk/serve.go
@@ -249,20 +249,9 @@ loop:
 	return nil
 }
 
-// buildForServe runs Wire and `go build` at moduleRoot to create exePath.
+// buildForServe runs `go build` at moduleRoot to create exePath.
 // Note that on Windows, exePath must end with .EXE.
 func buildForServe(ctx context.Context, pctx *processContext, moduleRoot string, exePath string) error {
-
-	if wireExe, err := exec.LookPath("wire"); err == nil {
-		// TODO(light): Only run Wire if needed, but that requires source analysis.
-		wireCmd := pctx.NewCommand(ctx, moduleRoot, wireExe, "./...")
-		wireCmd.Env = append(wireCmd.Env, "GO111MODULE=on")
-		// TODO(light): Collect build logs into error.
-		if err := wireCmd.Run(); err != nil {
-			return xerrors.Errorf("build server: wire: %w", err)
-		}
-	}
-
 	buildCmd := pctx.NewCommand(ctx, moduleRoot, "go", "build", "-o", exePath)
 	buildCmd.Env = append(buildCmd.Env, "GO111MODULE=on")
 	// TODO(light): Collect build logs into error.

--- a/internal/cmd/gocdk/serve_test.go
+++ b/internal/cmd/gocdk/serve_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestBuildForServe(t *testing.T) {
-	// TODO(light): This test is not hermetic because it brings
-	// in an external module.
 	const content = `package main
 import "fmt"
 func main() { fmt.Println("Hello, World!") }`

--- a/internal/cmd/gocdk/serve_test.go
+++ b/internal/cmd/gocdk/serve_test.go
@@ -24,47 +24,22 @@ import (
 )
 
 func TestBuildForServe(t *testing.T) {
-	t.Run("NoWire", func(t *testing.T) {
-		testBuildForServe(t, map[string]string{
-			"main.go": `package main
+	// TODO(light): This test is not hermetic because it brings
+	// in an external module.
+	const content = `package main
 import "fmt"
-func main() { fmt.Println("Hello, World!") }`,
-		})
-	})
-	t.Run("Wire", func(t *testing.T) {
-		if _, err := exec.LookPath("wire"); err != nil {
-			// Wire tool is run unconditionally. Needed for both tests.
-			t.Skip("wire not found:", err)
-		}
-		// TODO(light): This test is not hermetic because it brings
-		// in an external module.
-		testBuildForServe(t, map[string]string{
-			"main.go": `package main
-import "fmt"
-func main() { fmt.Println(greeting()) }`,
-			"setup.go": `// +build wireinject
+func main() { fmt.Println("Hello, World!") }`
 
-package main
-import "github.com/google/wire"
-func greeting() string {
-	wire.Build(wire.Value("Hello, World!"))
-	return ""
-}`,
-		})
-	})
-}
-
-func testBuildForServe(t *testing.T, files map[string]string) {
 	ctx := context.Background()
 	pctx, cleanup, err := newTestProject(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	for name, content := range files {
-		if err := ioutil.WriteFile(filepath.Join(pctx.workdir, name), []byte(content), 0666); err != nil {
-			t.Fatal(err)
-		}
+
+	// Overwrite main.go with content that just prints something out.
+	if err := ioutil.WriteFile(filepath.Join(pctx.workdir, "main.go"), []byte(content), 0666); err != nil {
+		t.Fatal(err)
 	}
 	exePath := filepath.Join(pctx.workdir, "hello")
 	if runtime.GOOS == "windows" {
@@ -73,7 +48,7 @@ func testBuildForServe(t *testing.T, files map[string]string) {
 
 	// Build program.
 	if err := buildForServe(ctx, pctx, pctx.workdir, exePath); err != nil {
-		t.Error("buildForServe(...):", err)
+		t.Fatal("buildForServe(...):", err)
 	}
 
 	// Run program and check output to ensure correctness.


### PR DESCRIPTION
Fixes #2572.
Fixes #1954.

Don't call `wire` as part of building for "gocdk build".

Rationale: It seems pretty unlikely that Go CDK users will be using `wire`. Even if they do, they will need to make sure to call `wire` before they `gocdk build` or `gocdk deploy`; doing it for them as part of `gocdk serve` isn't necessarily saving much.

Also, IMHO it might be surprising to have generated code being modified on the fly by a background process.