### PR TITLE
blob/azureblob: Add support for specifying Azure Cloud Environment 

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -102,7 +102,9 @@ type Options struct {
 
 	// CloudEnvironment can be provided to specify an Azure Cloud Environment
 	// domain to target for the blob storage account (i.e. public, government, china).
-	// The default value is "blob.core.windows.net".
+	// The default value is "blob.core.windows.net". Possible values will look similar
+	// to this but are different for each cloud (i.e. "blob.core.govcloudapi.net" for USGovernment). 
+	// Check the Azure developer guide for the cloud environment where your bucket resides. 
 	CloudEnvironment CloudEnvironment
 }
 

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -28,7 +28,9 @@
 // AZURE_STORAGE_ACCOUNT is required, along with one of the other two.
 // AZURE_BLOB_DOMAIN can optionally be used to provide an Azure Environment
 // blob storage domain to use. If no AZURE_BLOB_DOMAIN is provided, the
-// default Azure public domain "blob.core.windows.net" will be used.
+// default Azure public domain "blob.core.windows.net" will be used. Check
+// the Azure Developer Guide for your particular cloud environment to see
+// the proper blob storage domain name to provide.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
 // See https://gocloud.dev/concepts/urls/ for background information.

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -103,8 +103,8 @@ type Options struct {
 	// CloudEnvironment can be provided to specify an Azure Cloud Environment
 	// domain to target for the blob storage account (i.e. public, government, china).
 	// The default value is "blob.core.windows.net". Possible values will look similar
-	// to this but are different for each cloud (i.e. "blob.core.govcloudapi.net" for USGovernment). 
-	// Check the Azure developer guide for the cloud environment where your bucket resides. 
+	// to this but are different for each cloud (i.e. "blob.core.govcloudapi.net" for USGovernment).
+	// Check the Azure developer guide for the cloud environment where your bucket resides.
 	CloudEnvironment CloudEnvironment
 }
 

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -26,8 +26,8 @@
 // The default URL opener will use credentials from the environment variables
 // AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY, and AZURE_STORAGE_SAS_TOKEN.
 // AZURE_STORAGE_ACCOUNT is required, along with one of the other two.
-// AZURE_BLOB_DOMAIN can optionally be used to provide an Azure Environment
-// blob storage domain to use. If no AZURE_BLOB_DOMAIN is provided, the
+// AZURE_STORAGE_DOMAIN can optionally be used to provide an Azure Environment
+// blob storage domain to use. If no AZURE_STORAGE_DOMAIN is provided, the
 // default Azure public domain "blob.core.windows.net" will be used. Check
 // the Azure Developer Guide for your particular cloud environment to see
 // the proper blob storage domain name to provide.
