### PR TITLE
GCP: Add NewAnonymousHTTPClient

### DIFF
--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -45,6 +45,15 @@ type HTTPClient struct {
 	http.Client
 }
 
+// NewAnonymousHTTPClient creates a new anonymous HTTP client.
+func NewAnonymousHTTPClient(transport http.RoundTripper) *HTTPClient {
+	return &HTTPClient{
+		Client: http.Client{
+			Transport: transport,
+		},
+	}
+}
+
 // NewHTTPClient creates a new authenticated HTTP client.
 func NewHTTPClient(transport http.RoundTripper, ts TokenSource) (*HTTPClient, error) {
 	if ts == nil {


### PR DESCRIPTION
Currently, an anonymous GCP client has to be constructed manually via
```
client := &gcp.HTTPClient{Client: http.Client{Transport: gcp.DefaultTransport()}}
```

While this works, it is not very intuitive. This PR adds a simple
constructor for an anonymous client, making sure this capability is
visible in the godocs and easy to discover.