### PR TITLE
mysql: use TrimPrefix instead of TrimLeft

### DIFF
--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -47,7 +47,7 @@ func (*URLOpener) OpenMySQLURL(ctx context.Context, u *url.URL) (*sql.DB, error)
 }
 
 func openWithURL(url *url.URL) (*sql.DB, error) {
-	return sql.OpenDB(connector{dsn: strings.TrimLeft(url.String(), Scheme+"://")}), nil
+	return sql.OpenDB(connector{dsn: strings.TrimPrefix(url.String(), Scheme+"://")}), nil
 }
 
 type connector struct {


### PR DESCRIPTION
yueeong [pointed out](https://github.com/google/go-cloud/commit/a5f6c05207b2d477d31267b24edd23331ac6f228#commitcomment-35353748) that this use of `TrimLeft` should be `TrimPrefix`. `TrimLeft` trims all character in the "cutset" of its second argument, so `TrimLeft(s, "mysql://")` would remove any leading `m`, `y`, `s`, etc.. That's not what we want.