### PR TITLE
internal/gocdk: add verbose options to serve+deploy

### DIFF
--- a/internal/cmd/gocdk/biome.go
+++ b/internal/cmd/gocdk/biome.go
@@ -88,7 +88,7 @@ Runs "terraform init" followed by "terraform apply".`,
 		},
 	}
 	applyCmd.Flags().BoolVar(&input, "input", true, "ask for input for Terraform variables if not directly set")
-	applyCmd.Flags().BoolVar(&applyOpts.Verbose, "verbose", false, "true to print all output from Terraform")
+	applyCmd.Flags().BoolVarP(&applyOpts.Verbose, "verbose", "v", false, "true to print all output from Terraform")
 	applyCmd.Flags().BoolVar(&applyOpts.AutoApprove, "auto-approve", false, "true to auto-approve resource changes")
 	biomeCmd.AddCommand(applyCmd)
 
@@ -106,7 +106,7 @@ Runs "terraform destroy".`,
 		},
 	}
 	cleanupCmd.Flags().BoolVar(&deleteBiome, "delete", false, "delete the entire biome")
-	cleanupCmd.Flags().BoolVar(&cleanupOpts.Verbose, "verbose", false, "true to print all output from Terraform")
+	cleanupCmd.Flags().BoolVarP(&cleanupOpts.Verbose, "verbose", "v", false, "true to print all output from Terraform")
 	cleanupCmd.Flags().BoolVar(&cleanupOpts.AutoApprove, "auto-approve", false, "true to auto-approve resource changes")
 	biomeCmd.AddCommand(cleanupCmd)
 

--- a/internal/cmd/gocdk/deploy.go
+++ b/internal/cmd/gocdk/deploy.go
@@ -34,6 +34,7 @@ import (
 func registerDeployCmd(ctx context.Context, pctx *processContext, rootCmd *cobra.Command) {
 	var dockerImage string
 	var apply bool
+	var verbose bool
 	deployCmd := &cobra.Command{
 		Use:   "deploy <biome name>",
 		Short: "Deploy the application to the biome's deployment target",
@@ -43,18 +44,19 @@ By default, a new Docker image is built and deployed; use --image to skip the
 build and use an existing tagged image instead.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return deploy(ctx, pctx, args[0], dockerImage, apply)
+			return deploy(ctx, pctx, args[0], dockerImage, apply, verbose)
 		},
 	}
 	deployCmd.Flags().StringVar(&dockerImage, "image", "", "Docker image to deploy in the form `[name][:tag]`; name defaults to image name from Dockerfile, tag defaults to latest; empty string builds a new image")
-	deployCmd.Flags().BoolVar(&apply, "apply", true, "whether to run `biome apply` before deploying")
+	deployCmd.Flags().BoolVar(&apply, "apply", true, "whether to run \"biome apply\" before deploying")
+	deployCmd.Flags().BoolVar(&verbose, "verbose", false, "true to print all output from Terraform during \"biome apply\"")
 	rootCmd.AddCommand(deployCmd)
 }
 
 // deploy implements the "deploy" command.
 //
 // If dockerImage is not provided, it does a build for a generated tag.
