### PR TITLE
docs: Migrate runtimevar and secrets intro from godoc to how-to.

### DIFF
--- a/internal/website/content/howto/runtimevar/_index.md
+++ b/internal/website/content/howto/runtimevar/_index.md
@@ -23,7 +23,7 @@ providers with minimal initialization reconfiguration.
 
 ## Opening a Variable {#opening}
 
-The first step in watching a variable is to instantiate a
+The first step in watching a variable is to instantiate a portable
 [`*runtimevar.Variable`][] for your service.
 
 The easiest way to do so is to use [`runtimevar.OpenVariable`][] and a service-specific URL pointing

--- a/internal/website/content/howto/runtimevar/_index.md
+++ b/internal/website/content/howto/runtimevar/_index.md
@@ -6,22 +6,63 @@ showInSidenav: true
 toc: true
 ---
 
-The runtimevar package provides an easy and portable way to watch runtime
+The [`runtimevar` package][] provides an easy and portable way to watch runtime
 configuration variables. This guide shows how to work with runtime configuration
 variables using the Go CDK.
 
 <!--more-->
 
+Subpackages contain driver implementations of runtimevar for various services,
+including Cloud and on-prem solutions. You can develop your application locally
+using [`filevar`][] or [`constantvar`][], then deploy it to multiple Cloud
+providers with minimal initialization reconfiguration.
+
+[`runtimevar` package]: https://godoc.org/gocloud.dev/runtimevar
+[`filevar`]: https://godoc.org/gocloud.dev/runtimevar/filevar
+[`constantvar`]: https://godoc.org/gocloud.dev/runtimevar/constantvar
+
 ## Opening a Variable {#opening}
 
 The first step in watching a variable is to instantiate a
-[`*runtimevar.Variable`][].
+[`*runtimevar.Variable`][] for your service.
 
-The easiest way to do so is to use [`runtimevar.OpenVariable`][] and a URL pointing
+The easiest way to do so is to use [`runtimevar.OpenVariable`][] and a service-specific URL pointing
 to the variable, making sure you ["blank import"][] the driver package to link
-it in. See [Concepts: URLs][] for more details. If you need fine-grained control
+it in.
+
+```go
+import (
+	"gocloud.dev/runtimevar"
+	_ "gocloud.dev/runtimevar/<driver>"
+)
+...
+v, err := runtimevar.OpenVariable(context.Background(), "<driver-url>")
+if err != nil {
+    return fmt.Errorf("could not open variable: %v", err)
+}
+defer v.Close()
+// v is a *runtimevar.Variable; see usage below
+...
+```
+
+See [Concepts: URLs][] for general background and the [guide below][]
+for URL usage for each supported service.
+
+Alternatively, if you need fine-grained control
 over the connection settings, you can call the constructor function in the
 driver package directly (like `etcdvar.OpenVariable`).
+
+```go
+import "gocloud.dev/runtimevar/<driver>"
+...
+v, err := <driver>.OpenVariable(...)
+...
+```
+
+You may find the [`wire` package][] useful for managing your initialization code
+when switching between different backing services.
+
+See the [guide below][] for constructor usage for each supported service.
 
 When opening the variable, you can provide a [decoder][] parameter (either as a
 [query parameter][] for URLs, or explicitly to the constructor) to specify
@@ -30,8 +71,6 @@ whether the raw value stored in the variable is interpreted as a `string`, a
 
 {{< goexample src="gocloud.dev/runtimevar.Example_jsonDecoder" imports="0" >}}
 
-See the [guide below][] for usage of both forms for each supported provider.
-
 [`*runtimevar.Variable`]: https://godoc.org/gocloud.dev/runtimevar#Variable
 [`runtimevar.OpenVariable`]: https://godoc.org/gocloud.dev/runtimevar#OpenVariable
 ["blank import"]: https://golang.org/doc/effective_go.html#blank_import
