### PR TITLE
docstore/godoc: Move service references from package to driver godoc.

### DIFF
--- a/docstore/awsdynamodb/dynamo.go
+++ b/docstore/awsdynamodb/dynamo.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package awsdynamodb provides a docstore implementation backed by AWS
+// Package awsdynamodb provides a docstore implementation backed by Amazon
 // DynamoDB.
 // Use OpenCollection to construct a *docstore.Collection.
 //

--- a/docstore/doc.go
+++ b/docstore/doc.go
@@ -17,11 +17,9 @@
 // documents. Like other NoSQL databases, document stores are schemaless.
 // See https://en.wikipedia.org/wiki/Document-oriented_database for more information.
 //
-// Subpackages contain distinct implementations ("drivers") of docstore for public
-// cloud services like Google Cloud Firestore and Amazon DynamoDB as well as any MongoDB
-// or MongoDB-compatible service hosted by a cloud provider or on-premise. For example, you can
-// use Azure Cosmos DB and Amazon DocumentDB via the MongoDB driver. There is also
-// memdocstore, an in-process, in-memory implementation suitable for testing and
+// Subpackages contain distinct implementations ("drivers") of docstore for
+// various backing services, including Cloud and on-premise solutions. For example,
+// memdocstore supports an in-process, in-memory implementation suitable for testing and
 // development.
 //
 // In docstore, documents are grouped into collections, and each document has a key

--- a/docstore/gcpfirestore/fs.go
+++ b/docstore/gcpfirestore/fs.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package gcpfirestore provides a docstore implementation backed by GCP
+// Package gcpfirestore provides a docstore implementation backed by Google Cloud
 // Firestore.
 // Use OpenCollection to construct a *docstore.Collection.
 //

--- a/docstore/mongodocstore/mongo.go
+++ b/docstore/mongodocstore/mongo.go
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package mongodocstore provides an implementation of the docstore API for MongoDB.
+// Package mongodocstore provides a docstore implementation for MongoDB
+// and MongoDB-compatible services hosted on-premise or by cloud providers,
+// including Amazon DocumentDB and Azure Cosmos DB.
 //
 //
 // URLs


### PR DESCRIPTION
This makes the introduction more consistent with other APIs as we reshuffle the content between godoc and how-tos.