### PR TITLE
docs: Migrate docstore and pubsub intro from godoc to how-to

### DIFF
--- a/docstore/doc.go
+++ b/docstore/doc.go
@@ -13,40 +13,18 @@
 // limitations under the License.
 
 // Package docstore provides a portable way of interacting with a document store.
-// A document store is a service that stores data in semi-structured JSON-like
-// documents. Like other NoSQL databases, document stores are schemaless.
-// See https://en.wikipedia.org/wiki/Document-oriented_database for more information.
+// Subpackages contain driver implementations of docstore for supported
+// services.
 //
-// Subpackages contain distinct implementations ("drivers") of docstore for
-// various backing services, including Cloud and on-premise solutions. For example,
-// memdocstore supports an in-process, in-memory implementation suitable for testing and
-// development.
+// See https://gocloud.dev/howto/docstore/ for a detailed how-to guide.
+//
+//
+// Collections
 //
 // In docstore, documents are grouped into collections, and each document has a key
 // that is unique in its collection. You can add, retrieve, modify and delete
 // documents by key, and you can query a collection to retrieve documents that match
 // certain criteria.
-//
-// Your application should import one of the service-specific subpackages and use
-// its exported functions to create a *Collection; do not use the NewCollection
-// function in this package. For example:
-//
-//   coll, err := memdocstore.OpenCollection("SSN", nil)
-//   if err != nil {
-//       return fmt.Errorf("opening collection: %v", err)
-//   }
-//   defer coll.Close()
-//   // coll is a *docstore.Collection
-//
-// Then, write your application code using the *Collection type. You can easily
-// reconfigure your initialization code to choose a different driver.
-// You can develop your application locally using memdocstore, or deploy it to
-// multiple Cloud providers. You may find http://github.com/google/wire useful
-// for managing your initialization code.
-//
-// Alternatively, you can construct a *Collection via a URL and the
-// OpenCollection function. See https://gocloud.dev/concepts/urls for more
-// information.
 //
 //
 // Representing Documents

--- a/docstore/docstore.go
+++ b/docstore/docstore.go
@@ -62,7 +62,7 @@ var (
 	OpenCensusViews = oc.Views(pkgName, latencyMeasure)
 )
 
-// NewCollection is intended for use by drivers.
+// NewCollection is intended for use by drivers only. Do not use in application code.
 var NewCollection = newCollection
 
 // newCollection makes a Collection.

--- a/docstore/memdocstore/mem.go
+++ b/docstore/memdocstore/mem.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package memdocstore provides an in-memory implementation of the docstore
+// Package memdocstore provides an in-process in-memory implementation of the docstore
 // API. It is suitable for local development and testing.
 //
 // Every document in a memdocstore collection has a unique primary key. The primary

--- a/internal/website/content/howto/pubsub/_index.md
+++ b/internal/website/content/howto/pubsub/_index.md
@@ -15,8 +15,8 @@ that other parts of a system may subscribe to. This is commonly used to
 arrange for work to happen at some point after an interactive frontend
 request is finished or in other event-driven computing.
 
-The [`pubsub` package][] supports operations to publish messages and subscribe to
-messages.
+The [`pubsub` package][] supports operations to publish messages to a topic and
+to subscribe to receive messages from a topic.
 
 Subpackages contain driver implementations of pubsub for various services,
 including Cloud and on-prem solutions. You can develop your application

--- a/internal/website/content/howto/pubsub/_index.md
+++ b/internal/website/content/howto/pubsub/_index.md
@@ -4,14 +4,26 @@ date: 2019-03-26T09:44:06-07:00
 showInSidenav: true
 ---
 
+The [`pubsub` package][] provides an easy and portable way to interact with
+publish/subscribe systems. This guide shows how to work with pubsub
+in the Go CDK.
+
+<!--more-->
+
 The [publish/subscribe model][] allows parts of a system to publish messages
 that other parts of a system may subscribe to. This is commonly used to
 arrange for work to happen at some point after an interactive frontend
 request is finished or in other event-driven computing.
 
-The Go CDK provides portable APIs for publishing messages and subscribing to
+The [`pubsub` package][] supports operations to publish messages and subscribe to
 messages.
 