@@ -39,6 +78,7 @@ See the [guide below][] for usage of both forms for each supported provider.
 [decoder]: https://godoc.org/gocloud.dev/runtimevar#Decoder
 [guide below]: {{< ref "#services" >}}
 [query parameter]: https://godoc.org/gocloud.dev/runtimevar#DecoderByName
+[`wire` package]: http://github.com/google/wire
 
 ## Using a Variable {#using}
 
@@ -49,14 +89,17 @@ use it portably.
 
 The easiest way to a `Variable` is to use the [`Variable.Latest`][] method. It
 returns the latest good [`Snapshot`][] of the variable value, blocking if no
-good value has *ever* been received. The dynamic type of `Snapshot.Value`
+change has *ever* been detected. The dynamic type of `Snapshot.Value`
 depends on the decoder you provided when creating the `Variable`.
-
-To avoid blocking, you can pass an already-`Done` context.
 
 {{< goexample src="gocloud.dev/runtimevar.ExampleVariable_Latest" imports="0" >}}
 
+To avoid blocking, you can pass an already-`Done` context. You can also use
+[`Variable.CheckHealth`][], which reports as healthy when Latest will
+return a value without blocking.
+
 [`Variable.Latest`]: https://godoc.org/gocloud.dev/runtimevar#Variable.Latest
+[`Variable.CheckHealth`]: https://godoc.org/gocloud.dev/runtimevar#Variable.CheckHealth
 [`Snapshot`]: https://godoc.org/gocloud.dev/runtimevar#Snapshot
 
 ### Watch {#watch}

--- a/internal/website/content/howto/runtimevar/_index.md
+++ b/internal/website/content/howto/runtimevar/_index.md
@@ -89,13 +89,13 @@ use it portably.
 
 The easiest way to a `Variable` is to use the [`Variable.Latest`][] method. It
 returns the latest good [`Snapshot`][] of the variable value, blocking if no
-change has *ever* been detected. The dynamic type of `Snapshot.Value`
+good value has *ever* been detected. The dynamic type of `Snapshot.Value`
 depends on the decoder you provided when creating the `Variable`.
 
 {{< goexample src="gocloud.dev/runtimevar.ExampleVariable_Latest" imports="0" >}}
 
 To avoid blocking, you can pass an already-`Done` context. You can also use
-[`Variable.CheckHealth`][], which reports as healthy when Latest will
+[`Variable.CheckHealth`][], which reports as healthy when `Latest` will
 return a value without blocking.
 
 [`Variable.Latest`]: https://godoc.org/gocloud.dev/runtimevar#Variable.Latest

--- a/internal/website/content/howto/secrets/_index.md
+++ b/internal/website/content/howto/secrets/_index.md
@@ -7,8 +7,7 @@ toc: true
 ---
 
 The [`secrets` package][] provides access to key management services in a
-portable way called "secret keepers". These guides show how to work with
-secret keepers in the Go CDK.
+portable way. This guide shows how to work with secrets in the Go CDK.
 
 <!--more-->
 
@@ -25,7 +24,7 @@ usually with hardware-level security and audit logging.
 
 The [`secrets` package][] supports encryption and decryption operations.
 
-Subpackages contain driver implementations of secret keeper for various services,
+Subpackages contain driver implementations of secrets for various services,
 including Cloud and on-prem solutions. You can develop your application
 locally using [`localsecrets`][], then deploy it to multiple Cloud providers with
 minimal initialization reconfiguration.
@@ -36,7 +35,7 @@ minimal initialization reconfiguration.
 ## Opening a SecretsKeeper {#opening}
 
 The first step in working with your secrets is
-to instantiate a portable [`*secrets.Keeper`][] for your secret keeper service.
+to instantiate a portable [`*secrets.Keeper`][] for your service.
 
 The easiest way to do so is to use [`secrets.OpenKeeper`][] and a service-specific
 URL pointing to the keeper, making sure you ["blank import"][] the driver

--- a/runtimevar/runtimevar.go
+++ b/runtimevar/runtimevar.go
@@ -13,33 +13,10 @@
 // limitations under the License.
 
 // Package runtimevar provides an easy and portable way to watch runtime
