### PR TITLE
docstore/mongodocstore: add a conformance test for Amazon DocumentDB

### DIFF
--- a/docstore/mongodocstore/awsdocdb/main.tf
+++ b/docstore/mongodocstore/awsdocdb/main.tf
@@ -1,0 +1,85 @@
+# Specify the provider and access details
+provider "aws" {
+  version = "~> 2.0"
+  region  = "${var.aws_region}"
+}
+
+resource "aws_security_group" "docdbtest" {
+  name_prefix = "docdbtest"
+  description = "Test mongo driver on docdb"
+  vpc_id      = "${var.vpc_id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Public SSH access"
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = true
+    description = "Allow traffic within the security group for port forwarding"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Provisioning a DocumentDB cluster with an instance.
+
+resource "aws_docdb_cluster_instance" "docdbtest" {
+  cluster_identifier = "${aws_docdb_cluster.docdbtest.id}"
+  identifier_prefix  = "${aws_docdb_cluster.docdbtest.id}"
+  instance_class     = "db.r5.large"
+  apply_immediately  = true
+}
+
+resource "aws_docdb_cluster" "docdbtest" {
+  cluster_identifier = "docstore-test-cluster"
+  master_username    = "${var.db_username}"
+  master_password    = "${var.db_password}"
+
+  db_cluster_parameter_group_name = "docstore-test-pg"
+  vpc_security_group_ids          = ["${aws_security_group.docdbtest.id}"]
+
+  skip_final_snapshot = true
+}
+
+# Provisioning an EC2 instance within the same VPC group for port forwarding.
+
+resource "aws_key_pair" "docdbtest" {
+  key_name_prefix = "docdbtest"
+  public_key      = "${var.ssh_public_key}"
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"]
+}
+
+resource "aws_instance" "docdbtest" {
+  ami                    = "${data.aws_ami.ubuntu.id}"
+  instance_type          = "t2.micro"
+  vpc_security_group_ids = ["${aws_security_group.docdbtest.id}"]
+  key_name                    = "${aws_key_pair.docdbtest.key_name}"
+  associate_public_ip_address = true
+}

--- a/docstore/mongodocstore/awsdocdb/outputs.tf
+++ b/docstore/mongodocstore/awsdocdb/outputs.tf
@@ -1,0 +1,3 @@
+output "setup_ssh_tunnel" {
+  value = "ssh -L 27017:${aws_docdb_cluster.docdbtest.endpoint}:27017 ubuntu@${aws_instance.docdbtest.public_dns} -N"
+}

--- a/docstore/mongodocstore/awsdocdb/outputs.tf
+++ b/docstore/mongodocstore/awsdocdb/outputs.tf
@@ -1,3 +1,3 @@
 output "setup_ssh_tunnel" {
-  value = "ssh -L 27017:${aws_docdb_cluster.docdbtest.endpoint}:27017 ubuntu@${aws_instance.docdbtest.public_dns} -N"
+  value = "ssh -L 27019:${aws_docdb_cluster.docdbtest.endpoint}:27017 ubuntu@${aws_instance.docdbtest.public_dns} -N"
 }

--- a/docstore/mongodocstore/awsdocdb/variables.tf
+++ b/docstore/mongodocstore/awsdocdb/variables.tf
@@ -1,0 +1,20 @@
+variable "aws_region" {
+  description = "The AWS region to create docdb cluster and ec2 instance in."
+  default     = "us-east-2"
+}
+
+variable "vpc_id" {
+  description = "The ID of the default VPC used by docdb cluster and ec2 instance."
+}
+
+variable "ssh_public_key" {
+  description = "A public key line in .ssh/authorized_keys format to use to authenticate to your instance. This must be added to your SSH agent for provisioning to succeed."
+}
+
+variable "db_username" {
+  description = "The master username to login docdb"
+}
+
+variable "db_password" {
+  description = "The master password to login docdb"
+}

--- a/docstore/mongodocstore/docdb_test.go
+++ b/docstore/mongodocstore/docdb_test.go
@@ -1,0 +1,73 @@
+package mongodocstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"gocloud.dev/docstore/drivertest"
+	"gocloud.dev/internal/testing/setup"
+)
+
+const connectionStringTemplate = "mongodb://%s:%s@%s/?connect=direct&connectTimeoutMS=3000"
+
+// To run the conformance tests against Amazon DocumentDB:
+//
+//  1. Run `terraform apply ./awsdocdb` to provision a docdb cluster and an EC2 instance.
+//  2. Run the command provided by the terraform output string to setup port-forwarding.
+//  3. Set the following environment variables and run this test with `-record` flag.
+
+var (
+	username = os.Getenv("AWSDOCDB_USERNAME")
+	password = os.Getenv("AWSDOCDB_PASSWORD")
+	endpoint = os.Getenv("AWSDOCDB_ENDPOINT") // optional, default to localhost:27017
+)
+
+func TestConformanceDocDB(t *testing.T) {
+	if !*setup.Record {
+		t.Skip("replaying is not yet supported for Amazon DocumentDB")
+	}
+	if username == "" || password == "" {
+		t.Fatal("environment not setup to run DocDB test")
+	}
+
+	client := newDocDBTestClient(t)
+	defer client.Disconnect(context.Background())
+
+	newHarness := func(context.Context, *testing.T) (drivertest.Harness, error) {
+		return &harness{db: client.Database(dbName)}, nil
+	}
+	drivertest.RunConformanceTests(t, newHarness, codecTester{}, []drivertest.AsTest{verifyAs{}})
+}
+
+func newDocDBTestClient(t *testing.T) *mongo.Client {
+	ctx := context.Background()
+	if endpoint == "" {
+		endpoint = "localhost:27017"
+	}
+	connectionURI := fmt.Sprintf(connectionStringTemplate, username, password, endpoint)
+
+	o := options.Client().ApplyURI(connectionURI)
+	if err := o.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	client, err := mongo.NewClient(o)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Failed to connect to cluster: %v", err)
+	}
+
+	// Force a connection to verify our connection string
+	err = client.Ping(ctx, nil)
+	if err != nil {
+		t.Fatalf("Failed to ping cluster: %v", err)
+	}
+	return client
+}

