### PR TITLE
internal/gocdk: capture output from Terraform during "biome apply"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
   include:
     - go: "1.11.x"
       os: linux
-      if: branch = master AND type = push
+      # if: branch = master AND type = push
     - go: "1.12.x"
       os: linux
     - go: "1.12.x"
@@ -57,7 +57,7 @@ jobs:
     - go: "1.12.x"
       os: windows
       # Only run Windows build job on master; it's very slow.
-      if: branch = master AND type = push
+      # if: branch = master AND type = push
       # TODO(rvangent): Remove filter_secrets: false once the Travis issue is fixed:
       # https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264/10
       filter_secrets: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
   include:
     - go: "1.11.x"
       os: linux
-      # if: branch = master AND type = push
+      if: branch = master AND type = push
     - go: "1.12.x"
       os: linux
     - go: "1.12.x"
@@ -57,7 +57,7 @@ jobs:
     - go: "1.12.x"
       os: windows
       # Only run Windows build job on master; it's very slow.
-      # if: branch = master AND type = push
+      if: branch = master AND type = push
       # TODO(rvangent): Remove filter_secrets: false once the Travis issue is fixed:
       # https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264/10
       filter_secrets: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
     - go: "1.12.x"
       os: windows
       # Only run Windows build job on master; it's very slow.
-      if: branch = master AND type = push
+      # if: branch = master AND type = push
       # TODO(rvangent): Remove filter_secrets: false once the Travis issue is fixed:
       # https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264/10
       filter_secrets: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
     - go: "1.12.x"
       os: windows
       # Only run Windows build job on master; it's very slow.
-      # if: branch = master AND type = push
+      if: branch = master AND type = push
       # TODO(rvangent): Remove filter_secrets: false once the Travis issue is fixed:
       # https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264/10
       filter_secrets: false

