### PR TITLE
blob/fileblob: Handle empty filepath better

### DIFF
--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -163,18 +163,21 @@ type bucket struct {
 // openBucket creates a driver.Bucket that reads and writes to dir.
 // dir must exist.
 func openBucket(dir string, opts *Options) (driver.Bucket, error) {
-	dir = filepath.Clean(dir)
-	info, err := os.Stat(dir)
+	absdir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert %s into an absolute path: %v", dir, err)
+	}
+	info, err := os.Stat(absdir)
 	if err != nil {
 		return nil, err
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("%s is not a directory", dir)
+		return nil, fmt.Errorf("%s is not a directory", absdir)
 	}
 	if opts == nil {
 		opts = &Options{}
 	}
-	return &bucket{dir: dir, opts: opts}, nil
+	return &bucket{dir: absdir, opts: opts}, nil
 }
 
 // OpenBucket creates a *blob.Bucket backed by the filesystem and rooted at

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -256,7 +256,7 @@ func TestOpenBucketFromURL(t *testing.T) {
 		Want        string
 	}{
 		// Bucket doesn't exist -> error at construction time.
-		{"file:///bucket-not-found", "myfile.txt", true, false, ""},
+		{"file:///bucket-not-found", "", true, false, ""},
 		// File doesn't exist -> error at read time.
 		{"file://" + dirpath, "filenotfound.txt", false, true, ""},
 		// OK.


### PR DESCRIPTION
Fixes #2700.

When fileblob gets a URL like `file://`, it ends up using the relative path "." and getting things wrong after that. We should convert "." into an absolute path using `filepath.Abs`.