--- a/docstore/mongodocstore/docdb_test.go
+++ b/docstore/mongodocstore/docdb_test.go
@@ -16,14 +16,14 @@ const connectionStringTemplate = "mongodb://%s:%s@%s/?connect=direct&connectTime
 
 // To run the conformance tests against Amazon DocumentDB:
 //
-//  1. Run `terraform apply ./awsdocdb` to provision a docdb cluster and an EC2 instance.
+//  1. Run `terraform apply` in awsdocdb directory to provision a docdb cluster and an EC2 instance.
 //  2. Run the command provided by the terraform output string to setup port-forwarding.
 //  3. Set the following environment variables and run this test with `-record` flag.
 
 var (
 	username = os.Getenv("AWSDOCDB_USERNAME")
 	password = os.Getenv("AWSDOCDB_PASSWORD")
-	endpoint = os.Getenv("AWSDOCDB_ENDPOINT") // optional, default to localhost:27017
+	endpoint = os.Getenv("AWSDOCDB_ENDPOINT") // optional, default to localhost:27019
 )
 
 func TestConformanceDocDB(t *testing.T) {
@@ -46,7 +46,7 @@ func TestConformanceDocDB(t *testing.T) {
 func newDocDBTestClient(t *testing.T) *mongo.Client {
 	ctx := context.Background()
 	if endpoint == "" {
-		endpoint = "localhost:27017"
+		endpoint = "localhost:27019"
 	}
 	connectionURI := fmt.Sprintf(connectionStringTemplate, username, password, endpoint)
 


### PR DESCRIPTION
Also added a `awsdocdb` directory containing terraform files to provision the resources needed for running the tests.

Fixes #2294 