### PR TITLE
runtimevar/gcpruntimeconfig: Use non-deprecated gRPC APIs

### DIFF
--- a/runtimevar/gcpruntimeconfig/gcpruntimeconfig.go
+++ b/runtimevar/gcpruntimeconfig/gcpruntimeconfig.go
@@ -278,7 +278,7 @@ func equivalentError(err1, err2 error) bool {
 	if err1 == err2 || err1.Error() == err2.Error() {
 		return true
 	}
-	code1, code2 := grpc.Code(err1), grpc.Code(err2)
+	code1, code2 := status.Code(err1), status.Code(err2)
 	return code1 != codes.OK && code1 != codes.Unknown && code1 == code2
 }
 

--- a/runtimevar/gcpruntimeconfig/gcpruntimeconfig_test.go
+++ b/runtimevar/gcpruntimeconfig/gcpruntimeconfig_test.go
@@ -25,7 +25,6 @@ import (
 	"gocloud.dev/runtimevar/driver"
 	"gocloud.dev/runtimevar/drivertest"
 	pb "google.golang.org/genproto/googleapis/cloud/runtimeconfig/v1beta1"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -147,9 +146,9 @@ func TestEquivalentError(t *testing.T) {
 	}{
 		{Err1: errors.New("not grpc"), Err2: errors.New("not grpc"), Want: true},
 		{Err1: errors.New("not grpc"), Err2: errors.New("not grpc but different")},
-		{Err1: errors.New("not grpc"), Err2: grpc.Errorf(codes.Internal, "fail")},
-		{Err1: grpc.Errorf(codes.Internal, "fail"), Err2: grpc.Errorf(codes.InvalidArgument, "fail")},
-		{Err1: grpc.Errorf(codes.Internal, "fail"), Err2: grpc.Errorf(codes.Internal, "fail"), Want: true},
+		{Err1: errors.New("not grpc"), Err2: status.Errorf(codes.Internal, "fail")},
+		{Err1: status.Errorf(codes.Internal, "fail"), Err2: status.Errorf(codes.InvalidArgument, "fail")},
+		{Err1: status.Errorf(codes.Internal, "fail"), Err2: status.Errorf(codes.Internal, "fail"), Want: true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Use non-deprecated gRPC APIs in runtimevar/gcpruntimeconfig package. 