### PR TITLE
blob/docs: Migrate content from godoc to how-to.

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -16,7 +16,7 @@
 // within a storage location. Subpackages contain driver implementations of
 // blob for supported services.
 //
-// See https://gocloud.dev/howto/blob/ for detailed how-to guides.
+// See https://gocloud.dev/howto/blob/ for a detailed how-to guide.
 //
 //
 // Errors
@@ -453,7 +453,7 @@ var (
 		})
 )
 
-// NewBucket is intended for use by drivers.
+// NewBucket is intended for use by drivers only. Do not use in application code.
 var NewBucket = newBucket
 
 // newBucket creates a new *Bucket based on a specific driver implementation.

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -13,34 +13,10 @@
 // limitations under the License.
 
 // Package blob provides an easy and portable way to interact with blobs
-// within a storage location, hereafter called a "bucket". See
-// https://gocloud.dev/howto/blob/ for how-to guides.
+// within a storage location. Subpackages contain driver implementations of
+// blob for supported services.
 //
-// It supports operations like reading and writing blobs (using standard
-// interfaces from the io package), deleting blobs, and listing blobs in a
-// bucket.
-//
-// Subpackages contain distinct implementations of blob for various services,
-// including Cloud and on-prem solutions. For example, "fileblob" supports
-// blobs backed by a filesystem. Your application should import one of these
-// driver subpackages and use its exported function(s) to create a
-// *Bucket; do not use the NewBucket function in this package. For example:
-//
-//  bucket, err := fileblob.OpenBucket("path/to/dir", nil)
-//  if err != nil {
-//      return fmt.Errorf("could not open bucket: %v", err)
-//  }
-//  buf, err := bucket.ReadAll(context.Background(), "myfile.txt")
-//  ...
-//
-// Then, write your application code using the *Bucket type. You can easily
-// reconfigure your initialization code to choose a different driver.
-// You can develop your application locally using fileblob, or deploy it to
-// multiple Cloud providers. You may find http://github.com/google/wire useful
-// for managing your initialization code.
-//
-// Alternatively, you can construct a *Bucket via a URL and OpenBucket.
-// See https://gocloud.dev/concepts/urls/ for more information.
+// See https://gocloud.dev/howto/blob/ for detailed how-to guides.
 //
 //
 // Errors

--- a/internal/website/content/howto/blob/_index.md
+++ b/internal/website/content/howto/blob/_index.md
@@ -38,12 +38,12 @@ import (
 	_ "gocloud.dev/blob/<driver>"
 )
 ...
-var bucket *blob.Bucket
 bucket, err := blob.OpenBucket(context.Background(), "<driver-url>")
 if err != nil {
     return fmt.Errorf("could not open bucket: %v", err)
 }
 defer bucket.Close()
+// bucket is a *blob.Bucket; see usage below
 ...
 ``` 
 

--- a/internal/website/content/howto/blob/_index.md
+++ b/internal/website/content/howto/blob/_index.md
@@ -6,36 +6,39 @@ toc: true
 ---
 
 Blobs are a common abstraction for storing unstructured data on Cloud storage
-services and accessing them via HTTP. These guides show how to work with
+services and accessing them via HTTP. This guide shows how to work with
 blobs in the Go CDK.
 
 <!--more-->
 
-The Go CDK supports operations like reading and writing blobs (using standard
-[io package][] interfaces), deleting blobs, and listing blobs in a bucket.
+The [`blob` package][] supports operations like reading and writing blobs (using standard
+[`io` package][] interfaces), deleting blobs, and listing blobs in a bucket.
 
 Subpackages contain driver implementations of blob for various services,
 including Cloud and on-prem solutions. You can develop your application
 locally using [`fileblob`][], then deploy it to multiple Cloud providers with
 minimal reconfiguration of your initialization code.
 
-[io package]: https://golang.org/pkg/io/
+[`blob` package]: https://godoc.org/gocloud.dev/blob
+[`io` package]: https://golang.org/pkg/io/
 [`fileblob`]: https://godoc.org/gocloud.dev/blob/fileblob
 
 ## Opening a Bucket {#opening}
 
-The first step in interacting with unstructured storage is opening a connection
-to your storage service to instantiate a portable [`*blob.Bucket`][].
+The first step in interacting with unstructured storage is
+to instantiate a portable [`*blob.Bucket`][] for your storage service.
 
-The easiest way to open a blob is using [`blob.OpenBucket`][] and a URL
-pointing to the blob, making sure you ["blank import"][] the driver package to
-link it in. Do not use `NewBucket` function, intended for use by the driver
-implementations only. See [Concepts: URLs][] for more details.
+The easiest way to do so is to use [`blob.OpenBucket`][] and a service-specific URL
+pointing to the bucket, making sure you ["blank import"][] the driver package to
+link it in.
 
 ```go
-import _ "gocloud.dev/blob/<driver>"
-
-var bucket *blob.Bucket;
+import (
+	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/<driver>"
+)
+...
+var bucket *blob.Bucket
 bucket, err := blob.OpenBucket(context.Background(), "<driver-url>")
 if err != nil {
     return fmt.Errorf("could not open bucket: %v", err)
@@ -44,23 +47,26 @@ defer bucket.Close()
 ...
 ``` 
 
+See [Concepts: URLs][] for general background and the [guide below][] for URL usage
+for each supported service.
+
 Alternatively, if you need
 fine-grained control over the connection settings, you can call the constructor
 function in the driver package directly.
 
 ```go
 import "gocloud.dev/blob/<driver>"
-
+...
 bucket, err := <driver>.OpenBucket(...)
 ...
 ```
 
-You may find the [wire package][] useful for managing your initialization code
+You may find the [`wire` package][] useful for managing your initialization code
 when switching between different backing services.
 
-See the [guide below][] for usage of both connection forms for each supported service.
+See the [guide below][] for constructor usage for each supported service.
 
-[wire package]: http://github.com/google/wire
+[`wire` package]: http://github.com/google/wire
 [`*blob.Bucket`]: https://godoc.org/gocloud.dev/blob#Bucket
 [`blob.OpenBucket`]: https://godoc.org/gocloud.dev/blob#OpenBucket
 ["blank import"]: https://golang.org/doc/effective_go.html#blank_import

--- a/internal/website/content/howto/blob/_index.md
+++ b/internal/website/content/howto/blob/_index.md
@@ -35,12 +35,12 @@ implementations only. See [Concepts: URLs][] for more details.
 ```go
 import _ "gocloud.dev/blob/<driver>"
 
+var bucket *blob.Bucket;
 bucket, err := blob.OpenBucket(context.Background(), "<driver-url>")
 if err != nil {
     return fmt.Errorf("could not open bucket: %v", err)
 }
 defer bucket.Close()
-// bucket is a *blob.Bucket
 ...
 ``` 
 

--- a/internal/website/content/howto/blob/_index.md
+++ b/internal/website/content/howto/blob/_index.md
@@ -17,7 +17,7 @@ The [`blob` package][] supports operations like reading and writing blobs (using
 Subpackages contain driver implementations of blob for various services,
 including Cloud and on-prem solutions. You can develop your application
 locally using [`fileblob`][], then deploy it to multiple Cloud providers with
-minimal reconfiguration of your initialization code.
+minimal initialization reconfiguration.
 
 [`blob` package]: https://godoc.org/gocloud.dev/blob
 [`io` package]: https://golang.org/pkg/io/


### PR DESCRIPTION
Updates #2387
Add more details to "Opening" how-to section.