### PR TITLE
internal/gocdk: update Help for the root command

### DIFF
--- a/internal/cmd/gocdk/main.go
+++ b/internal/cmd/gocdk/main.go
@@ -58,9 +58,12 @@ func doit() int {
 
 func run(ctx context.Context, pctx *processContext, args []string) error {
 	var rootCmd = &cobra.Command{
-		Use:   "gocdk",
-		Short: "TODO gocdk",
-		Long:  "TODO more about gocdk",
+		Use: "gocdk",
+		// Short is not used since this is the root command.
+		Long: `gocdk can initialize a new project, add deployment targets (known as "biomes"),
+add demos of Go CDK portable types, provision Cloud resources and use them in the demos,
+build the application into a Docker image, deploy the Docker image to a chosen Cloud provider,
+and serve the application locally with live code reloading.`,
 		// We want to print usage for any command/flag parsing errors, but
 		// suppress usage for random errors returned by a command's RunE.
 		// This function gets called right before RunE, so suppress from now on.

--- a/internal/cmd/gocdk/main.go
+++ b/internal/cmd/gocdk/main.go
@@ -61,7 +61,7 @@ func run(ctx context.Context, pctx *processContext, args []string) error {
 		Use: "gocdk",
 		// Short is not used since this is the root command.
 		Long: `gocdk can initialize a new project, add deployment targets (known as "biomes"),
-add demos of Go CDK portable types, provision Cloud resources and use them in the demos,
+add demos of Go CDK portable types, provision cloud resources and use them in the demos,
 build the application into a Docker image, deploy the Docker image to a chosen Cloud provider,
 and serve the application locally with live code reloading.`,
 		// We want to print usage for any command/flag parsing errors, but

--- a/internal/cmd/gocdk/testdata/help.ct
+++ b/internal/cmd/gocdk/testdata/help.ct
@@ -1,6 +1,6 @@
 $ gocdk
 gocdk can initialize a new project, add deployment targets (known as "biomes"),
-add demos of Go CDK portable types, provision Cloud resources and use them in the demos,
+add demos of Go CDK portable types, provision cloud resources and use them in the demos,
 build the application into a Docker image, deploy the Docker image to a chosen Cloud provider,
 and serve the application locally with live code reloading.
 
@@ -24,7 +24,7 @@ Use "gocdk [command] --help" for more information about a command.
 
 $ gocdk help
 gocdk can initialize a new project, add deployment targets (known as "biomes"),
-add demos of Go CDK portable types, provision Cloud resources and use them in the demos,
+add demos of Go CDK portable types, provision cloud resources and use them in the demos,
 build the application into a Docker image, deploy the Docker image to a chosen Cloud provider,
 and serve the application locally with live code reloading.
 
@@ -48,7 +48,7 @@ Use "gocdk [command] --help" for more information about a command.
 
 $ gocdk --help
 gocdk can initialize a new project, add deployment targets (known as "biomes"),
-add demos of Go CDK portable types, provision Cloud resources and use them in the demos,
+add demos of Go CDK portable types, provision cloud resources and use them in the demos,
 build the application into a Docker image, deploy the Docker image to a chosen Cloud provider,
 and serve the application locally with live code reloading.
 
@@ -72,7 +72,7 @@ Use "gocdk [command] --help" for more information about a command.
 
 $ gocdk -h
 gocdk can initialize a new project, add deployment targets (known as "biomes"),
-add demos of Go CDK portable types, provision Cloud resources and use them in the demos,
+add demos of Go CDK portable types, provision cloud resources and use them in the demos,
 build the application into a Docker image, deploy the Docker image to a chosen Cloud provider,
 and serve the application locally with live code reloading.
 

--- a/internal/cmd/gocdk/testdata/help.ct
+++ b/internal/cmd/gocdk/testdata/help.ct
@@ -1,5 +1,8 @@
 $ gocdk
-TODO more about gocdk
+gocdk can initialize a new project, add deployment targets (known as "biomes"),
+add demos of Go CDK portable types, provision Cloud resources and use them in the demos,
+build the application into a Docker image, deploy the Docker image to a chosen Cloud provider,
+and serve the application locally with live code reloading.
 
 Usage:
   gocdk [command]
@@ -20,7 +23,10 @@ Flags:
 Use "gocdk [command] --help" for more information about a command.
 
 $ gocdk help
-TODO more about gocdk
+gocdk can initialize a new project, add deployment targets (known as "biomes"),
+add demos of Go CDK portable types, provision Cloud resources and use them in the demos,
+build the application into a Docker image, deploy the Docker image to a chosen Cloud provider,
+and serve the application locally with live code reloading.
 
 Usage:
   gocdk [command]
@@ -41,7 +47,10 @@ Flags:
 Use "gocdk [command] --help" for more information about a command.
 
 $ gocdk --help
-TODO more about gocdk
+gocdk can initialize a new project, add deployment targets (known as "biomes"),
+add demos of Go CDK portable types, provision Cloud resources and use them in the demos,
+build the application into a Docker image, deploy the Docker image to a chosen Cloud provider,
+and serve the application locally with live code reloading.
 
 Usage:
   gocdk [command]
@@ -62,7 +71,10 @@ Flags:
 Use "gocdk [command] --help" for more information about a command.
 
 $ gocdk -h
-TODO more about gocdk
+gocdk can initialize a new project, add deployment targets (known as "biomes"),
+add demos of Go CDK portable types, provision Cloud resources and use them in the demos,
+build the application into a Docker image, deploy the Docker image to a chosen Cloud provider,
+and serve the application locally with live code reloading.
 
 Usage:
   gocdk [command]


### PR DESCRIPTION
Fixes #2304.

Last one! This is for the top-level / root command, which is shown for `gocdk` or `gocdk help`.