### PR TITLE
internal/cmd/gocdk: pass around biomeApplyOptions by value

### DIFF
--- a/internal/cmd/gocdk/deploy.go
+++ b/internal/cmd/gocdk/deploy.go
@@ -72,7 +72,7 @@ func deploy(ctx context.Context, pctx *processContext, biome, dockerImage string
 
 	// Run "biome apply".
 	if apply {
-		if err := biomeApply(ctx, pctx, biome, nil); err != nil {
+		if err := biomeApply(ctx, pctx, biome, biomeApplyOptions{}); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/gocdk/serve.go
+++ b/internal/cmd/gocdk/serve.go
@@ -141,7 +141,7 @@ func serveBuildLoop(ctx context.Context, pctx *processContext, logger *log.Logge
 	}()
 
 	// Apply Terraform configuration in biome.
-	if err := biomeApply(ctx, pctx, opts.biome, nil); err != nil {
+	if err := biomeApply(ctx, pctx, opts.biome, biomeApplyOptions{}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Eliminates possibility of nil pointer panic when accessing apply options. I also slightly tweaked the fields such that the zero value is the same as the default flags, so that functions that call with the zero options value will provide the same inputs.

Fixes #2607