### PR TITLE
release: prepare for release v0.17.0

### DIFF
--- a/docstore/mongodocstore/go.mod
+++ b/docstore/mongodocstore/go.mod
@@ -27,5 +27,3 @@ require (
 	go.mongodb.org/mongo-driver v1.0.3
 	gocloud.dev v0.16.0
 )
-
-replace gocloud.dev => ../../

--- a/docstore/mongodocstore/go.mod
+++ b/docstore/mongodocstore/go.mod
@@ -25,5 +25,5 @@ require (
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.0.3
-	gocloud.dev v0.16.0
+	gocloud.dev v0.17.0
 )

--- a/internal/contributebot/go.mod
+++ b/internal/contributebot/go.mod
@@ -30,5 +30,3 @@ require (
 	google.golang.org/api v0.6.0
 	google.golang.org/appengine v1.6.1
 )
-
-replace gocloud.dev => ../../

--- a/internal/contributebot/go.mod
+++ b/internal/contributebot/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/wire v0.3.0
 	go.opencensus.io v0.22.0
-	gocloud.dev v0.16.0
+	gocloud.dev v0.17.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20190620070143-6f217b454f45
 	google.golang.org/api v0.6.0

--- a/pubsub/kafkapubsub/go.mod
+++ b/pubsub/kafkapubsub/go.mod
@@ -20,5 +20,5 @@ require (
 	github.com/DataDog/zstd v1.4.0 // indirect
 	github.com/Shopify/sarama v1.22.1
 	github.com/google/go-cmp v0.3.0
-	gocloud.dev v0.16.0
+	gocloud.dev v0.17.0
 )

--- a/pubsub/kafkapubsub/go.mod
+++ b/pubsub/kafkapubsub/go.mod
@@ -22,5 +22,3 @@ require (
 	github.com/google/go-cmp v0.3.0
 	gocloud.dev v0.16.0
 )
-
-replace gocloud.dev => ../../

--- a/pubsub/natspubsub/go.mod
+++ b/pubsub/natspubsub/go.mod
@@ -22,5 +22,3 @@ require (
 	github.com/nats-io/nats.go v1.8.1
 	gocloud.dev v0.16.0
 )
-
-replace gocloud.dev => ../../

--- a/pubsub/natspubsub/go.mod
+++ b/pubsub/natspubsub/go.mod
@@ -20,5 +20,5 @@ require (
 	github.com/google/go-cmp v0.3.0
 	github.com/nats-io/nats-server/v2 v2.0.0
 	github.com/nats-io/nats.go v1.8.1
-	gocloud.dev v0.16.0
+	gocloud.dev v0.17.0
 )

--- a/pubsub/rabbitpubsub/go.mod
+++ b/pubsub/rabbitpubsub/go.mod
@@ -18,5 +18,5 @@ go 1.12
 
 require (
 	github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271
-	gocloud.dev v0.16.0
+	gocloud.dev v0.17.0
 )

--- a/pubsub/rabbitpubsub/go.mod
+++ b/pubsub/rabbitpubsub/go.mod
@@ -20,5 +20,3 @@ require (
 	github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271
 	gocloud.dev v0.16.0
 )
-
-replace gocloud.dev => ../../

--- a/runtimevar/etcdvar/go.mod
+++ b/runtimevar/etcdvar/go.mod
@@ -45,7 +45,7 @@ require (
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.10.0 // indirect
-	gocloud.dev v0.16.0
+	gocloud.dev v0.17.0
 	google.golang.org/grpc v1.21.1
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/runtimevar/etcdvar/go.mod
+++ b/runtimevar/etcdvar/go.mod
@@ -49,5 +49,3 @@ require (
 	google.golang.org/grpc v1.21.1
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
-
-replace gocloud.dev => ../../

--- a/samples/go.mod
+++ b/samples/go.mod
@@ -40,17 +40,3 @@ require (
 	google.golang.org/genproto v0.0.0-20190620144150-6af8c5fc6601
 	gopkg.in/pipe.v2 v2.0.0-20140414041502-3c2ca4d52544
 )
-
-replace gocloud.dev => ../
-
-replace gocloud.dev/docstore/mongodocstore => ../docstore/mongodocstore
-
-replace gocloud.dev/pubsub/kafkapubsub => ../pubsub/kafkapubsub
-
-replace gocloud.dev/pubsub/natspubsub => ../pubsub/natspubsub
-
-replace gocloud.dev/pubsub/rabbitpubsub => ../pubsub/rabbitpubsub
-
-replace gocloud.dev/runtimevar/etcdvar => ../runtimevar/etcdvar
-
-replace gocloud.dev/secrets/hashivault => ../secrets/hashivault

--- a/samples/go.mod
+++ b/samples/go.mod
@@ -30,13 +30,13 @@ require (
 	github.com/gorilla/mux v1.7.2
 	github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271
 	go.opencensus.io v0.22.0
-	gocloud.dev v0.16.0
-	gocloud.dev/docstore/mongodocstore v0.16.0
-	gocloud.dev/pubsub/kafkapubsub v0.16.0
-	gocloud.dev/pubsub/natspubsub v0.16.0
-	gocloud.dev/pubsub/rabbitpubsub v0.16.0
-	gocloud.dev/runtimevar/etcdvar v0.16.0
-	gocloud.dev/secrets/hashivault v0.16.0
+	gocloud.dev v0.17.0
+	gocloud.dev/docstore/mongodocstore v0.17.0
+	gocloud.dev/pubsub/kafkapubsub v0.17.0
+	gocloud.dev/pubsub/natspubsub v0.17.0
+	gocloud.dev/pubsub/rabbitpubsub v0.17.0
+	gocloud.dev/runtimevar/etcdvar v0.17.0
+	gocloud.dev/secrets/hashivault v0.17.0
 	google.golang.org/genproto v0.0.0-20190620144150-6af8c5fc6601
 	gopkg.in/pipe.v2 v2.0.0-20140414041502-3c2ca4d52544
 )

--- a/secrets/hashivault/go.mod
+++ b/secrets/hashivault/go.mod
@@ -18,5 +18,5 @@ go 1.12
 
 require (
 	github.com/hashicorp/vault/api v1.0.2
-	gocloud.dev v0.16.0
+	gocloud.dev v0.17.0
 )

--- a/secrets/hashivault/go.mod
+++ b/secrets/hashivault/go.mod
@@ -20,5 +20,3 @@ require (
 	github.com/hashicorp/vault/api v1.0.2
 	gocloud.dev v0.16.0
 )
-
-replace gocloud.dev => ../../


### PR DESCRIPTION
Travis is expected to fail.

Doing a release due to #2666, to make sure we work with `go 1.13`.