@@ -102,12 +102,12 @@ type Options struct {
 	// See https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1#shared-access-signature-parameters.
 	SASToken SASToken
 
-	// CloudEnvironment can be provided to specify an Azure Cloud Environment
+	// StorageDomain can be provided to specify an Azure Cloud Environment
 	// domain to target for the blob storage account (i.e. public, government, china).
 	// The default value is "blob.core.windows.net". Possible values will look similar
 	// to this but are different for each cloud (i.e. "blob.core.govcloudapi.net" for USGovernment).
 	// Check the Azure developer guide for the cloud environment where your bucket resides.
-	CloudEnvironment CloudEnvironment
+	StorageDomain StorageDomain
 }
 
 const (
@@ -143,8 +143,8 @@ func (o *lazyCredsOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.
 		accountName, _ := DefaultAccountName()
 		accountKey, _ := DefaultAccountKey()
 		sasToken, _ := DefaultSASToken()
-		cloudEnvironment, _ := DefaultCloudEnvironment()
-		o.opener, o.err = openerFromEnv(accountName, accountKey, sasToken, cloudEnvironment)
+		storageDomain, _ := DefaultStorageDomain()
+		o.opener, o.err = openerFromEnv(accountName, accountKey, sasToken, storageDomain)
 	})
 	if o.err != nil {
 		return nil, fmt.Errorf("open bucket %v: %v", u, o.err)
@@ -172,7 +172,7 @@ type URLOpener struct {
 	Options Options
 }
 
-func openerFromEnv(accountName AccountName, accountKey AccountKey, sasToken SASToken, cloudEnv CloudEnvironment) (*URLOpener, error) {
+func openerFromEnv(accountName AccountName, accountKey AccountKey, sasToken SASToken, storageDomain StorageDomain) (*URLOpener, error) {
 	// azblob.Credential is an interface; we will use either a SharedKeyCredential
 	// or anonymous credentials. If the former, we will also fill in
 	// Options.Credential so that SignedURL will work.
@@ -192,9 +192,9 @@ func openerFromEnv(accountName AccountName, accountKey AccountKey, sasToken SAST
 		AccountName: accountName,
 		Pipeline:    NewPipeline(credential, azblob.PipelineOptions{}),
 		Options: Options{
-			Credential:       storageAccountCredential,
-			SASToken:         sasToken,
-			CloudEnvironment: cloudEnv,
+			Credential:    storageAccountCredential,
+			SASToken:      sasToken,
+			StorageDomain: storageDomain,
 		},
 	}, nil
 }
@@ -236,9 +236,10 @@ type AccountKey string
 // https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1
 type SASToken string
 
-// CloudEnvironment is an Azure Cloud Environment domain name to target (i.e. AzureCloud, AzureUSGovernment, AzureChinaCloud).
-// It is read from the AZURE_BLOB_DOMAIN environment variable.
-type CloudEnvironment string
+// StorageDomain is an Azure Cloud Environment domain name to target
+// (i.e. blob.core.windows.net, blob.core.govcloudapi.net, blob.core.chinacloudapi.cn).
+// It is read from the AZURE_STORAGE_DOMAIN environment variable.
+type StorageDomain string
 
 // DefaultAccountName loads the Azure storage account name from the
 // AZURE_STORAGE_ACCOUNT environment variable.
@@ -270,14 +271,11 @@ func DefaultSASToken() (SASToken, error) {
 	return SASToken(s), nil
 }
 
-// DefaultCloudEnvironment loads the desired Azure Cloud to target from
-// the AZURE_BLOB_DOMAIN environment variable.
-func DefaultCloudEnvironment() (CloudEnvironment, error) {
-	s := os.Getenv("AZURE_BLOB_DOMAIN")
-	if s == "" {
-		return CloudEnvironment("blob.core.windows.net"), nil // If unspecified, use default public domain.
-	}
-	return CloudEnvironment(s), nil
+// DefaultStorageDomain loads the desired Azure Cloud to target from
+// the AZURE_STORAGE_DOMAIN environment variable.
+func DefaultStorageDomain() (StorageDomain, error) {
+	s := os.Getenv("AZURE_STORAGE_DOMAIN")
+	return StorageDomain(s), nil
 }
 
 // NewCredential creates a SharedKeyCredential.
@@ -327,11 +325,11 @@ func openBucket(ctx context.Context, pipeline pipeline.Pipeline, accountName Acc
 	if opts == nil {
 		opts = &Options{}
 	}
-	if opts.CloudEnvironment == "" {
-		// If opts.CloudEnvironment is missing, use default domain.
-		opts.CloudEnvironment = "blob.core.windows.net"
+	if opts.StorageDomain == "" {
+		// If opts.StorageDomain is missing, use default domain.
+		opts.StorageDomain = "blob.core.windows.net"
 	}
-	blobURL, err := url.Parse(fmt.Sprintf("https://%s.%s", accountName, opts.CloudEnvironment))
+	blobURL, err := url.Parse(fmt.Sprintf("https://%s.%s", accountName, opts.StorageDomain))
 	if err != nil {
 		return nil, err
 	}

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -322,15 +322,15 @@ func TestOpenBucket(t *testing.T) {
 
 func TestOpenerFromEnv(t *testing.T) {
 	tests := []struct {
-		name             string
-		accountName      AccountName
-		accountKey       AccountKey
-		cloudEnvironment CloudEnvironment
-		sasToken         SASToken
+		name          string
+		accountName   AccountName
+		accountKey    AccountKey
+		storageDomain StorageDomain
+		sasToken      SASToken
 
-		wantSharedCreds      bool
-		wantSASToken         SASToken
-		wantCloudEnvironment CloudEnvironment
+		wantSharedCreds   bool
+		wantSASToken      SASToken
+		wantStorageDomain StorageDomain
 	}{
 		{
 			name:            "AccountKey",
@@ -339,18 +339,18 @@ func TestOpenerFromEnv(t *testing.T) {
 			wantSharedCreds: true,
 		},
 		{
-			name:                 "SASToken",
-			accountName:          "myaccount",
-			sasToken:             "borkborkbork",
-			cloudEnvironment:     "mycloudenv",
-			wantSharedCreds:      false,
-			wantSASToken:         "borkborkbork",
-			wantCloudEnvironment: "mycloudenv",
+			name:              "SASToken",
+			accountName:       "myaccount",
+			sasToken:          "borkborkbork",
+			storageDomain:     "mycloudenv",
+			wantSharedCreds:   false,
+			wantSASToken:      "borkborkbork",
+			wantStorageDomain: "mycloudenv",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			o, err := openerFromEnv(test.accountName, test.accountKey, test.sasToken, test.cloudEnvironment)
+			o, err := openerFromEnv(test.accountName, test.accountKey, test.sasToken, test.storageDomain)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -375,8 +375,8 @@ func TestOpenerFromEnv(t *testing.T) {
 			if o.Options.SASToken != test.wantSASToken {
 				t.Errorf("Options.SASToken = %q; want %q", o.Options.SASToken, test.wantSASToken)
 			}
-			if o.Options.CloudEnvironment != test.wantCloudEnvironment {
-				t.Errorf("Options.CloudEnvironment = %q; want %q", o.Options.CloudEnvironment, test.wantCloudEnvironment)
+			if o.Options.StorageDomain != test.wantStorageDomain {
+				t.Errorf("Options.StorageDomain = %q; want %q", o.Options.StorageDomain, test.wantStorageDomain)
 			}
 		})
 	}

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -385,14 +385,14 @@ func TestOpenerFromEnv(t *testing.T) {
 func TestOpenBucketFromURL(t *testing.T) {
 	prevAccount := os.Getenv("AZURE_STORAGE_ACCOUNT")
 	prevKey := os.Getenv("AZURE_STORAGE_KEY")
-	prevEnv := os.Getenv("AZURE_CLOUD_ENVIRONMENT")
+	prevEnv := os.Getenv("AZURE_STORAGE_DOMAIN")
 	os.Setenv("AZURE_STORAGE_ACCOUNT", "my-account")
 	os.Setenv("AZURE_STORAGE_KEY", "bXlrZXk=") // mykey base64 encoded
-	os.Setenv("AZURE_CLOUD_ENVIRONMENT", "my-cloud")
+	os.Setenv("AZURE_STORAGE_DOMAIN", "my-cloud")
 	defer func() {
 		os.Setenv("AZURE_STORAGE_ACCOUNT", prevAccount)
 		os.Setenv("AZURE_STORAGE_KEY", prevKey)
-		os.Setenv("AZURE_CLOUD_ENVIRONMENT", prevEnv)
+		os.Setenv("AZURE_STORAGE_DOMAIN", prevEnv)
 	}()
 
 	tests := []struct {

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -54,7 +54,7 @@ import (
 
 const (
 	bucketName  = "go-cloud-bucket"
-	accountName = AccountName("my-account")
+	accountName = AccountName("gocloudblobtests")
 	cloudEnv    = CloudEnvironment("")
 )
 

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -52,7 +52,7 @@ import (
 
 const (
 	bucketName  = "go-cloud-bucket"
-	accountName = AccountName("gocloudblobtests")
+	accountName = AccountName("lbsaccount")
 )
 
 type harness struct {
@@ -325,10 +325,12 @@ func TestOpenerFromEnv(t *testing.T) {
 		name        string
 		accountName AccountName
 		accountKey  AccountKey
+		cloudEnvironment CloudEnvironment
 		sasToken    SASToken
 
 		wantSharedCreds bool
 		wantSASToken    SASToken
+		wantCloudEnvironment CloudEnvironment
 	}{
 		{
 			name:            "AccountKey",
@@ -340,13 +342,15 @@ func TestOpenerFromEnv(t *testing.T) {
 			name:            "SASToken",
 			accountName:     "myaccount",
 			sasToken:        "borkborkbork",
+			cloudEnvironment: "mycloudenv",
 			wantSharedCreds: false,
 			wantSASToken:    "borkborkbork",
+			wantCloudEnvironment: "mycloudenv",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			o, err := openerFromEnv(test.accountName, test.accountKey, test.sasToken)
+			o, err := openerFromEnv(test.accountName, test.accountKey, test.sasToken, test.cloudEnvironment)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -370,6 +374,9 @@ func TestOpenerFromEnv(t *testing.T) {
 			}
 			if o.Options.SASToken != test.wantSASToken {
 				t.Errorf("Options.SASToken = %q; want %q", o.Options.SASToken, test.wantSASToken)
+			}
+			if o.Options.CloudEnvironment != test.wantCloudEnvironment {
+				t.Errorf("Options.CloudEnvironment = %q; want %q", o.Options.CloudEnvironment, test.wantCloudEnvironment)
 			}
 		})
 	}

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -39,10 +39,8 @@ import (
 //
 // 3. Locate the Access Key (Primary or Secondary) under your Storage Account > Settings > Access Keys.
 //
-// 4. Set the environment variables AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY, and AZURE_CLOUD_ENVIRONMENT to
-//    the storage account name, your access key, and the Azure Cloud Environment. Possible cloud environments
-// 	  are "AzureCloud", "AzureUSGovernment", "AzureChinaCloud", and "AzureGermanCloud". If you want to leave
-// 	  AZURE_CLOUD_ENVIRONMENT unset, use "" for cloudEnv
+// 4. Set the environment variables AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY to
+//    the storage account name and your access key.
 //
 // 5. Create a container in your Storage Account > Blob. Update the bucketName
 // constant to your container name.
@@ -54,8 +52,7 @@ import (
 
 const (
 	bucketName  = "go-cloud-bucket"
-	accountName = AccountName("gocloudblobtests")
-	cloudEnv    = CloudEnvironment("")
+	accountName = AccountName("lbsaccount")
 )
 
 type harness struct {
@@ -78,13 +75,6 @@ func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
 		key, err = DefaultAccountKey()
 		if err != nil {
 			t.Fatal(err)
-		}
-		env, err := DefaultCloudEnvironment()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if env != cloudEnv {
-			t.Fatalf("Please update the cloudEnv constant to match your settings file so future records work (%q vs %q)", env, cloudEnv)
 		}
 	} else {
 		// In replay mode, we use fake credentials.
@@ -123,7 +113,7 @@ func (h *harness) HTTPClient() *http.Client {
 }
 
 func (h *harness) MakeDriver(ctx context.Context) (driver.Bucket, error) {
-	return openBucket(ctx, h.pipeline, accountName, bucketName, &Options{Credential: h.credential, CloudEnvironment: cloudEnv})
+	return openBucket(ctx, h.pipeline, accountName, bucketName, &Options{Credential: h.credential})
 }
 
 func (h *harness) Close() {

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -52,7 +52,7 @@ import (
 
 const (
 	bucketName  = "go-cloud-bucket"
-	accountName = AccountName("lbsaccount")
+	accountName = AccountName("gocloudblobtests")
 )
 
 type harness struct {


### PR DESCRIPTION
Fixes #2716
Updated 12/24/19 to reflect changes in implementation:
The current go-cloud azureblob implementation always targets "blob.core.windows.net" when attempting to open a bucket, making USGovernment, China, and German cloud buckets inaccessible. 

With this addition, users can specify the Azure Cloud Environment they would like to target by setting  the AZURE_STORAGE_DOMAIN environment variable to a value like "blob.core.govcloudapi.net", "blob.core.chinacloudapi.cn", etc. allowing them to access the different Azure blob storage endpoints for each of these clouds. 

If users leave the AZURE_STORAGE_DOMAIN variable unset, the bucket opener will target "blob.core.windows.net" by default, which is the public domain that most users are likely already using. Any changes made by this request should be transparent to end users who have not been setting this environment variable. 

If you have any questions or feedback regarding this change, please let me know! Thank you! 🙂 