### PR TITLE
internal/website: add reference section for docstore; cleanup

### DIFF
--- a/internal/website/content/ref/blob.md
+++ b/internal/website/content/ref/blob.md
@@ -15,10 +15,10 @@ listing blobs in a bucket.
 
 <!--more-->
 
-[Top-level package documentation](https://godoc.org/gocloud.dev/blob)<br>
-[How-to guides]({{< ref "/howto/blob/_index.md" >}})
+[How-to guide]({{< ref "/howto/blob/_index.md" >}})<br>
+[Top-level package documentation](https://godoc.org/gocloud.dev/blob)
 
-## Supported Providers
+## Supported Services
 
 * [GCS blob](https://godoc.org/gocloud.dev/blob/gcsblob)
 * [AWS S3 blob](https://godoc.org/gocloud.dev/blob/s3blob)
@@ -32,7 +32,6 @@ listing blobs in a bucket.
 
 * [CLI Tutorial]({{< ref "/tutorials/cli-uploader.md" >}})
 * [CLI Sample](https://github.com/google/go-cloud/tree/master/samples/gocdk-blob)
-* [Guestbook
-  sample](https://github.com/google/go-cloud/tree/master/samples/guestbook)
+* [Guestbook sample](https://gocloud.dev/tutorials/guestbook/)
 * [blob package examples](https://godoc.org/gocloud.dev/blob#pkg-examples)
 

--- a/internal/website/content/ref/docstore.md
+++ b/internal/website/content/ref/docstore.md
@@ -1,0 +1,31 @@
+---
+title: "docstore"
+date: 2019-08-14T00:00:00-08:00
+aliases:
+- /pages/docstore/
+---
+
+The docstore package provides an abstraction layer over common document stores
+like Google Cloud Firestore, Amazon DynamoDB, and MongoDB.
+
+<!--more-->
+
+[How-to guide]({{< ref "/howto/docstore/_index.md" >}})<br>
+[Top-level package documentation](https://godoc.org/gocloud.dev/docstore)
+
+## Supported Services
+
+* [GCP Firestore](https://godoc.org/gocloud.dev/docstore/gcpfirestore)
+* [AWS DynamoDB](https://godoc.org/gocloud.dev/docstore/awsdynamodb)
+* [Azure blob](https://godoc.org/gocloud.dev/docstore/azureblob)
+* [MongoDB](https://godoc.org/gocloud.dev/docstore/mongodocstore)
+  * AWS DocumentDB and Azure Cosmos DB have MongoDB-compatible APIs.
+* [In-memory](https://godoc.org/gocloud.dev/docstore/memdocstore) - mainly
+  useful for local testing
+
+## Usage Samples
+
+* [CLI Sample](https://github.com/google/go-cloud/tree/master/samples/gocdk-docstore)
+* [Order Processor sample](https://gocloud.dev/tutorials/order/)
+* [docstore package examples](https://godoc.org/gocloud.dev/docstore#pkg-examples)
+

--- a/internal/website/content/ref/docstore.md
+++ b/internal/website/content/ref/docstore.md
@@ -17,7 +17,6 @@ like Google Cloud Firestore, Amazon DynamoDB, and MongoDB.
 
 * [GCP Firestore](https://godoc.org/gocloud.dev/docstore/gcpfirestore)
 * [AWS DynamoDB](https://godoc.org/gocloud.dev/docstore/awsdynamodb)
-* [Azure blob](https://godoc.org/gocloud.dev/docstore/azureblob)
 * [MongoDB](https://godoc.org/gocloud.dev/docstore/mongodocstore)
   * AWS DocumentDB and Azure Cosmos DB have MongoDB-compatible APIs.
 * [In-memory](https://godoc.org/gocloud.dev/docstore/memdocstore) - mainly

--- a/internal/website/content/ref/mysql.md
+++ b/internal/website/content/ref/mysql.md
@@ -13,13 +13,14 @@ will automatically collect diagnostic information via [OpenCensus][].
 
 <!--more-->
 
-Top-level package documentation: https://godoc.org/gocloud.dev/mysql
+[How-to guide]({{< ref "/howto/sql/_index.md" >}})<br>
+[Top-level package documentation](https://godoc.org/gocloud.dev/mysql)
 
 [`*sql.DB`]: https://godoc.org/database/sql#DB
 [MySQL]: https://www.mysql.com/
 [OpenCensus]: https://opencensus.io/
 
-## Supported Providers
+## Supported Services
 
 * [GCP Cloud SQL for MySQL](https://godoc.org/gocloud.dev/mysql/gcpmysql)
 * [AWS RDS for MySQL](https://godoc.org/gocloud.dev/mysql/awsmysql)
@@ -28,5 +29,4 @@ Top-level package documentation: https://godoc.org/gocloud.dev/mysql
 
 ## Usage Samples
 
-* [Guestbook
-  sample](https://github.com/google/go-cloud/tree/master/samples/guestbook)
+* [Guestbook sample](https://gocloud.dev/tutorials/guestbook/)

--- a/internal/website/content/ref/postgres.md
+++ b/internal/website/content/ref/postgres.md
@@ -11,13 +11,14 @@ using this package will automatically collect diagnostic information via
 
 <!--more-->
 
-Top-level package documentation: https://godoc.org/gocloud.dev/postgres.
+[How-to guide]({{< ref "/howto/sql/_index.md" >}})<br>
+[Top-level package documentation](https://godoc.org/gocloud.dev/postgres)
 
 [`*sql.DB`]: https://godoc.org/database/sql#DB
 [OpenCensus]: https://opencensus.io/
 [PostgreSQL]: https://www.postgresql.org/
 
-## Supported Providers
+## Supported Services
 
 * [GCP Cloud SQL for PostgreSQL](https://godoc.org/gocloud.dev/postgres/gcppostgres)
 * [AWS RDS for PostgreSQL](https://godoc.org/gocloud.dev/postgres/awspostgres)

--- a/internal/website/content/ref/pubsub.md
+++ b/internal/website/content/ref/pubsub.md
@@ -16,10 +16,10 @@ delivery](https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol#Overvi
 
 <!--more-->
 
-[Top-level package documentation](https://godoc.org/gocloud.dev/pubsub)<br>
-[How-to guides]({{< ref "/howto/pubsub/_index.md" >}})
+[How-to guide]({{< ref "/howto/pubsub/_index.md" >}})<br>
+[Top-level package documentation](https://godoc.org/gocloud.dev/pubsub)
 
-## Supported Providers
+## Supported Services
 
 * [Google Cloud Pub/Sub](https://godoc.org/gocloud.dev/pubsub/gcppubsub)
 * [Amazon SNS+SQS](https://godoc.org/gocloud.dev/pubsub/awssnssqs)
@@ -33,4 +33,5 @@ delivery](https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol#Overvi
 ## Usage Samples
 
 * [CLI Sample](https://github.com/google/go-cloud/tree/master/samples/gocdk-pubsub)
+* [Order Processor sample](https://gocloud.dev/tutorials/order/)
 * [pubsub package examples](https://godoc.org/gocloud.dev/pubsub#pkg-examples)

--- a/internal/website/content/ref/runtimevar.md
+++ b/internal/website/content/ref/runtimevar.md
@@ -10,9 +10,10 @@ remote configuration variables.
 
 <!--more-->
 
-Top-level package documentation: https://godoc.org/gocloud.dev/runtimevar
+[How-to guide]({{< ref "/howto/runtimevar/_index.md" >}})<br>
+[Top-level package documentation](https://godoc.org/gocloud.dev/runtimevar)
 
-## Supported Providers
+## Supported Services
 
 * [GCP Runtime
   Configurator](https://godoc.org/gocloud.dev/runtimevar/gcpruntimeconfig)
@@ -31,7 +32,5 @@ Top-level package documentation: https://godoc.org/gocloud.dev/runtimevar
 ## Usage Samples
 
 * [CLI Sample](https://github.com/google/go-cloud/tree/master/samples/gocdk-runtimevar)
-* [Guestbook
-  sample](https://github.com/google/go-cloud/tree/master/samples/guestbook)
-* [runtimevar package
-  examples](https://godoc.org/gocloud.dev/runtimevar#pkg-examples)
+* [Guestbook sample](https://gocloud.dev/tutorials/guestbook/)
+* [runtimevar package examples](https://godoc.org/gocloud.dev/runtimevar#pkg-examples)

--- a/internal/website/content/ref/secrets.md
+++ b/internal/website/content/ref/secrets.md
@@ -17,9 +17,10 @@ activites.
 
 <!--more-->
 
-Top-level package documentation: <https://godoc.org/gocloud.dev/secrets>
+[How-to guide]({{< ref "/howto/secrets/_index.md" >}})<br>
+[Top-level package documentation](https://godoc.org/gocloud.dev/secrets)
 
-## Supported Providers
+## Supported Services
 
 * [Google Cloud KMS](https://godoc.org/gocloud.dev/secrets/gcpkms)
 * [AWS KMS](https://godoc.org/gocloud.dev/secrets/awskms)

--- a/internal/website/content/ref/server.md
+++ b/internal/website/content/ref/server.md
@@ -9,9 +9,10 @@ Package `server` provides a preconfigured HTTP server with diagnostic hooks.
 
 <!--more-->
 
-Top-level package documentation: https://godoc.org/gocloud.dev/server
+[How-to guide]({{< ref "/howto/server/_index.md" >}})<br>
+[Top-level package documentation](https://godoc.org/gocloud.dev/server)
 
-## Supported Providers
+## Supported Services
 
 * [Stackdriver](https://godoc.org/gocloud.dev/server/sdserver)
 * [AWS X-Ray](https://godoc.org/gocloud.dev/server/xrayserver)
@@ -19,5 +20,4 @@ Top-level package documentation: https://godoc.org/gocloud.dev/server
 ## Usage Samples
 
 * [Minimal server sample](https://github.com/google/go-cloud/tree/master/samples/server)
-* [Guestbook
-  sample](https://github.com/google/go-cloud/tree/master/samples/guestbook)
+* [Guestbook sample](https://gocloud.dev/tutorials/guestbook/)


### PR DESCRIPTION
Noticed we were missing a reference section for docstore, and fixed some inconsistencies along the way.