### PR TITLE
internal/website/howto: improve and make consistent description of auth for GCP and AWS

### DIFF
--- a/internal/website/content/howto/blob/_index.md
+++ b/internal/website/content/howto/blob/_index.md
@@ -180,7 +180,7 @@ other API that takes in a `*gcp.HTTPClient`.) You can find functions in the
 
 ### S3 {#s3}
 
-S3 URLs in the Go CDK closely resemble the URLs you would see in the AWS CLI.
+S3 URLs in the Go CDK closely resemble the URLs you would see in the [AWS CLI][].
 You should specify the `region` query parameter to ensure your application
 connects to the correct region.
 
@@ -189,6 +189,7 @@ connects to the correct region.
 it will use those credentials. See [AWS Session][] to learn about authentication
 alternatives, including using environment variables.
 
+[AWS CLI]: https://aws.amazon.com/cli/
 [AWS Session]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
 
 {{< goexample "gocloud.dev/blob/s3blob.Example_openBucketFromURL" >}}

--- a/internal/website/content/howto/blob/_index.md
+++ b/internal/website/content/howto/blob/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Blob"
 date: 2019-07-09T16:46:29-07:00
+lastmod: 2019-07-29T12:00:00-07:00
 showInSidenav: true
 toc: true
 ---
@@ -107,15 +108,24 @@ Other operations like listing and reading metadata are documented in the
 ### Google Cloud Storage {#gcs}
 
 [Google Cloud Storage][] (GCS) URLs in the Go CDK closely resemble the URLs
-you would see in the `gsutil` CLI. `blob.OpenBucket` will use [Application
-Default Credentials][GCP creds].
+you would see in the [`gsutil`][] CLI.
+
+[Google Cloud Storage]: https://cloud.google.com/storage/
+[`gsutil`]: https://cloud.google.com/storage/docs/gsutil
+
+`blob.OpenBucket` will use Application Default Credentials; if you have
+authenticated via [`gcloud auth login`][], it will use those credentials. See
+[Application Default Credentials][GCP creds] to learn about authentication
+alternatives, including using environment variables.
+
+[GCP creds]: https://cloud.google.com/docs/authentication/production
+[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
 
 {{< goexample "gocloud.dev/blob/gcsblob.Example_openBucketFromURL" >}}
 
 Full details about acceptable URLs can be found under the API reference for
 [`gcsblob.URLOpener`][].
 
-[Google Cloud Storage]: https://cloud.google.com/storage/
 [`gcsblob.URLOpener`]: https://godoc.org/gocloud.dev/blob/gcsblob#URLOpener
 
 #### GCS Constructor {#gcs-ctor}
@@ -128,16 +138,21 @@ other API that takes in a `*gcp.HTTPClient`.) You can find functions in the
 
 {{< goexample "gocloud.dev/blob/gcsblob.ExampleOpenBucket" >}}
 
-[GCP creds]: https://cloud.google.com/docs/authentication/production
 [`gcsblob.OpenBucket`]: https://godoc.org/gocloud.dev/blob/gcsblob#OpenBucket
 [`gocloud.dev/gcp`]: https://godoc.org/gocloud.dev/gcp
 
 ### S3 {#s3}
 
 S3 URLs in the Go CDK closely resemble the URLs you would see in the AWS CLI.
-You can specify the `region` query parameter to ensure your application connects
-to the correct region, but otherwise `blob.OpenBucket` will use the region found
-in the environment variables or your AWS CLI configuration.
+You should specify the `region` query parameter to ensure your application
+connects to the correct region.
+
+`blob.OpenBucket` will create a default AWS Session with the
+`SharedConfigEnable` option enabled; if you have authenticated with the AWS CLI,
+it will use those credentials. See [AWS Session][] to learn about authentication
+alternatives, including using environment variables.
+
+[AWS Session]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
 
 {{< goexample "gocloud.dev/blob/s3blob.Example_openBucketFromURL" >}}
 

--- a/internal/website/content/howto/docstore/_index.md
+++ b/internal/website/content/howto/docstore/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Docstore"
 date: 2019-06-08T15:11:57-04:00
-lastmod: 2019-07-11T21:03:45-07:00
+lastmod: 2019-07-29T12:00:00-07:00
 draft: true
 showInSidenav: true
 toc: true
