### PR TITLE
internal/cmd/gocdk: fix crash on deploying newly built image

### DIFF
--- a/internal/cmd/gocdk/deploy.go
+++ b/internal/cmd/gocdk/deploy.go
@@ -63,7 +63,7 @@ func deploy(ctx context.Context, pctx *processContext, biome, dockerImage string
 	// If no image was specified, do a build.
 	if dockerImage == "" {
 		var err error
-		dockerImage, err := build(ctx, pctx, nil)
+		dockerImage, err = build(ctx, pctx, nil)
 		if err != nil {
 			return xerrors.Errorf("gocdk deploy: %w", err)
 		}


### PR DESCRIPTION
A shadowed variable caused the build to occur, but the image reference to be ignored by the rest of the deploy process. The error would look like:

```
Error: gocdk deploy: cloud run launch: docker tag: docker push: Error parsing reference: "" is not a valid repository/tag: invalid reference format
```

@vangent for review