-[publish/subscribe model]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
+Subpackages contain driver implementations of pubsub for various services,
+including Cloud and on-prem solutions. You can develop your application
+locally using [`mempubsub`][], then deploy it to multiple Cloud providers with
+minimal initialization reconfiguration.
 
-<!--more-->
+[publish/subscribe model]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
+[`pubsub` package]: https://godoc.org/gocloud.dev/pubsub
+[`mempubsub`]: https://godoc.org/gocloud.dev/pubsub/mempubsub
+

--- a/internal/website/content/howto/pubsub/publish.md
+++ b/internal/website/content/howto/pubsub/publish.md
@@ -18,18 +18,57 @@ Publishing a message to a topic with the Go CDK takes two steps:
 
 ## Opening a Topic {#opening}
 
-The easiest way to open a topic is using [`pubsub.OpenTopic`][] and a URL
+The first step in publishing messages to a topic is to instantiate a
+portable [`*pubsub.Topic`][] for your service.
+
+The easiest way to do so is to use [`pubsub.OpenTopic`][] and a service-specific URL
 pointing to the topic, making sure you ["blank import"][] the driver package to
-link it in. See [Concepts: URLs][] for more details. If you need fine-grained
+link it in.
+
+```go
+import (
+    "context"
+
+    "gocloud.dev/pubsub"
+    _ "gocloud.dev/pubsub/<driver>"
+)
+...
+ctx := context.Background()
+topic, err := pubsub.OpenTopic(ctx, "<driver-url>")
+if err != nil {
+    return fmt.Errorf("could not open topic: %v", err)
+}
+defer topic.Shutdown(ctx)
+// topic is a *pubsub.Topic; see usage below
+...
+```
+
+See [Concepts: URLs][] for general background and the [guide below][]
+for URL usage for each supported service.
+
+Alternatively, if you need fine-grained
 control over the connection settings, you can call the constructor function in
 the driver package directly (like `gcppubsub.OpenTopic`).
-See the [guide below][] for usage of both forms for each supported provider.
+
+```go
+import "gocloud.dev/pubsub/<driver>"
+...
+topic, err := <driver>.OpenTopic(...)
+...
+```
+
+You may find the [`wire` package][] useful for managing your initialization code
+when switching between different backing services.
+
+See the [guide below][] for constructor usage for each supported service.
 
 [guide below]: {{< ref "#services" >}}
+[`*pubsub.Topic`]: https://godoc.org/gocloud.dev/pubsub#Topic
 [`pubsub.OpenTopic`]:
 https://godoc.org/gocloud.dev/pubsub#OpenTopic
 ["blank import"]: https://golang.org/doc/effective_go.html#blank_import
 [Concepts: URLs]: {{< ref "/concepts/urls.md" >}}
+[`wire` package]: http://github.com/google/wire
 
 ## Sending Messages on a Topic {#sending}
 

--- a/internal/website/content/howto/pubsub/subscribe.md
+++ b/internal/website/content/howto/pubsub/subscribe.md
@@ -21,18 +21,56 @@ Subscribing to messages on a topic with the Go CDK takes three steps:
 
 ## Opening a Subscription {#opening}
 
-The easiest way to open a subscription is using [`pubsub.OpenSubscription`][]
-and a URL pointing to the topic, making sure you ["blank import"][] the driver
-package to link it in. See [Concepts: URLs][] for more details. If you need
-fine-grained control over the connection settings, you can call the constructor
-function in the driver package directly (like `gcppubsub.OpenSubscription`).
-See the [guide below][] for usage of both forms for each supported provider.
+The first step in subscribing to messages is
+to instantiate a portable [`*pubsub.Subscription`][] for your service.
+
+The easiest way to do so is to use [`pubsub.OpenSubscription`][]
+and a service-specific URL pointing to the topic, making sure you
+["blank import"][] the driver package to link it in.
+
+```go
+import (
+    "context"
+
+    "gocloud.dev/pubsub"
+    _ "gocloud.dev/pubsub/<driver>"
+)
+...
+ctx := context.Background()
+subs, err := pubsub.OpenSubscription(ctx, "<driver-url>")
+if err != nil {
+    return fmt.Errorf("could not open topic subscription: %v", err)
+}
+defer subs.Shutdown(ctx)
+// subs is a *pubsub.Subscription; see usage below
+...
+```
+
+See [Concepts: URLs][] for general background and the [guide below][]
+for URL usage for each supported service.
+
+Alternatively, if you need fine-grained
+control over the connection settings, you can call the constructor function in
+the driver package directly (like `gcppubsub.OpenTopic`).
+
+```go
+import "gocloud.dev/pubsub/<driver>"
+...
+subs, err := <driver>.OpenSubscription(...)
+...
+```
+
+You may find the [`wire` package][] useful for managing your initialization code
+when switching between different backing services.
+
+See the [guide below][] for constructor usage for each supported service.
 
 [guide below]: {{< ref "#services" >}}
 [`pubsub.OpenSubscription`]:
 https://godoc.org/gocloud.dev/pubsub#OpenTopic
 ["blank import"]: https://golang.org/doc/effective_go.html#blank_import
 [Concepts: URLs]: {{< ref "/concepts/urls.md" >}}
