### PR TITLE
Add Header and Body to Entry struct to allow logging Request details

### DIFF
--- a/server/requestlog/requestlog.go
+++ b/server/requestlog/requestlog.go
@@ -67,6 +67,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		RemoteIP:          ipFromHostPort(r.RemoteAddr),
 		TraceID:           sc.TraceID,
 		SpanID:            sc.SpanID,
+		Request:           r,
 	}
 	if addr, ok := r.Context().Value(http.LocalAddrContextKey).(net.Addr); ok {
 		ent.ServerIP = ipFromHostPort(addr.String())
@@ -114,6 +115,7 @@ type Entry struct {
 	Latency            time.Duration
 	TraceID            trace.TraceID
 	SpanID             trace.SpanID
+	Request            *http.Request
 }
 
 func ipFromHostPort(hp string) string {

--- a/server/requestlog/requestlog.go
+++ b/server/requestlog/requestlog.go
@@ -67,7 +67,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		RemoteIP:          ipFromHostPort(r.RemoteAddr),
 		TraceID:           sc.TraceID,
 		SpanID:            sc.SpanID,
-		Request:           r,
+		Header:            r.Header,
+		Body:              r.Body,
 	}
 	if addr, ok := r.Context().Value(http.LocalAddrContextKey).(net.Addr); ok {
 		ent.ServerIP = ipFromHostPort(addr.String())
@@ -115,7 +116,8 @@ type Entry struct {
 	Latency            time.Duration
 	TraceID            trace.TraceID
 	SpanID             trace.SpanID
-	Request            *http.Request
+	Header             http.Header
+	Body               io.ReadCloser
 }
 
 func ipFromHostPort(hp string) string {


### PR DESCRIPTION
Fixes #2734 

This commit brings the `http.Request` into the `requestlog.Entry` struct so developers have access to it when logging using the `Log` method of the `requestlog.Logger` interface.

Thanks so much for your consideration of this!

Best,

Dan