@@ -221,6 +221,14 @@ function to extract the name from a document.
 Firestore URLs provide the project and collection, as well as the field that
 holds the document name.
 
+`docstore.OpenCollection` will use Application Default Credentials; if you have
+authenticated via [`gcloud auth login`][], it will use those credentials. See
+[Application Default Credentials][GCP creds] to learn about authentication
+alternatives, including using environment variables.
+
+[GCP creds]: https://cloud.google.com/docs/authentication/production
+[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
+
 {{< goexample
 "gocloud.dev/docstore/gcpfirestore.Example_openCollectionFromURL" >}}
 
@@ -261,6 +269,13 @@ collection corresponds to a DynamoDB table.
 
 DynamoDB URLs provide the table, partition key field and optionally the sort key
 field for the collection.
+
+`docstore.OpenCollection` will create a default AWS Session with the
+`SharedConfigEnable` option enabled; if you have authenticated with the AWS CLI,
+it will use those credentials. See [AWS Session][] to learn about authentication
+alternatives, including using environment variables.
+
+[AWS Session]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
 
 {{< goexample
 "gocloud.dev/docstore/awsdynamodb.Example_openCollectionFromURL" >}}

--- a/internal/website/content/howto/pubsub/publish.md
+++ b/internal/website/content/howto/pubsub/publish.md
@@ -1,6 +1,7 @@
 ---
 title: "Publish Messages to a Topic"
 date: 2019-03-26T09:44:15-07:00
+lastmod: 2019-07-29T12:00:00-07:00
 weight: 1
 toc: true
 ---
@@ -46,13 +47,19 @@ Note that the [semantics of message delivery][] can vary by backing service.
 ### Google Cloud Pub/Sub {#gcp}
 
 The Go CDK can publish to a Google [Cloud Pub/Sub][] topic. The URLs use the
-project ID and the topic ID. `pubsub.OpenTopic` will use [Application Default
-Credentials][GCP creds].
-
-{{< goexample "gocloud.dev/pubsub/gcppubsub.Example_openTopicFromURL" >}}
+project ID and the topic ID.
 
 [Cloud Pub/Sub]: https://cloud.google.com/pubsub/docs/
+
+`pubsub.OpenTopic` will use Application Default Credentials; if you have
+authenticated via [`gcloud auth login`][], it will use those credentials. See
+[Application Default Credentials][GCP creds] to learn about authentication
+alternatives, including using environment variables.
+
 [GCP creds]: https://cloud.google.com/docs/authentication/production
+[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
+
+{{< goexample "gocloud.dev/pubsub/gcppubsub.Example_openTopicFromURL" >}}
 
 #### Google Cloud Pub/Sub Constructor {#gcp-ctor}
 
@@ -69,10 +76,17 @@ topics.)
 
 The Go CDK can publish to an Amazon [Simple Notification Service][SNS] (SNS)
 topic. SNS URLs in the Go CDK use the Amazon Resource Name (ARN) to identify
-the topic. You can specify the `region` query parameter to ensure your
-application connects to the correct region, but otherwise `pubsub.OpenTopic`
-will use the region found in the environment variables or your AWS CLI
-configuration.
+the topic. You should specify the `region` query parameter to ensure your
+application connects to the correct region.
+
+[SNS]: https://aws.amazon.com/sns/
+
+`pubsub.OpenTopic` will create a default AWS Session with the
+`SharedConfigEnable` option enabled; if you have authenticated with the AWS CLI,
+it will use those credentials. See [AWS Session][] to learn about authentication
+alternatives, including using environment variables.
+
+[AWS Session]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
 
 {{< goexample "gocloud.dev/pubsub/awssnssqs.Example_openSNSTopicFromURL" >}}
 
@@ -86,7 +100,6 @@ you may need to manually Base64 decode the message payload.
 
 [Base64]: https://en.wikipedia.org/wiki/Base64
 [SQS Subscribe]: {{< relref "./subscribe.md#sqs" >}}
-[SNS]: https://aws.amazon.com/sns/
 
 #### Amazon SNS Constructor {#sns-ctor}
 

--- a/internal/website/content/howto/pubsub/subscribe.md
+++ b/internal/website/content/howto/pubsub/subscribe.md
@@ -1,6 +1,7 @@
 ---
 title: "Subscribe to Messages from a Topic"
 date: 2019-03-26T09:44:33-07:00
+lastmod: 2019-07-29T12:00:00-07:00
 weight: 2
 toc: true
 ---
@@ -57,12 +58,18 @@ Note that the [semantics of message delivery][] can vary by backing service.
 
 The Go CDK can receive messages from a Google [Cloud Pub/Sub][] subscription.
 The URLs use the project ID and the subscription ID.
-`pubsub.OpenSubscription` will use [Application Default Credentials][GCP creds].
-
-{{< goexample "gocloud.dev/pubsub/gcppubsub.Example_openSubscriptionFromURL" >}}
 
 [Cloud Pub/Sub]: https://cloud.google.com/pubsub/docs/
+
+`pubsub.OpenSubscription` will use Application Default Credentials; if you have
+authenticated via [`gcloud auth login`][], it will use those credentials. See
+[Application Default Credentials][GCP creds] to learn about authentication
+alternatives, including using environment variables.
+
 [GCP creds]: https://cloud.google.com/docs/authentication/production
+[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
+
+{{< goexample "gocloud.dev/pubsub/gcppubsub.Example_openSubscriptionFromURL" >}}
 
 #### Google Cloud Pub/Sub Constructor {#gcp-ctor}
 
@@ -79,10 +86,17 @@ reused among subscriptions.)
 
 The Go CDK can subscribe to an Amazon [Simple Queueing Service][SQS] (SQS)
 topic. SQS URLs closely resemble the the queue URL, except the leading
-`https://` is replaced with `awssqs://`. You can specify the `region`
-query parameter to ensure your application connects to the correct region, but
-otherwise `pubsub.OpenSubscription` will use the region found in the environment
-variables or your AWS CLI configuration.
+`https://` is replaced with `awssqs://`. You should specify the `region`
+query parameter to ensure your application connects to the correct region.
+
+[SQS]: https://aws.amazon.com/sqs/
+
+`pubsub.OpenSubscription` will create a default AWS Session with the
+`SharedConfigEnable` option enabled; if you have authenticated with the AWS CLI,
+it will use those credentials. See [AWS Session][] to learn about authentication
+alternatives, including using environment variables.
+
+[AWS Session]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
 
 {{< goexample "gocloud.dev/pubsub/awssnssqs.Example_openSubscriptionFromURL" >}}
 
@@ -100,7 +114,6 @@ or the [SQS publshing guide][] for more details.
 [SNS publishing guide]: {{< ref "./publish.md#sns" >}}
 [SQS publishing guide]: {{< ref "./publish.md#sqs" >}}
 [SNS JSON]: https://aws.amazon.com/sns/faqs/#Raw_message_delivery
-[SQS]: https://aws.amazon.com/sqs/
 
 #### Amazon SQS Constructor {#sqs-ctor}
 

--- a/internal/website/content/howto/runtimevar/_index.md
+++ b/internal/website/content/howto/runtimevar/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Runtime Configuration"
 date: 2019-07-11T12:00:00-07:00
+lastmod: 2019-07-29T12:00:00-07:00
 showInSidenav: true
 toc: true
 ---
@@ -71,9 +72,17 @@ recommend starting with `Latest` as it's conceptually simpler to work with.
 ### GCP Runtime Configurator {#gcprc}
 
 To open a variable stored in [GCP Runtime Configurator][] via a URL, you can use
-the `runtimevar.OpenVariable` function as follows.
+the `runtimevar.OpenVariable` function as shown in the example below.
 
 [GCP Runtime Configurator]: https://cloud.google.com/deployment-manager/runtime-configurator/
+
+`runtimevar.OpenVariable` will use Application Default Credentials; if you have
+authenticated via [`gcloud auth login`][], it will use those credentials. See
+[Application Default Credentials][GCP creds] to learn about authentication
+alternatives, including using environment variables.
+
+[GCP creds]: https://cloud.google.com/docs/authentication/production
+[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
 
 {{< goexample
 "gocloud.dev/runtimevar/gcpruntimeconfig.Example_openVariableFromURL" >}}
@@ -90,13 +99,20 @@ variable.
 ### AWS Parameter Store {#awsps}
 
 To open a variable stored in [AWS Parameter Store][] via a URL, you can use the
-`runtimevar.OpenVariable` function as follows.
-
-{{< goexample
-"gocloud.dev/runtimevar/awsparamstore.Example_openVariableFromURL" >}}
+`runtimevar.OpenVariable` function as shown in the example below.
 
 [AWS Parameter Store]:
 https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html
+
+`runtimevar.OpenVariable` will create a default AWS Session with the
+`SharedConfigEnable` option enabled; if you have authenticated with the AWS CLI,
+it will use those credentials. See [AWS Session][] to learn about authentication
+alternatives, including using environment variables.
+
+[AWS Session]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
+
+{{< goexample
+"gocloud.dev/runtimevar/awsparamstore.Example_openVariableFromURL" >}}
 
 #### AWS Constructor {#awsps-ctor}
 

--- a/internal/website/content/howto/secrets/_index.md
+++ b/internal/website/content/howto/secrets/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Secrets"
 date: 2019-03-21T17:42:18-07:00
+lastmod: 2019-07-29T12:00:00-07:00
 showInSidenav: true
 toc: true
 ---
@@ -115,23 +116,29 @@ runtime configuration.
 ### Google Cloud Key Management Service {#gcp}
 
 The Go CDK can use keys from Google Cloud Platform's [Key Management
-Service][GCP KMS] (GCP KMS) to keep information secret. `secrets.OpenKeeper`
-will use [Application Default Credentials][GCP credentials]. GCP KMS URLs are
-similar to [key resource IDs][]:
-
-{{< goexample "gocloud.dev/secrets/gcpkms.Example_openFromURL" >}}
+Service][GCP KMS] (GCP KMS) to keep information secret. GCP KMS URLs are
+similar to [key resource IDs][].
 
 [GCP KMS]: https://cloud.google.com/kms/
 [key resource IDs]: https://cloud.google.com/kms/docs/object-hierarchy#key
 