+[`wire` package]: http://github.com/google/wire
 
 ## Receiving and Acknowledging Messages {#receiving}
 

--- a/internal/website/content/howto/pubsub/subscribe.md
+++ b/internal/website/content/howto/pubsub/subscribe.md
@@ -1,12 +1,12 @@
 ---
-title: "Subscribe to Messages from a Topic"
+title: "Subscribe to Receive Messages from a Topic"
 date: 2019-03-26T09:44:33-07:00
 lastmod: 2019-07-29T12:00:00-07:00
 weight: 2
 toc: true
 ---
 
-Subscribing to messages on a topic with the Go CDK takes three steps:
+Subscribing to receive message from a topic with the Go CDK takes three steps:
 
 1. [Open a subscription][] with the Pub/Sub provider of your choice (once per
    subscription).
@@ -21,7 +21,7 @@ Subscribing to messages on a topic with the Go CDK takes three steps:
 
 ## Opening a Subscription {#opening}
 
-The first step in subscribing to messages is
+The first step in subscribing to receive messages from a topic is
 to instantiate a portable [`*pubsub.Subscription`][] for your service.
 
 The easiest way to do so is to use [`pubsub.OpenSubscription`][]
@@ -51,7 +51,7 @@ for URL usage for each supported service.
 
 Alternatively, if you need fine-grained
 control over the connection settings, you can call the constructor function in
