### PR TITLE
mysql: remove mysql:// prefix when passing DSN to driver

### DIFF
--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"net/url"
+	"strings"
 
 	"github.com/go-sql-driver/mysql"
 	"gocloud.dev/internal/openurl"
@@ -46,7 +47,7 @@ func (*URLOpener) OpenMySQLURL(ctx context.Context, u *url.URL) (*sql.DB, error)
 }
 
 func openWithURL(url *url.URL) (*sql.DB, error) {
-	return sql.OpenDB(connector{dsn: url.String()}), nil
+	return sql.OpenDB(connector{dsn: strings.TrimLeft(url.String(), Scheme+"://")}), nil
 }
 
 type connector struct {


### PR DESCRIPTION
This commit removes the `mysql://` prefix before passing the DSN to the
MySQL driver for Go. The latter requires the DSN in a format like:

```
[username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]
```

as described in
https://github.com/go-sql-driver/mysql/blob/master/README.md#dsn-data-source-name.

It doesn't accept a `mysql://` prefix and, when used, will not parse the
DSN correctly.

Fixes #2644