-func deploy(ctx context.Context, pctx *processContext, biome, dockerImage string, apply bool) error {
+func deploy(ctx context.Context, pctx *processContext, biome, dockerImage string, apply, verbose bool) error {
 	moduleRoot, err := pctx.ModuleRoot(ctx)
 	if err != nil {
 		return xerrors.Errorf("gocdk deploy: %w", err)
@@ -72,7 +74,7 @@ func deploy(ctx context.Context, pctx *processContext, biome, dockerImage string
 
 	// Run "biome apply".
 	if apply {
-		if err := biomeApply(ctx, pctx, biome, biomeApplyOptions{}); err != nil {
+		if err := biomeApply(ctx, pctx, biome, biomeApplyOptions{Verbose: verbose}); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/gocdk/deploy.go
+++ b/internal/cmd/gocdk/deploy.go
@@ -33,8 +33,7 @@ import (
 
 func registerDeployCmd(ctx context.Context, pctx *processContext, rootCmd *cobra.Command) {
 	var dockerImage string
-	var apply bool
-	var verbose bool
+	var opts deployOptions
 	deployCmd := &cobra.Command{
 		Use:   "deploy <biome name>",
 		Short: "Deploy the application to the biome's deployment target",
@@ -44,19 +43,26 @@ By default, a new Docker image is built and deployed; use --image to skip the
 build and use an existing tagged image instead.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return deploy(ctx, pctx, args[0], dockerImage, apply, verbose)
+			return deploy(ctx, pctx, args[0], dockerImage, opts)
 		},
 	}
 	deployCmd.Flags().StringVar(&dockerImage, "image", "", "Docker image to deploy in the form `[name][:tag]`; name defaults to image name from Dockerfile, tag defaults to latest; empty string builds a new image")
-	deployCmd.Flags().BoolVar(&apply, "apply", true, "whether to run \"biome apply\" before deploying")
-	deployCmd.Flags().BoolVar(&verbose, "verbose", false, "true to print all output from Terraform during \"biome apply\"")
+	deployCmd.Flags().BoolVar(&opts.Apply, "apply", true, "whether to run \"biome apply\" before deploying")
+	deployCmd.Flags().BoolVarP(&opts.ApplyOpts.Verbose, "verbose", "v", false, "true to print all output from Terraform during \"biome apply\"")
 	rootCmd.AddCommand(deployCmd)
+}
+
+type deployOptions struct {
+	// Apply determines whether "biome apply" is run before the deploy.
+	Apply bool
+	// ApplyOpts holds options for "biome apply" if Apply is true.
+	ApplyOpts biomeApplyOptions
 }
 
 // deploy implements the "deploy" command.
 //
 // If dockerImage is not provided, it does a build for a generated tag.
-func deploy(ctx context.Context, pctx *processContext, biome, dockerImage string, apply, verbose bool) error {
+func deploy(ctx context.Context, pctx *processContext, biome, dockerImage string, opts deployOptions) error {
 	moduleRoot, err := pctx.ModuleRoot(ctx)
 	if err != nil {
 		return xerrors.Errorf("gocdk deploy: %w", err)
@@ -73,8 +79,8 @@ func deploy(ctx context.Context, pctx *processContext, biome, dockerImage string
 	}
 
 	// Run "biome apply".
-	if apply {
-		if err := biomeApply(ctx, pctx, biome, biomeApplyOptions{Verbose: verbose}); err != nil {
+	if opts.Apply {
+		if err := biomeApply(ctx, pctx, biome, opts.ApplyOpts); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/gocdk/serve.go
+++ b/internal/cmd/gocdk/serve.go
@@ -51,6 +51,7 @@ The application will reload any time it detects a change under your project.`,
 		},
 	}
 	serveCmd.Flags().StringVar(&opts.address, "address", "localhost:8080", "`host:port` address to serve on")
+	serveCmd.Flags().BoolVar(&opts.verbose, "verbose", false, "true to print all output from Terraform")
 	serveCmd.Flags().StringVar(&opts.biome, "biome", "dev", "`name` of biome to apply and use configuration from")
 	serveCmd.Flags().DurationVar(&opts.pollInterval, "poll-interval", 500*time.Millisecond, "time between checking project directory for changes")
 	rootCmd.AddCommand(serveCmd)
@@ -106,6 +107,7 @@ type serveOptions struct {
 	biome        string
 	address      string
 	pollInterval time.Duration
+	verbose      bool
 
 	// actualAddress is the local address that the reverse proxy is
 	// listening on.
@@ -141,7 +143,7 @@ func serveBuildLoop(ctx context.Context, pctx *processContext, logger *log.Logge
 	}()
 
 	// Apply Terraform configuration in biome.
-	if err := biomeApply(ctx, pctx, opts.biome, biomeApplyOptions{}); err != nil {
+	if err := biomeApply(ctx, pctx, opts.biome, biomeApplyOptions{Verbose: opts.verbose}); err != nil {
 		return err
 	}
 

--- a/internal/cmd/gocdk/serve.go
+++ b/internal/cmd/gocdk/serve.go
@@ -51,7 +51,7 @@ The application will reload any time it detects a change under your project.`,
 		},
 	}
 	serveCmd.Flags().StringVar(&opts.address, "address", "localhost:8080", "`host:port` address to serve on")
-	serveCmd.Flags().BoolVar(&opts.verbose, "verbose", false, "true to print all output from Terraform")
+	serveCmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "true to print all output from Terraform")
 	serveCmd.Flags().StringVar(&opts.biome, "biome", "dev", "`name` of biome to apply and use configuration from")
 	serveCmd.Flags().DurationVar(&opts.pollInterval, "poll-interval", 500*time.Millisecond, "time between checking project directory for changes")
 	rootCmd.AddCommand(serveCmd)

--- a/internal/cmd/gocdk/testdata/biome-apply.ct
+++ b/internal/cmd/gocdk/testdata/biome-apply.ct
@@ -21,7 +21,7 @@ Flags:
       --auto-approve   true to auto-approve resource changes
   -h, --help           help for apply
       --input          ask for input for Terraform variables if not directly set (default true)
-      --verbose        true to print all output from Terraform
+  -v, --verbose        true to print all output from Terraform
 
 # Biome name must exist.
 $ gocdk biome apply notabiome --> FAIL

--- a/internal/cmd/gocdk/testdata/biome-cleanup.ct
+++ b/internal/cmd/gocdk/testdata/biome-cleanup.ct
@@ -21,7 +21,7 @@ Flags:
       --auto-approve   true to auto-approve resource changes
       --delete         delete the entire biome
   -h, --help           help for cleanup
-      --verbose        true to print all output from Terraform
+  -v, --verbose        true to print all output from Terraform
 
 # Biome name must exist.
 $ gocdk biome cleanup notabiome --> FAIL

--- a/internal/cmd/gocdk/testdata/deploy-help.ct
+++ b/internal/cmd/gocdk/testdata/deploy-help.ct
@@ -8,9 +8,10 @@ Usage:
   gocdk deploy <biome name> [flags]
 
 Flags:
-      --apply biome apply    whether to run biome apply before deploying (default true)
+      --apply                whether to run "biome apply" before deploying (default true)
   -h, --help                 help for deploy
       --image [name][:tag]   Docker image to deploy in the form [name][:tag]; name defaults to image name from Dockerfile, tag defaults to latest; empty string builds a new image
+      --verbose              true to print all output from Terraform during "biome apply"
 
 $ gocdk deploy -h
 Deploy the application to the biome's configured deployment target.
@@ -22,9 +23,10 @@ Usage:
   gocdk deploy <biome name> [flags]
 
 Flags:
-      --apply biome apply    whether to run biome apply before deploying (default true)
+      --apply                whether to run "biome apply" before deploying (default true)
   -h, --help                 help for deploy
       --image [name][:tag]   Docker image to deploy in the form [name][:tag]; name defaults to image name from Dockerfile, tag defaults to latest; empty string builds a new image
+      --verbose              true to print all output from Terraform during "biome apply"
 
 $ gocdk deploy --help
 Deploy the application to the biome's configured deployment target.
@@ -36,6 +38,7 @@ Usage:
   gocdk deploy <biome name> [flags]
 
 Flags:
-      --apply biome apply    whether to run biome apply before deploying (default true)
+      --apply                whether to run "biome apply" before deploying (default true)
   -h, --help                 help for deploy
       --image [name][:tag]   Docker image to deploy in the form [name][:tag]; name defaults to image name from Dockerfile, tag defaults to latest; empty string builds a new image
+      --verbose              true to print all output from Terraform during "biome apply"

--- a/internal/cmd/gocdk/testdata/deploy-help.ct
+++ b/internal/cmd/gocdk/testdata/deploy-help.ct
@@ -11,7 +11,7 @@ Flags:
       --apply                whether to run "biome apply" before deploying (default true)
   -h, --help                 help for deploy
       --image [name][:tag]   Docker image to deploy in the form [name][:tag]; name defaults to image name from Dockerfile, tag defaults to latest; empty string builds a new image
-      --verbose              true to print all output from Terraform during "biome apply"
+  -v, --verbose              true to print all output from Terraform during "biome apply"
 
 $ gocdk deploy -h
 Deploy the application to the biome's configured deployment target.
@@ -26,7 +26,7 @@ Flags:
       --apply                whether to run "biome apply" before deploying (default true)
   -h, --help                 help for deploy
       --image [name][:tag]   Docker image to deploy in the form [name][:tag]; name defaults to image name from Dockerfile, tag defaults to latest; empty string builds a new image
-      --verbose              true to print all output from Terraform during "biome apply"
+  -v, --verbose              true to print all output from Terraform during "biome apply"
 
 $ gocdk deploy --help
 Deploy the application to the biome's configured deployment target.
@@ -41,4 +41,4 @@ Flags:
       --apply                whether to run "biome apply" before deploying (default true)
   -h, --help                 help for deploy
       --image [name][:tag]   Docker image to deploy in the form [name][:tag]; name defaults to image name from Dockerfile, tag defaults to latest; empty string builds a new image
-      --verbose              true to print all output from Terraform during "biome apply"
+  -v, --verbose              true to print all output from Terraform during "biome apply"

--- a/internal/cmd/gocdk/testdata/serve-help.ct
+++ b/internal/cmd/gocdk/testdata/serve-help.ct
@@ -11,7 +11,7 @@ Flags:
       --biome name               name of biome to apply and use configuration from (default "dev")
   -h, --help                     help for serve
       --poll-interval duration   time between checking project directory for changes (default 500ms)
-      --verbose                  true to print all output from Terraform
+  -v, --verbose                  true to print all output from Terraform
 
 $ gocdk serve -h
 Run an auto-reloading local server.
@@ -26,7 +26,7 @@ Flags:
       --biome name               name of biome to apply and use configuration from (default "dev")
   -h, --help                     help for serve
       --poll-interval duration   time between checking project directory for changes (default 500ms)
-      --verbose                  true to print all output from Terraform
+  -v, --verbose                  true to print all output from Terraform
 
 $ gocdk serve --help
 Run an auto-reloading local server.
@@ -41,4 +41,4 @@ Flags:
       --biome name               name of biome to apply and use configuration from (default "dev")
   -h, --help                     help for serve
       --poll-interval duration   time between checking project directory for changes (default 500ms)
-      --verbose                  true to print all output from Terraform
+  -v, --verbose                  true to print all output from Terraform

--- a/internal/cmd/gocdk/testdata/serve-help.ct
+++ b/internal/cmd/gocdk/testdata/serve-help.ct
@@ -11,6 +11,7 @@ Flags:
       --biome name               name of biome to apply and use configuration from (default "dev")
   -h, --help                     help for serve
       --poll-interval duration   time between checking project directory for changes (default 500ms)
+      --verbose                  true to print all output from Terraform
 
 $ gocdk serve -h
 Run an auto-reloading local server.
@@ -25,6 +26,7 @@ Flags:
       --biome name               name of biome to apply and use configuration from (default "dev")
   -h, --help                     help for serve
       --poll-interval duration   time between checking project directory for changes (default 500ms)
+      --verbose                  true to print all output from Terraform
 
 $ gocdk serve --help
 Run an auto-reloading local server.
@@ -39,3 +41,4 @@ Flags:
       --biome name               name of biome to apply and use configuration from (default "dev")
   -h, --help                     help for serve
       --poll-interval duration   time between checking project directory for changes (default 500ms)
+      --verbose                  true to print all output from Terraform


### PR DESCRIPTION
This is needed because both `serve` and `deploy` can call `biome apply`, which normally hides the Terraform output if there are changes and says "re-run with --verbose to see details" or something like that.