+`secrets.OpenKeeper` will use Application Default Credentials; if you have
+authenticated via [`gcloud auth login`][], it will use those credentials. See
+[Application Default Credentials][GCP creds] to learn about authentication
+alternatives, including using environment variables.
+
+[GCP creds]: https://cloud.google.com/docs/authentication/production
+[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
+
+{{< goexample "gocloud.dev/secrets/gcpkms.Example_openFromURL" >}}
+
 #### GCP Constructor {#gcp-ctor}
 
 The [`gcpkms.OpenKeeper`][] constructor opens a GCP KMS key. You must first
-obtain [GCP credentials][] and then create a gRPC connection to GCP KMS.
+obtain [GCP credentials][GCP creds] and then create a gRPC connection to GCP KMS.
 
 {{< goexample "gocloud.dev/secrets/gcpkms.ExampleOpenKeeper" >}}
 
-[GCP credentials]: https://cloud.google.com/docs/authentication/production
 [`gcpkms.OpenKeeper`]: https://godoc.org/gocloud.dev/secrets/gcpkms#OpenKeeper
 
 ### AWS Key Management Service {#aws}
@@ -139,14 +146,19 @@ obtain [GCP credentials][] and then create a gRPC connection to GCP KMS.
 The Go CDK can use customer master keys from Amazon Web Service's [Key
 Management Service][AWS KMS] (AWS KMS) to keep information secret. AWS KMS
 URLs can use the key's ID, alias, or Amazon Resource Name (ARN) to identify
-the key. You can specify the `region` query parameter to ensure your
-application connects to the correct region, but otherwise
-`secrets.OpenKeeper` will use the region found in the environment variable
-`AWS_REGION` or your AWS CLI configuration.
-
-{{< goexample "gocloud.dev/secrets/awskms.Example_openFromURL" >}}
+the key. You should specify the `region` query parameter to ensure your
+application connects to the correct region.
 
 [AWS KMS]: https://aws.amazon.com/kms/
+
+`secrets.OpenKeeper` will create a default AWS Session with the
+`SharedConfigEnable` option enabled; if you have authenticated with the AWS CLI,
+it will use those credentials. See [AWS Session][] to learn about authentication
+alternatives, including using environment variables.
+
+[AWS Session]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
+
+{{< goexample "gocloud.dev/secrets/awskms.Example_openFromURL" >}}
 
 #### AWS Constructor {#aws-ctor}
 


### PR DESCRIPTION
We were incomplete and inconsistent about our descriptions of how URLOpeners authenticate to GCP and AWS.