-the driver package directly (like `gcppubsub.OpenTopic`).
+the driver package directly (like `gcppubsub.OpenSubscription`).
 
 ```go
 import "gocloud.dev/pubsub/<driver>"

--- a/internal/website/content/howto/pubsub/subscribe.md
+++ b/internal/website/content/howto/pubsub/subscribe.md
@@ -8,7 +8,7 @@ toc: true
 
 Subscribing to receive message from a topic with the Go CDK takes three steps:
 
-1. [Open a subscription][] to a topic with the Pub/Sub provider of your choice (once per
+1. [Open a subscription][] to a topic with the Pub/Sub service of your choice (once per
    subscription).
 2. [Receive and acknowledge messages][] from the topic. After completing any
    work related to the message, use the Ack method to prevent it from being

--- a/internal/website/content/howto/pubsub/subscribe.md
+++ b/internal/website/content/howto/pubsub/subscribe.md
@@ -1,5 +1,5 @@
 ---
-title: "Subscribe to Receive Messages from a Topic"
+title: "Subscribe to Messages from a Topic"
 date: 2019-03-26T09:44:33-07:00
 lastmod: 2019-07-29T12:00:00-07:00
 weight: 2

--- a/internal/website/content/howto/pubsub/subscribe.md
+++ b/internal/website/content/howto/pubsub/subscribe.md
@@ -8,7 +8,7 @@ toc: true
 
 Subscribing to receive message from a topic with the Go CDK takes three steps:
 
-1. [Open a subscription][] with the Pub/Sub provider of your choice (once per
+1. [Open a subscription][] to a topic with the Pub/Sub provider of your choice (once per
    subscription).
 2. [Receive and acknowledge messages][] from the topic. After completing any
    work related to the message, use the Ack method to prevent it from being

--- a/internal/website/data/examples.json
+++ b/internal/website/data/examples.json
@@ -169,7 +169,7 @@
 	},
 	"gocloud.dev/pubsub.ExampleTopic_Send": {
 		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/pubsub\"\n)",
-		"code": "err := topic.Send(ctx, \u0026pubsub.Message{\n\tBody: []byte(\"Hello, World!\\n\"),\n\tMetadata: map[string]string{\n\t\t// These are examples of metadata.\n\t\t// There is nothing special about the key names.\n\t\t\"language\":   \"en\",\n\t\t\"importance\": \"high\",\n\t},\n})\nif err != nil {\n\treturn err\n}"
+		"code": "err := topic.Send(ctx, \u0026pubsub.Message{\n\tBody: []byte(\"Hello, World!\\n\"),\n\t// Metadata is optional and can be nil.\n\tMetadata: map[string]string{\n\t\t// These are examples of metadata.\n\t\t// There is nothing special about the key names.\n\t\t\"language\":   \"en\",\n\t\t\"importance\": \"high\",\n\t},\n})\nif err != nil {\n\treturn err\n}"
 	},
 	"gocloud.dev/pubsub/awssnssqs.ExampleOpenSNSTopic": {
 		"imports": "import (\n\t\"context\"\n\n\t\"github.com/aws/aws-sdk-go/aws\"\n\t\"github.com/aws/aws-sdk-go/aws/session\"\n\t\"gocloud.dev/pubsub/awssnssqs\"\n)",

--- a/pubsub/example_test.go
+++ b/pubsub/example_test.go
@@ -34,6 +34,7 @@ func ExampleTopic_Send() {
 
 	err := topic.Send(ctx, &pubsub.Message{
 		Body: []byte("Hello, World!\n"),
+		// Metadata is optional and can be nil.
 		Metadata: map[string]string{
 			// These are examples of metadata.
 			// There is nothing special about the key names.

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -12,29 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package pubsub provides an easy and portable way to interact with publish/
-// subscribe systems. See https://gocloud.dev/howto/pubsub/ for how-to guides.
+// Package pubsub provides an easy and portable way to interact with
+// publish/subscribe systems. Subpackages contain driver implementations of
+// pubsub for supported services
 //
-// Subpackages contain distinct implementations of pubsub for various services,
-// including Cloud and on-premise solutions. For example, "gcppubsub" supports
-// Google Cloud Pub/Sub. Your application should import one of these
-// driver subpackages and use its exported functions to get a
-// *Topic and/or *Subscription; do not use the NewTopic/NewSubscription
-// functions in this package. For example:
+// See https://gocloud.dev/howto/pubsub/ for a detailed how-to guide.
 //
-//  topic := mempubsub.NewTopic()
-//  err := topic.Send(ctx.Background(), &pubsub.Message{Body: []byte("hi"))
-//  ...
-//
-// Then, write your application code using the *Topic/*Subscription types. You
-// can easily reconfigure your initialization code to choose a different driver.
-// You can develop your application locally using memblob, or deploy it to
-// multiple Cloud providers. You may find http://github.com/google/wire useful
-// for managing your initialization code.
-//
-// Alternatively, you can construct a *Topic/*Subscription via a URL and
-// OpenTopic/OpenSubscription.
-// See https://gocloud.dev/concepts/urls/ for more information.
 //
 // At-most-once and At-least-once Delivery
 //
@@ -312,7 +295,7 @@ func (t *Topic) ErrorAs(err error, i interface{}) bool {
 	return gcerr.ErrorAs(err, i, t.driver.ErrorAs)
 }
 
-// NewTopic is for use by drivers.
+// NewTopic is for use by drivers only. Do not use in application code.
 var NewTopic = newTopic
 
 // newSendBatcher creates a batcher for topics, for use with NewTopic.
@@ -733,7 +716,7 @@ func (s *Subscription) ErrorAs(err error, i interface{}) bool {
 	return gcerr.ErrorAs(err, i, s.driver.ErrorAs)
 }
 
-// NewSubscription is for use by drivers.
+// NewSubscription is for use by drivers only. Do not use in application code.
 var NewSubscription = newSubscription
 
 // newSubscription creates a Subscription from a driver.Subscription.


### PR DESCRIPTION
Updates #2387.
Add examples to "Opening" how-to sections.

I kept some of the intro text in docstore godoc (now under Collection section) because it defines concepts that the rest of the godoc relies on. I plan to migrate this together with other sections in a separate PR.