-// configuration variables.
+// configuration variables. Subpackages contain driver implementations of
+// runtimevar for supported services.
 //
-// It provides a blocking method that returns a Snapshot of the variable value
-// whenever a change is detected.
-//
-// Subpackages contain distinct implementations of runtimevar for various
-// services, including Cloud and on-premise solutions. For example, "etcdvar"
-// supports variables stored in etcd. Your application should import one of
-// these driver subpackages and use its exported function(s) to
-// create a *Variable; do not use the New function in this package. For example:
-//
-//  var v *runtimevar.Variable
-//  var err error
-//  v, err = etcdvar.New("my variable", etcdClient, runtimevar.JSONDecode, nil)
-//  ...
-//
-// Then, write your application code using the *Variable type. You can
-// easily reconfigure your initialization code to choose a different driver.
-// You can develop your application locally using filevar or constantvar, and
-// deploy it to multiple Cloud providers. You may find
-// http://github.com/google/wire useful for managing your initialization code.
-//
-// Variable implements health.Checker; it reports as healthy when Latest will
-// return a value without blocking.
-//
-// Alternatively, you can construct a *Variable via a URL and OpenVariable.
-// See https://gocloud.dev/concepts/urls/ for more information.
+// See https://gocloud.dev/howto/runtimevar/ for a detailed how-to guide.
 //
 //
 // OpenCensus Integration
@@ -143,7 +120,7 @@ type Variable struct {
 	lastGood Snapshot
 }
 
-// New is intended for use by drivers.
+// New is intended for use by drivers only. Do not use in application code.
 var New = newVar
 
 // newVar creates a new *Variable based on a specific driver implementation.

--- a/secrets/localsecrets/localsecrets.go
+++ b/secrets/localsecrets/localsecrets.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package localsecrets provides a secrets implementation using a locally
-// locally provided symmetric key.
+// provided symmetric key.
 // Use NewKeeper to construct a *secrets.Keeper.
 //
 // URLs

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -13,27 +13,10 @@
 // limitations under the License.
 
 // Package secrets provides an easy and portable way to encrypt and decrypt
-// messages.
+// messages. Subpackages contain driver implementations of
+// blob for supported services.
 //
-// Subpackages contain distinct implementations of secrets for various
-// services, including Cloud and on-premise solutions. For example, "localsecrets"
-// supports encryption/decryption using a locally provided key. Your application
-// should import one of these driver subpackages and use its exported
-// function(s) to create a *Keeper; do not use the NewKeeper function in this
-// package. For example:
-//
-//  keeper := localsecrets.NewKeeper(myKey)
-//  encrypted, err := keeper.Encrypt(ctx.Background(), []byte("text"))
-//  ...
-//
-// Then, write your application code using the *Keeper type. You can easily
-// reconfigure your initialization code to choose a different driver.
-// You can develop your application locally using localsecrets, or deploy it to
-// multiple Cloud providers. You may find http://github.com/google/wire useful
-// for managing your initialization code.
-//
-// Alternatively, you can construct a *Keeper via a URL and OpenKeeper.
-// See https://gocloud.dev/concepts/urls/ for more information.
+// See https://gocloud.dev/howto/secrets/ for a detailed how-to guide.
 //
 //
 // OpenCensus Integration
@@ -82,7 +65,7 @@ type Keeper struct {
 	closed bool
 }
 
-// NewKeeper is intended for use by drivers.
+// NewKeeper is intended for use by drivers only. Do not use in application code.
 var NewKeeper = newKeeper
 
 // newKeeper creates a Keeper.

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -14,7 +14,7 @@
 
 // Package secrets provides an easy and portable way to encrypt and decrypt
 // messages. Subpackages contain driver implementations of
-// blob for supported services.
+// secrets for supported services.
 //
 // See https://gocloud.dev/howto/secrets/ for a detailed how-to guide.
 //


### PR DESCRIPTION
Updates #2387.
Add examples to "Opening" how-to sections.

