### PR TITLE
blob: Let readFromWriteTo return the original err

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -163,7 +163,7 @@ func readFromWriteTo(r io.Reader, w io.Writer) (int64, int64, error) {
 			numWritten, werr := w.Write(buf[0:numRead])
 			totalWritten += int64(numWritten)
 			if werr != nil {
-				return totalRead, totalWritten, fmt.Errorf("failed to write: %v", werr)
+				return totalRead, totalWritten, werr
 			}
 		}
 		if rerr == io.EOF {
@@ -171,7 +171,7 @@ func readFromWriteTo(r io.Reader, w io.Writer) (int64, int64, error) {
 			return totalRead, totalWritten, nil
 		}
 		if rerr != nil {
-			return totalRead, totalWritten, fmt.Errorf("failed to read: %v", rerr)
+			return totalRead, totalWritten, rerr
 		}
 	}
 }


### PR DESCRIPTION
Allows the caller to detect the error type instead of returning a
formatted string