### PR TITLE
pubsub/awssnssqs: fix docs/examples/tests to show SNS ARN in path, not hostname

### DIFF
--- a/internal/website/data/examples.json
+++ b/internal/website/data/examples.json
@@ -177,7 +177,7 @@
 	},
 	"gocloud.dev/pubsub/awssnssqs.Example_openSNSTopicFromURL": {
 		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/pubsub\"\n\t_ \"gocloud.dev/pubsub/awssnssqs\"\n)",
-		"code": "const topicARN = \"arn:aws:sns:us-east-2:123456789012:mytopic\"\ntopic, err := pubsub.OpenTopic(ctx, \"awssns://\"+topicARN+\"?region=us-east-2\")\nif err != nil {\n\treturn err\n}\ndefer topic.Shutdown(ctx)"
+		"code": "const topicARN = \"arn:aws:sns:us-east-2:123456789012:mytopic\"\n// Note the 3 slashes; ARNs have multiple colons and therefore aren't valid\n// as hostnames in the URL.\ntopic, err := pubsub.OpenTopic(ctx, \"awssns:///\"+topicARN+\"?region=us-east-2\")\nif err != nil {\n\treturn err\n}\ndefer topic.Shutdown(ctx)"
 	},
 	"gocloud.dev/pubsub/awssnssqs.Example_openSQSTopicFromURL": {
 		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/pubsub\"\n\t_ \"gocloud.dev/pubsub/awssnssqs\"\n)",

--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -182,11 +182,13 @@ const SNSScheme = "awssns"
 // pubsub.DefaultMux.
 const SQSScheme = "awssqs"
 
-// URLOpener opens AWS SNS/SQS URLs like "awssns://sns-topic-arn" for
+// URLOpener opens AWS SNS/SQS URLs like "awssns:///sns-topic-arn" for
 // SNS topics or "awssqs://sqs-queue-url" for SQS topics and subscriptions.
 //
 // For SNS topics, the URL's host+path is used as the topic Amazon Resource Name
-// (ARN).
+// (ARN). Since ARNs have ":" in them, and ":" precedes a port in URL
+// hostnames, leave the host blank and put the ARN in the path
+// (e.g., "awssns:///arn:aws:service:region:accountid:resourceType/resourcePath").
 //
 // For SQS topics and subscriptions, the URL's host+path is prefixed with
 // "https://" to create the queue URL.

--- a/pubsub/awssnssqs/awssnssqs_test.go
+++ b/pubsub/awssnssqs/awssnssqs_test.go
@@ -414,11 +414,11 @@ func TestOpenTopicFromURL(t *testing.T) {
 		// SNS...
 
 		// OK.
-		{"awssns://arn:aws:service:region:accountid:resourceType/resourcePath", false},
+		{"awssns:///arn:aws:service:region:accountid:resourceType/resourcePath", false},
 		// OK, setting region.
-		{"awssns://arn:aws:service:region:accountid:resourceType/resourcePath?region=us-east-2", false},
+		{"awssns:///arn:aws:service:region:accountid:resourceType/resourcePath?region=us-east-2", false},
 		// Invalid parameter.
-		{"awssns://arn:aws:service:region:accountid:resourceType/resourcePath?param=value", true},
+		{"awssns:///arn:aws:service:region:accountid:resourceType/resourcePath?param=value", true},
 
 		// SQS...
 		// OK.

--- a/pubsub/awssnssqs/example_test.go
+++ b/pubsub/awssnssqs/example_test.go
@@ -73,7 +73,9 @@ func Example_openSNSTopicFromURL() {
 	ctx := context.Background()
 
 	const topicARN = "arn:aws:sns:us-east-2:123456789012:mytopic"
-	topic, err := pubsub.OpenTopic(ctx, "awssns://"+topicARN+"?region=us-east-2")
+	// Note the 3 slashes; ARNs have multiple colons and therefore aren't valid
+	// as hostnames in the URL.
+	topic, err := pubsub.OpenTopic(ctx, "awssns:///"+topicARN+"?region=us-east-2")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #2647.