--- a/internal/cmd/gocdk/biome.go
+++ b/internal/cmd/gocdk/biome.go
@@ -331,10 +331,14 @@ func biomeApply(ctx context.Context, pctx *processContext, biome string, opts *b
 		// Exit code 2 --> there's a diff.
 		// Print out a summary of the changes (unless Verbose).
 		if !opts.Verbose {
-			if idx := bytes.LastIndex(out, []byte("Plan:")); idx == -1 {
-				pctx.Logf("Resources changes are needed; re-run with --verbose for more details.")
-			} else {
-				pctx.Logf(string(out[idx:]))
+			pctx.Logf("Resources changes are needed; re-run with --verbose for more details.")
+			// Best-effort try to print the summary "Plan: " line.
+			if idx := bytes.LastIndex(out, []byte("Plan:")); idx != -1 {
+				// Move to start of that line.
+				for idx >= 0 && out[idx] != '\n' {
+					idx--
+				}
+				pctx.Logf(string(out[idx+1:]))
 			}
 		}
 		// Prompt for approval (unless AutoApprove).

--- a/internal/cmd/gocdk/biome.go
+++ b/internal/cmd/gocdk/biome.go
@@ -321,6 +321,8 @@ func biomeApply(ctx context.Context, pctx *processContext, biome string, opts *b
 	// No error means success and no diffs.
 	// Exit code 1 means the command failed.
 	// Exit code 2 means the command succeeded, but there's a diff.
+	// TODO(rvangent): Go 1.12 added ExitCode (https://godoc.org/os#ProcessState.ExitCode);
+	// use that instead of a string check once support for Go 1.11 is dropped.
 	if out, err := runTerraform(c); err != nil && !strings.Contains(err.Error(), "exit status 2") {
 		// A real failure.
 		writeBufferedTerraformOutput(c, out)

--- a/internal/cmd/gocdk/biome_test.go
+++ b/internal/cmd/gocdk/biome_test.go
@@ -76,14 +76,6 @@ func TestBiomeAdd(t *testing.T) {
 }
 
 func TestBiomeApply(t *testing.T) {
-	// TODO(#1809): test cases
-	// didn't supply biome name to command
-	// named biome doesn't exist
-	// no terraform file
-	// terraform not initialized *
-	// terraform never previously applied
-	// terraform apply repeat
-
 	if _, err := exec.LookPath("terraform"); err != nil {
 		t.Skip("terraform not found:", err)
 	}
@@ -111,17 +103,16 @@ func TestBiomeApply(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Call the main package run function as if 'apply dev' were passed
-	// on the command line. As part of this, ensureTerraformInit is called to check
-	// that terraform has been properly initialized before running 'terraform apply'.
+	// Call the main package run function as if 'biome apply dev' were passed
+	// on the command line.
+	// This should run "terraform init", "terraform plan", and "terraform apply".
 	if err := run(ctx, pctx, []string{"biome", "apply", "dev"}); err != nil {
 		t.Fatalf("run error: %+v", err)
 	}
 
-	// After a successful terraform apply, 'terraform output' should return the greeting
-	// we configured. Terraform output fails if 'terraform init' was not called.
-	// It also fails if 'terraform apply' has never been run, as there will be no
-	// terraform state file (terraform.tfstate).
+	// After a successful "biome apply", "terraform output" should return the greeting
+	// we configured. It will fail if "terraform init" was not called, or if
+	// "terraform apply" wasn't , as there will be no terraform state file (terraform.tfstate).
 	outputs, err := tfReadOutput(ctx, devBiomeDir, os.Environ())
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cmd/gocdk/deploy.go
+++ b/internal/cmd/gocdk/deploy.go
@@ -72,7 +72,7 @@ func deploy(ctx context.Context, pctx *processContext, biome, dockerImage string
 
 	// Run "biome apply".
 	if apply {
-		if err := biomeApply(ctx, pctx, biome, true); err != nil {
+		if err := biomeApply(ctx, pctx, biome, nil); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/gocdk/main_test.go
+++ b/internal/cmd/gocdk/main_test.go
@@ -106,8 +106,17 @@ func TestCLI(t *testing.T) {
 		t.Fatal(err)
 	}
 	goroot := strings.TrimSpace(string(gorootOut))
-	os.Setenv("PATH", fmt.Sprintf("%s/bin", goroot)) // gocdk runs the go command
-	os.Setenv("GO111MODULE", "on")                   // gocdk requires module behavior even when under GOPATH
+	tfPath, err := exec.LookPath("terraform")
+	if err != nil {
+		t.Skip("terraform not found")
+	}
+	paths := []string{
+		os.Getenv("PATH"),
+		filepath.Join(goroot, "bin"), // gocdk runs the go command
+		tfPath,                       // gocdk runs the terraform command
+	}
+	os.Setenv("PATH", strings.Join(paths, string(os.PathListSeparator)))
+	os.Setenv("GO111MODULE", "on") // gocdk requires module behavior even when under GOPATH
 
 	ts, err := cmdtest.Read("testdata")
 	if err != nil {

--- a/internal/cmd/gocdk/serve.go
+++ b/internal/cmd/gocdk/serve.go
@@ -141,7 +141,7 @@ func serveBuildLoop(ctx context.Context, pctx *processContext, logger *log.Logge
 	}()
 
 	// Apply Terraform configuration in biome.
-	if err := biomeApply(ctx, pctx, opts.biome, false); err != nil {
+	if err := biomeApply(ctx, pctx, opts.biome, nil); err != nil {
 		return err
 	}
 

--- a/internal/cmd/gocdk/testdata/biome-apply.ct
+++ b/internal/cmd/gocdk/testdata/biome-apply.ct
@@ -38,7 +38,8 @@ gocdk: Success!
 $ echof stdin notyes
 $ gocdk biome apply dev < stdin --> FAIL
 gocdk: Checking to see if resource updates are needed...
-gocdk: Plan:[0m 1 to add, 0 to change, 0 to destroy.[0m
+gocdk: Resources changes are needed; re-run with --verbose for more details.
+gocdk: [0m[1mPlan:[0m 1 to add, 0 to change, 0 to destroy.[0m
 
 Do you want to perform these actions (only 'yes' will be accepted to approve)?
 Enter a value, or "cancel": Error: cancelled
@@ -47,7 +48,8 @@ Enter a value, or "cancel": Error: cancelled
 $ echof stdin yes
 $ gocdk biome apply dev < stdin
 gocdk: Checking to see if resource updates are needed...
-gocdk: Plan:[0m 1 to add, 0 to change, 0 to destroy.[0m
+gocdk: Resources changes are needed; re-run with --verbose for more details.
+gocdk: [0m[1mPlan:[0m 1 to add, 0 to change, 0 to destroy.[0m
 
 Do you want to perform these actions (only 'yes' will be accepted to approve)?
 Enter a value, or "cancel": gocdk: Success!

--- a/internal/cmd/gocdk/testdata/biome-apply.ct
+++ b/internal/cmd/gocdk/testdata/biome-apply.ct
@@ -1,0 +1,62 @@
+$ gocdk init myproj
+gocdk: Project created at ${ROOTDIR}/myproj with:
+gocdk: - Go HTTP server
+gocdk: - Dockerfile
+gocdk: - 'dev' biome for local development settings
+gocdk: Run `cd myproj`, then run:
+gocdk: - `gocdk serve` to run the server locally with live code reloading
+gocdk: - `gocdk demo` to test new APIs
+gocdk: - `gocdk build` to build a Docker container
+gocdk: - `gocdk biome add` to configure launch settings
+
+$ cd myproj
+
+# Biome name is required.
+$ gocdk biome apply --> FAIL
+Error: accepts 1 arg(s), received 0
+Usage:
+  gocdk biome apply <biome name> [flags]
+
+Flags:
+      --auto-approve   true to auto-approve resource changes
+  -h, --help           help for apply
+      --input          ask for input for Terraform variables if not directly set (default true)
+      --quiet          true to suppress all output from Terraform unless there's an error
+      --verbose        true to print all output from Terraform
+
+# Biome name must exist.
+$ gocdk biome apply notabiome --> FAIL
+Error: biome apply notabiome: biome notabiome not found
+
+$ gocdk resource add dev blob/fileblob
+gocdk: Adding "blob/fileblob" to "dev"...
+gocdk:   added a Terraform provider "local" to "main.tf"
+gocdk:   added an output variable "BLOB_BUCKET_URL" to "outputs.tf"
+gocdk:   added a new file "fileblob.tf"
+gocdk: Success!
+
+# User doesn't approve changes.
+$ echof stdin notyes
+$ gocdk biome apply dev --quiet < stdin --> FAIL
+gocdk: Checking to see if resource updates are needed...
+gocdk: Resources updates are needed.
+gocdk: Not showing update details due to --quiet.
+
+Do you want to perform these actions (only 'yes' will be accepted to approve)?
+Enter a value, or "cancel": Error: cancelled
+
+# User approves changes, they are applied.
+$ echof stdin yes
+$ gocdk biome apply dev --quiet < stdin
+gocdk: Checking to see if resource updates are needed...
+gocdk: Resources updates are needed.
+gocdk: Not showing update details due to --quiet.
+
+Do you want to perform these actions (only 'yes' will be accepted to approve)?
+Enter a value, or "cancel": gocdk: Success!
+
+# Re-running "biome apply" has no changes.
+$ gocdk biome apply dev --quiet
+gocdk: Checking to see if resource updates are needed...
+gocdk: No resources updates are needed.
+gocdk: Success!

--- a/internal/cmd/gocdk/testdata/biome-apply.ct
+++ b/internal/cmd/gocdk/testdata/biome-apply.ct
@@ -21,7 +21,6 @@ Flags:
       --auto-approve   true to auto-approve resource changes
   -h, --help           help for apply
       --input          ask for input for Terraform variables if not directly set (default true)
-      --quiet          true to suppress all output from Terraform unless there's an error
       --verbose        true to print all output from Terraform
 
 # Biome name must exist.
@@ -37,26 +36,24 @@ gocdk: Success!
 
 # User doesn't approve changes.
 $ echof stdin notyes
-$ gocdk biome apply dev --quiet < stdin --> FAIL
+$ gocdk biome apply dev < stdin --> FAIL
 gocdk: Checking to see if resource updates are needed...
-gocdk: Resources updates are needed.
-gocdk: Not showing update details due to --quiet.
+gocdk: Plan:[0m 1 to add, 0 to change, 0 to destroy.[0m
 
 Do you want to perform these actions (only 'yes' will be accepted to approve)?
 Enter a value, or "cancel": Error: cancelled
 
 # User approves changes, they are applied.
 $ echof stdin yes
-$ gocdk biome apply dev --quiet < stdin
+$ gocdk biome apply dev < stdin
 gocdk: Checking to see if resource updates are needed...
-gocdk: Resources updates are needed.
-gocdk: Not showing update details due to --quiet.
+gocdk: Plan:[0m 1 to add, 0 to change, 0 to destroy.[0m
 
 Do you want to perform these actions (only 'yes' will be accepted to approve)?
 Enter a value, or "cancel": gocdk: Success!
 
 # Re-running "biome apply" has no changes.
-$ gocdk biome apply dev --quiet
+$ gocdk biome apply dev
 gocdk: Checking to see if resource updates are needed...
 gocdk: No resources updates are needed.
 gocdk: Success!


### PR DESCRIPTION
Fixes #1821.

Previous to this PR, during "biome apply" we would run `terraform init`, then `terraform apply`, and dump all of the stdout/stderr output from those commands to the terminal. That's a lot of confusing text.

This PR changes "biome apply" to:

* Run "terraform init", then "terraform plan" (which generates a "plan" file with all the needed changes), then "terraform apply" on the generated plan. The result is basically the same as before, but splits the plan + apply into separate steps so that we can prompt for approval in between, and so that we can be more judicious about what to output for the user to see. Terraform won't prompt in `plan`, and also won't prompt in `apply` if you give it an explicit plan.

* Capture the output from each call to `terraform`, and only sometimes emit it to the terminal. When we do emit it, it's surrounded by line separators to try to distinguish it (see example below).
  * We always emit it if there's an error.
  * We always emit proposed changes from `terraform plan` if there are any (unless the user specifies `--quiet`).
  * We always emit output if the user specifies `--verbose`.

* If there are changes, we prompt for approval (unless the user specifies `--auto-approve`).

Sample output (you can see more in the `biome-apply.ct` file, but it uses `--quiet` to avoid Terraform output in the log, since Terraform output differs by OS):

```
$ gocdk biome apply dev
gocdk: Checking to see if resource updates are needed...
gocdk: Resources updates are needed.

#########################################
Output from "terraform plan -detailed-exitcode -out=/usr/local/google/home/rvangent/go/src/foo/biomes/dev/tf.plan -input=true"
#########################################
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

local_file.samplefile: Refreshing state... [id=d3486ae9136e7856bc42212385ea797094475802]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # local_file.samplefile must be replaced
-/+ resource "local_file" "samplefile" {
      ~ content  = "Hello world!" -> "xHello world!" # forces replacement
        filename = "/usr/local/google/home/rvangent/go/src/foo/biomes/dev/fileblob_scratchdir/samplefile.txt"
      ~ id       = "d3486ae9136e7856bc42212385ea797094475802" -> (known after apply)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
#########################################


Do you want to perform these actions (only 'yes' will be accepted to approve)?
Enter a value, or "cancel": yes
gocdk: Success!


$ gocdk biome apply dev
gocdk: Checking to see if resource updates are needed...
gocdk: No resources updates are needed.
gocdk: Success!```