### PR TITLE
runtimevar/awsparamstore: Use WithDecryption=true to decrypt encrypted parameters

### DIFF
--- a/runtimevar/awsparamstore/awsparamstore.go
+++ b/runtimevar/awsparamstore/awsparamstore.go
@@ -251,7 +251,11 @@ func (w *watcher) WatchVariable(ctx context.Context, prev driver.State) (driver.
 	}
 	// GetParameter from S3 to get the current value and version.
 	svc := ssm.New(w.sess)
-	getResp, err := svc.GetParameter(&ssm.GetParameterInput{Name: aws.String(w.name)})
+	getResp, err := svc.GetParameter(&ssm.GetParameterInput{
+		Name: aws.String(w.name),
+		// Ignored if the parameter is not encrypted.
+		WithDecryption: aws.Bool(true),
+	})
 	if err != nil {
 		return errorState(err, prev), w.wait
 	}

--- a/runtimevar/awsparamstore/testdata/TestConformance/TestAs/verify_As.replay
+++ b/runtimevar/awsparamstore/testdata/TestConformance/TestAs/verify_As.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7U35N8OJ//vP5c",
+  "Initial": "AQAAAA7WFu1CJSD0V/5c",
   "Version": "0.2",
   "Converter": {
     "ClearHeaders": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "7540c3957bac3ffa",
+      "ID": "20c255b31cb6c3f1",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -49,7 +49,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "26"
+            "48"
           ],
           "User-Agent": [
             "CLEARED"
@@ -63,7 +63,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidmFyaWFibGUtZm9yLWFzIn0="
+          "eyJOYW1lIjoidmFyaWFibGUtZm9yLWFzIiwiV2l0aERlY3J5cHRpb24iOnRydWV9"
         ]
       },
       "Response": {
@@ -82,17 +82,17 @@
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:17:00 GMT"
+            "Wed, 01 Apr 2020 20:14:57 GMT"
           ],
           "X-Amzn-Requestid": [
-            "74c1bd05-63f8-4cc1-b608-6eeb8a2549a4"
+            "0fd5f431-65f4-406a-9d27-029c0400a791"
           ]
         },
         "Body": "H4sIAAAAAAAAAKtWio8vqSxIVbJSCkgsSsxNLUkt8ssvccsvzUtRqgUAF48DRR4AAAA="
       }
     },
     {
-      "ID": "9ce195d02c41dfdf",
+      "ID": "7e7bba0af8afccbf",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -128,23 +128,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "33"
+            "51"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:17:01 GMT"
+            "Wed, 01 Apr 2020 20:14:58 GMT"
           ],
           "X-Amzn-Requestid": [
-            "67e8ac32-b46f-4a4e-b770-ad3649eb52c4"
+            "1773c6f6-c6d8-4da3-b29b-5229271386ab"
           ]
         },
-        "Body": "H4sIAAAAAAAAAKtWCkstKs7Mz1OyMqwFAOQVrPcNAAAA"
+        "Body": "H4sIAAAAAAAAAKtWCslMLVKyUgouScxLSSxKUdJRCkstKs7Mz1OyMqwFAFB+6N8fAAAA"
       }
     },
     {
-      "ID": "31e6dc400642a7ac",
+      "ID": "14d0637c37850165",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -153,7 +153,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "26"
+            "48"
           ],
           "User-Agent": [
             "CLEARED"
@@ -167,7 +167,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidmFyaWFibGUtZm9yLWFzIn0="
+          "eyJOYW1lIjoidmFyaWFibGUtZm9yLWFzIiwiV2l0aERlY3J5cHRpb24iOnRydWV9"
         ]
       },
       "Response": {
@@ -180,23 +180,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "170"
+            "179"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:17:01 GMT"
+            "Wed, 01 Apr 2020 20:14:58 GMT"
           ],
           "X-Amzn-Requestid": [
-            "9661b46f-f58c-449b-b5c3-f7baaffacd8c"
+            "8690954c-7a03-444f-b01c-8388c52941be"
           ]
         },
-        "Body": "H4sIAAAAAAAAAGWNzQ6CMBCEX8XsmaoUCro3E70pMWq8r2HRJoWSFiSG8O6WgyeP8/PNjHAmRzV37ABH2F0KQCDXIA0eva+x94LJd0Jimslks5ZS5VJi+6NWb3KaHoZFZZ0gDxEcQ/9kS11pLvfUMWC8VJlKsjyVsVLqsI2gCHR4+odvn3YOrp3TzTPoO5l+Nl5sjF0M1plydtl5bZuwPE1fLctI88MAAAA="
+        "Body": "H4sIAAAAAAAAAGXMwQ6CMBAE0F8xPYNCFYHeTPSmxKjxvoZFmxRKtkU0hH93SfTkcWYybxBHIKjRIwk1iM2pEEoANQp6p5yrVedCBOdDqVZrucwiKZNUStX+XosnkIabwbCyFIITgdiCh8u7RZY8vjw3exYOttSVxpJXXuJ5kiVpKqM8j7N4lweiYI8f/9yXOnvSzZ3zFUw3FQ80xs56S6acWiSnbcPyOH4AqDFms9UAAAA="
       }
     },
     {
-      "ID": "9fa6f30d8a556ae8",
+      "ID": "3ca2609ce2464d88",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -232,23 +232,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "177"
+            "187"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:17:01 GMT"
+            "Wed, 01 Apr 2020 20:14:58 GMT"
           ],
           "X-Amzn-Requestid": [
-            "17f07d38-6cf3-4228-8f43-5794d4559f2f"
+            "edc1e219-d7b3-4410-bdad-e24f4803162c"
           ]
         },
-        "Body": "H4sIAAAAAAAAAFWOPQ+CMBCG/8vN4EehoJ11U0MiuhiHUw5yCRRzrRhD+O9WN8d7v+4ZoUDBjjyJA3MZYYfO7/uKa6Zqg57ALGc600mWp2qptd6uo7/MyZGAARRr8OUMY2dMmqlktVBK50qZZwjMZUDbkPUQwSF8C4UBhfHWUlz3EqMLRtG3fGf6YlwjKPm3e/RoK5Qq+OX7QT9F2DbhPgdk7m0AnK7TB1qdGL7IAAAA"
+        "Body": "H4sIAAAAAAAAAFWPwQ6CQAxE/2XPoLKKwJ71poYE9GI4VCmkCSymu6LG+O9W48Vj82Y6M0+VA0OPHtkpc3yqFXgoHxdURnm8exWoDTi/HWpqCGuhQqJJnMZJomdZFqXROvvX7B2yuIGtgZszBL0xi6WepzOt40RrcxXBlEewLdpPwE7yxTACE5w6DJuBQ3AC8qGjM+GnWBWokr5/Cw+2Bq6F/3oWnsm2ch9kBA1WCr6q1xswU1j22gAAAA=="
       }
     },
     {
-      "ID": "0e94432c7a7aef41",
+      "ID": "e5f5a57000dcace6",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -290,10 +290,10 @@
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:17:01 GMT"
+            "Wed, 01 Apr 2020 20:14:59 GMT"
           ],
           "X-Amzn-Requestid": [
-            "ba05bacf-42db-4e2e-a647-5ae705833f50"
+            "2ea47ba8-8168-41d6-8384-b576274ae8eb"
           ]
         },
         "Body": "H4sIAAAAAAAAAKuuBQBDv6ajAgAAAA=="

--- a/runtimevar/awsparamstore/testdata/TestConformance/TestAs/verify_As_returns_false_when_passed_nil.replay
+++ b/runtimevar/awsparamstore/testdata/TestConformance/TestAs/verify_As_returns_false_when_passed_nil.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7U35N9OYT0dP5c",
+  "Initial": "AQAAAA7WFu1DHpuxNf5c",
   "Version": "0.2",
   "Converter": {
     "ClearHeaders": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "afb90a2b584a7420",
+      "ID": "3d82a61dd0d82f4d",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -49,7 +49,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "26"
+            "48"
           ],
           "User-Agent": [
             "CLEARED"
@@ -63,7 +63,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidmFyaWFibGUtZm9yLWFzIn0="
+          "eyJOYW1lIjoidmFyaWFibGUtZm9yLWFzIiwiV2l0aERlY3J5cHRpb24iOnRydWV9"
         ]
       },
       "Response": {
@@ -82,17 +82,17 @@
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:17:02 GMT"
+            "Wed, 01 Apr 2020 20:14:59 GMT"
           ],
           "X-Amzn-Requestid": [
-            "909b8db9-7b12-4eb1-be4e-87dd93e702ba"
+            "c5cff77a-2042-45a6-a883-e169e6437162"
           ]
         },
         "Body": "H4sIAAAAAAAAAKtWio8vqSxIVbJSCkgsSsxNLUkt8ssvccsvzUtRqgUAF48DRR4AAAA="
       }
     },
     {
-      "ID": "a6abfda35fda72bd",
+      "ID": "e2303de5e202eba6",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -128,23 +128,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "33"
+            "51"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:17:02 GMT"
+            "Wed, 01 Apr 2020 20:14:59 GMT"
           ],
           "X-Amzn-Requestid": [
-            "9e360867-450d-434b-a622-bbaec59a9373"
+            "3f6c14f0-154e-450d-aa79-90845127e731"
           ]
         },
-        "Body": "H4sIAAAAAAAAAKtWCkstKs7Mz1OyMqwFAOQVrPcNAAAA"
+        "Body": "H4sIAAAAAAAAAKtWCslMLVKyUgouScxLSSxKUdJRCkstKs7Mz1OyMqwFAFB+6N8fAAAA"
       }
     },
     {
-      "ID": "8dff3d1bb25f45aa",
+      "ID": "6b9031fefe2710fe",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -153,7 +153,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "26"
+            "48"
           ],
           "User-Agent": [
             "CLEARED"
@@ -167,7 +167,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidmFyaWFibGUtZm9yLWFzIn0="
+          "eyJOYW1lIjoidmFyaWFibGUtZm9yLWFzIiwiV2l0aERlY3J5cHRpb24iOnRydWV9"
         ]
       },
       "Response": {
@@ -180,23 +180,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "170"
+            "179"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:17:02 GMT"
+            "Wed, 01 Apr 2020 20:14:59 GMT"
           ],
           "X-Amzn-Requestid": [
-            "4418aa3c-26c6-43ba-9ba3-a44a19d3ec23"
+            "2bcdf5e4-aaa1-4e3e-a488-329dd60241c9"
           ]
         },
-        "Body": "H4sIAAAAAAAAAGWNuQ7CMBBEfwVtHXM4J9shQQcRAkS/KBuw5MSR7RChKP+OU1BRzvFmRjiTpYY9W8ARdpcSEMi2SIND5xrsnWByXkhMMhkXaynTXErsftTqTVbRQ7OojRXkIIJj6J9MpWrF1Z48A26WaZbGWZ4EukgP2wjKQIenf/j26ebg6q1qn0HfSfez8WKtzWIwVlezy9Yp04blafoCy2mTIMMAAAA="
+        "Body": "H4sIAAAAAAAAAGXMwQrCMBAE0F+RnI2m0diam6A3LaLifaVbDaRNSVKrlP67W9CTx5lhXs+O4KHCiJ7pnm1OOdMMfK2hCzqESreBI4TIpV6u5CITUqpUSt38XvMneAM3i7x0nkNgU7aFCJd3gyRFfEVq9iQcXGFKgwWttCQzlak0lYkQIlO79ZTl5NHjn/tS5+hNfad8BduOxQOtdZPOeVuMLfpgXE3yMHwAQrMU09UAAAA="
       }
     },
     {
-      "ID": "63f1d2f7373023c4",
+      "ID": "10f4ec7f6473e8aa",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -232,23 +232,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "177"
+            "187"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:17:02 GMT"
+            "Wed, 01 Apr 2020 20:14:59 GMT"
           ],
           "X-Amzn-Requestid": [
-            "b2c43675-ee47-4dc9-87ef-cc3e5f299602"
+            "d5b1c655-873f-4ec7-affd-43e2d5edc5e1"
           ]
         },
-        "Body": "H4sIAAAAAAAAAFWOPQ+CMBCG/8vN4EehoJ11U0MiuhiHUw5yCRRzrRhD+O9WN8d7v+4ZoUDBjjyJA3MZYYfO7/uKa6Zqg57ALGc600mWp2qptd6uo7/MyZGAARRr8OUMY2dMmqlktVBK50qZZwjMZUDbkPUQwSF8C4UBhfHWUlz3EqMLRtG3fGf6YlwjKPm3e/RoK5Qq+OX7QT9F2DbhPgdk7m0AnK7TB1qdGL7IAAAA"
+        "Body": "H4sIAAAAAAAAAFWPwQ6CQAxE/2XPoLKKwJ71poYE9GI4VCmkCSymu6LG+O9W48Vj82Y6M0+VA0OPHtkpc3yqFXgoHxdURnm8exWoDTi/HWpqCGuhQqJJnMZJomdZFqXROvvX7B2yuIGtgZszBL0xi6WepzOt40RrcxXBlEewLdpPwE7yxTACE5w6DJuBQ3AC8qGjM+GnWBWokr5/Cw+2Bq6F/3oWnsm2ch9kBA1WCr6q1xswU1j22gAAAA=="
       }
     },
     {
-      "ID": "4c4a0e86dcb2b1bd",
+      "ID": "623e6580b18a53bf",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -290,10 +290,10 @@
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:17:02 GMT"
+            "Wed, 01 Apr 2020 20:14:59 GMT"
           ],
           "X-Amzn-Requestid": [
-            "9a773521-dc22-4869-8fcb-9defb47a57c3"
+            "f15df7e6-527a-43ef-845a-c2147b52fad1"
           ]
         },
         "Body": "H4sIAAAAAAAAAKuuBQBDv6ajAgAAAA=="

--- a/runtimevar/awsparamstore/testdata/TestConformance/TestDelete.replay
+++ b/runtimevar/awsparamstore/testdata/TestConformance/TestDelete.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7U35N6EiKqxf5c",
+  "Initial": "AQAAAA7WFu1ADqofRf5c",
   "Version": "0.2",
   "Converter": {
     "ClearHeaders": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "ca0cc2fadf914727",
+      "ID": "8ede4402fee50619",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -76,23 +76,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "33"
+            "51"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:57 GMT"
+            "Wed, 01 Apr 2020 20:14:56 GMT"
           ],
           "X-Amzn-Requestid": [
-            "68bde83c-f8d5-44f8-8651-1618d8d66c46"
+            "bf4e25f1-b300-4785-90d2-f9abc3217fef"
           ]
         },
-        "Body": "H4sIAAAAAAAAAKtWCkstKs7Mz1OyMqwFAOQVrPcNAAAA"
+        "Body": "H4sIAAAAAAAAAKtWCslMLVKyUgouScxLSSxKUdJRCkstKs7Mz1OyMqwFAFB+6N8fAAAA"
       }
     },
     {
-      "ID": "fae1cc3a9b1a715b",
+      "ID": "5842db92191541aa",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -101,7 +101,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "31"
+            "53"
           ],
           "User-Agent": [
             "CLEARED"
@@ -115,7 +115,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUifQ=="
+          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUiLCJXaXRoRGVjcnlwdGlvbiI6dHJ1ZX0="
         ]
       },
       "Response": {
@@ -128,23 +128,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "174"
+            "182"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:57 GMT"
+            "Wed, 01 Apr 2020 20:14:56 GMT"
           ],
           "X-Amzn-Requestid": [
-            "dfd16882-87ce-4421-b810-182cf22afbed"
+            "4735e5d0-d792-4146-bfb7-75ffa5632d61"
           ]
         },
-        "Body": "H4sIAAAAAAAAAHWNwQ6CMBBEf8XsGVQKFO3NRG9KjBrvqyzYpLSkLRJD+HfLwaPHmcl7M8IZLbbkyYIYYXcpQQBaLXBwwrlW9C4mdD5mIuMs3awZywvGRPejVp7C+jS6lk38RivxoQgiOAboZCpZS6r26AlEssx5nvIiSzacF4dtBGVQhLs/htunm9ert1I3Id9R9XPxIqXMYjBWVXNL1kmjg36avsZQRaLNAAAA"
+        "Body": "H4sIAAAAAAAAAG2Myw6CMBBFf8V0LYrV8ujORHdKjBr3owzYpFDSFtEQ/t3B6M7lPSf39OwAFir0aJns2fqYMcnA1hI6J52rZOsCBOcDLlcRXyYh5yLmXDa/19wj2ZupC1UGD7AKrhrZlG3Aw/nVIOU8Pj2RHWX2JleFwpwsmcVMJCKOeZhGIoy36ZRlFP08/ja/vZO3qi5pX0C3I7ij1mbSGavzkaJ1ytSUH4Y3PMFqat8AAAA="
       }
     },
     {
-      "ID": "b231dd157bb92398",
+      "ID": "c370f4eb8ddc12a0",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -180,23 +180,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "180"
+            "189"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:57 GMT"
+            "Wed, 01 Apr 2020 20:14:56 GMT"
           ],
           "X-Amzn-Requestid": [
-            "c8f99d57-4135-4e05-9114-1d38164b4291"
+            "3ef33a2d-c7e7-43a5-a8a7-8721e2fd261f"
           ]
         },
-        "Body": "H4sIAAAAAAAAAFWOPQ+CMBCG/8vNoFK+tLNuakhEF8Nw0oNcAsW0FWMI/93K5njv1z0TFGiwJ0fGgrxPcETrToPihknt0RHIaJVmaZzlSZRFiTjsgr/M1ZIBCWi0xLeVjL2USSbi7UaINBdCvnxgbUbULWkHAZz9N19wZF1YD7rhNhzRMD468m4xdFwz/ViqAEpexi8OtUKjvF9+nrQohnXr75vn5kF7yrmav1ourBTNAAAA"
+        "Body": "H4sIAAAAAAAAAFWPOQ4CMQxF7+KaYQmEYVJDBwiJpUEUZmJGliBBTtiEuDsG0VBa79v/+QkLFDxRJkngtk8YY8bV40zgINM9QwummPIsej4weaVKem07smVputXAVHZS/WfWiUS3UYLDW3KMJ+cGQ9MfdY2xpTHuooGOXDE0FD4Fc+3/1qVc1DEcuCmuKIz7IyldxCPXTB+7XQtW/D2+zBg8ilf+k11m4dDovNFPOAa1fO1ebz5OFl7fAAAA"
       }
     },
     {
-      "ID": "2b07d39b94684998",
+      "ID": "ebd8f6121dbeeb17",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -238,17 +238,17 @@
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:56 GMT"
           ],
           "X-Amzn-Requestid": [
-            "54b08704-f95a-4a9f-ba28-ff9240d9bb43"
+            "3b843f09-2bc8-4212-adb6-f69a66583c82"
           ]
         },
         "Body": "H4sIAAAAAAAAAKuuBQBDv6ajAgAAAA=="
       }
     },
     {
-      "ID": "81e1bdf82591ad9c",
+      "ID": "7c0b11012a179ffa",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -257,7 +257,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "31"
+            "53"
           ],
           "User-Agent": [
             "CLEARED"
@@ -271,7 +271,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUifQ=="
+          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUiLCJXaXRoRGVjcnlwdGlvbiI6dHJ1ZX0="
         ]
       },
       "Response": {
@@ -290,17 +290,17 @@
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:56 GMT"
           ],
           "X-Amzn-Requestid": [
-            "42e4a9ea-ebe7-4c3b-8c2a-0828cc96cbe4"
+            "3f2d90eb-69d8-4d3a-bee3-4b0443fe6b11"
           ]
         },
         "Body": "H4sIAAAAAAAAAKtWio8vqSxIVbJSCkgsSsxNLUkt8ssvccsvzUtRqgUAF48DRR4AAAA="
       }
     },
     {
-      "ID": "dc7b78a3c45c7434",
+      "ID": "6aa601716ede27a3",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -336,23 +336,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "33"
+            "51"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:57 GMT"
           ],
           "X-Amzn-Requestid": [
-            "8adbedf8-7d41-40c3-ba1d-d9c6615be087"
+            "f500a5a2-ad4d-42da-b848-8f98b5a573f4"
           ]
         },
-        "Body": "H4sIAAAAAAAAAKtWCkstKs7Mz1OyMqwFAOQVrPcNAAAA"
+        "Body": "H4sIAAAAAAAAAKtWCslMLVKyUgouScxLSSxKUdJRCkstKs7Mz1OyMqwFAFB+6N8fAAAA"
       }
     },
     {
-      "ID": "07639f31b88845a5",
+      "ID": "946218e09727cf6b",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -361,7 +361,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "31"
+            "53"
           ],
           "User-Agent": [
             "CLEARED"
@@ -375,7 +375,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUifQ=="
+          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUiLCJXaXRoRGVjcnlwdGlvbiI6dHJ1ZX0="
         ]
       },
       "Response": {
@@ -388,23 +388,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "176"
+            "184"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:57 GMT"
           ],
           "X-Amzn-Requestid": [
-            "f6feb517-55e9-4c14-b8d6-3221c7e66ad2"
+            "0b25bf0b-3b7d-4602-86c5-c14eba4093e2"
           ]
         },
-        "Body": "H4sIAAAAAAAAAHWNyw6CMBREf8XcNaiUl3RnojslRo37i72QJtCStkgI4d8tC5cuZ07mzAw3NNiRIwN8huO9BA5oFMfRcms7PtiQ0LqQ8SRj8WHPWJozxvvfaufI07dWtWzCDxqJVUsQwMWPrlrIWpI4oSPg0TbN0jjLk6hIovxcBFB6hb/7Y3hO/UofzkjV+PzCdliLRmtRTbQZtWnF2pOxUit/sCxf4IttP88AAAA="
+        "Body": "H4sIAAAAAAAAAG2NwQ6CMBAFf8X0DApVLPRmojclRo33RRbSBChpi0gI/+5i9OZxZ/JmR3YGAzU6NEyObHdJmWRgGgm9ldbWsrM+gnU+l5stX8cB55HgXLa/1coh2YduClX6TzAKsgqZx/bg4Da0SDmHL0fkSJmTzlWhMCdLJlxGcSQEDxIRJuKQeCyl6Gfxt/ntXZ1RTUn3HapuBqXWeTbgotemymeOxird0INpegNHfpkt4QAAAA=="
       }
     },
     {
-      "ID": "aba6342bd0fd0751",
+      "ID": "92c0a3e76de44be4",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -440,23 +440,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "181"
+            "189"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:57 GMT"
           ],
           "X-Amzn-Requestid": [
-            "bec556fc-2012-4b80-adbf-0bc395782558"
+            "d8863588-912b-463d-b1a7-345e8006df93"
           ]
         },
-        "Body": "H4sIAAAAAAAAAFWOPQ+CMBCG/8vNoFK+pLNuakhEF8Nw2oNcAsW0FWMI/93K5njv1z0TlGiwJ0fGgrxNcEDrjoPihknt0BHIaJVmaZzlSVQkUb4vgr/MxZIBCWi0xLeVjL2USSbi7UaINBdCvnxgbUbULWkHAZz8N19wZF34GHTDbTiiYbx35N1y6PjB9GOpA6h4GT871AqN8n71edKiGNatv6+emwftKed6/gJKUWXczQAAAA=="
+        "Body": "H4sIAAAAAAAAAFWPOQ4CMQxF7+KaYQmEYVJDBwiJpUEUZmJGliBBTtiEuDsG0VBa79v/+QkLFDxRJkngtk8YY8bV40zgINM9QwummPIsej4weaVKem07smVputXAVHZS/WfWiUS3UYLDW3KMJ+cGQ9MfdY2xpTHuooGOXDE0FD4Fc+3/1qVc1DEcuCmuKIz7IyldxCPXTB+7XQtW/D2+zBg8ilf+k11m4dDovNFPOAa1fO1ebz5OFl7fAAAA"
       }
     },
     {
-      "ID": "3789ecce53447c74",
+      "ID": "bf7bfe488dc88b7d",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -498,10 +498,10 @@
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:57 GMT"
           ],
           "X-Amzn-Requestid": [
-            "4b698bd8-e198-42a4-aaf2-8647723c7f3f"
+            "13742f08-cec6-4d27-bf9e-f8edb7ef7b21"
           ]
         },
         "Body": "H4sIAAAAAAAAAKuuBQBDv6ajAgAAAA=="

--- a/runtimevar/awsparamstore/testdata/TestConformance/TestInvalidJSON.replay
+++ b/runtimevar/awsparamstore/testdata/TestConformance/TestInvalidJSON.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7U35N4H29sIP5c",
+  "Initial": "AQAAAA7WFu0+J56/mf5c",
   "Version": "0.2",
   "Converter": {
     "ClearHeaders": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "a3ec9ec27c58087e",
+      "ID": "c961810c61ab4716",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -76,23 +76,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "33"
+            "51"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:54 GMT"
           ],
           "X-Amzn-Requestid": [
-            "21accc9c-b664-4e1e-a099-5790c31add92"
+            "a75c21bb-0460-4239-93a7-d37357e680ee"
           ]
         },
-        "Body": "H4sIAAAAAAAAAKtWCkstKs7Mz1OyMqwFAOQVrPcNAAAA"
+        "Body": "H4sIAAAAAAAAAKtWCslMLVKyUgouScxLSSxKUdJRCkstKs7Mz1OyMqwFAFB+6N8fAAAA"
       }
     },
     {
-      "ID": "190adfcb1da8e725",
+      "ID": "2304d71862ccff2d",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -101,7 +101,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "31"
+            "53"
           ],
           "User-Agent": [
             "CLEARED"
@@ -115,7 +115,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUifQ=="
+          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUiLCJXaXRoRGVjcnlwdGlvbiI6dHJ1ZX0="
         ]
       },
       "Response": {
@@ -128,23 +128,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "172"
+            "179"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:54 GMT"
           ],
           "X-Amzn-Requestid": [
-            "0ea58f85-aa9b-4551-b552-e9e9d66d8595"
+            "0eafeb16-b360-4299-867f-d2275ae78674"
           ]
         },
-        "Body": "H4sIAAAAAAAAAHWNMQ+CMBSE/8ubqUqBFt9mopsSo8b9qYXUQEvaojGE/24ZHN3u7svdjXAkR50KygGOsDlVgEDOIL09et/h4JkiHxjHXPCsXHFeSM6x/7WWQUV6t6bWDXuR03RrFSSwj6WDfehaq8eWggJMF4UoMiHzVMhS7tYJVHEi3v1ZuHz6mZ6D06aJ/krtMAfGBvb01syRcl5Hhek0fQF2S+vDygAAAA=="
+        "Body": "H4sIAAAAAAAAAG2MzQ6CMBAG36VnqlhAoDcTvSkxaryvspAaaElb/Anh3V2M3rztzuSbge3BQoseLZMDWx0KJhlYLeHhpHOt7B1HcJ4LGS9FlIVCJKkQsvut5h7JXo2uVM3vYBVcGmQBW4OH06tDynl8eiJbyuxMqSqFJVkyi1mSJWkqwjzOo2iTB6yg6Gfxt/ntHb1Vuqb/DE0/AW08vzmjJ4TWKbrkYhzfMPIh6dwAAAA="
       }
     },
     {
-      "ID": "61af9f016c56e607",
+      "ID": "a2ea3d4f97583589",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -180,23 +180,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "180"
+            "189"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:54 GMT"
           ],
           "X-Amzn-Requestid": [
-            "66faa9bb-e63e-412b-91cd-102fe1b59d2e"
+            "2db31af0-fece-4c30-a9a1-5c15f112b855"
           ]
         },
-        "Body": "H4sIAAAAAAAAAFWOPQ+CMBCG/8vNoFK+tLNuakhEF8Nw0oNcAsW0FWMI/93K5njv1z0TFGiwJ0fGgrxPcETrToPihknt0RHIaJVmaZzlSZRFiTjsgr/M1ZIBCWi0xLeVjL2USSbi7UaINBdCvnxgbUbULWkHAZz9N19wZF1YD7rhNhzRMD468m4xdFwz/ViqAEpexi8OtUKjvF9+nrQohnXr75vn5kF7yrmav1ourBTNAAAA"
+        "Body": "H4sIAAAAAAAAAFWPOQ4CMQxF7+KaYQmEYVJDBwiJpUEUZmJGliBBTtiEuDsG0VBa79v/+QkLFDxRJkngtk8YY8bV40zgINM9QwummPIsej4weaVKem07smVputXAVHZS/WfWiUS3UYLDW3KMJ+cGQ9MfdY2xpTHuooGOXDE0FD4Fc+3/1qVc1DEcuCmuKIz7IyldxCPXTB+7XQtW/D2+zBg8ilf+k11m4dDovNFPOAa1fO1ebz5OFl7fAAAA"
       }
     },
     {
-      "ID": "5c232d7be3896ed8",
+      "ID": "c125bc28c3a2d221",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -238,10 +238,10 @@
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:55 GMT"
           ],
           "X-Amzn-Requestid": [
-            "0c2c1c8c-d86c-47f3-a873-44297f4dd16b"
+            "b0fe39ea-f18f-4084-b924-67432c8d3f5b"
           ]
         },
         "Body": "H4sIAAAAAAAAAKuuBQBDv6ajAgAAAA=="

--- a/runtimevar/awsparamstore/testdata/TestConformance/TestJSON.replay
+++ b/runtimevar/awsparamstore/testdata/TestConformance/TestJSON.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7U35N3MzFQD/5c",
+  "Initial": "AQAAAA7WFu0+AWv+N/5c",
   "Version": "0.2",
   "Converter": {
     "ClearHeaders": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "2e59efe1cad1e945",
+      "ID": "68a98257c42a2de2",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -76,23 +76,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "33"
+            "51"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:53 GMT"
           ],
           "X-Amzn-Requestid": [
-            "c2a6b404-871a-41b2-ae8e-21432f9fd0a5"
+            "74e3c207-1787-473e-9407-699e8326ae6b"
           ]
         },
-        "Body": "H4sIAAAAAAAAAKtWCkstKs7Mz1OyMqwFAOQVrPcNAAAA"
+        "Body": "H4sIAAAAAAAAAKtWCslMLVKyUgouScxLSSxKUdJRCkstKs7Mz1OyMqwFAFB+6N8fAAAA"
       }
     },
     {
-      "ID": "a02932fd50b170ae",
+      "ID": "0cb94a326f8263f7",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -101,7 +101,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "31"
+            "53"
           ],
           "User-Agent": [
             "CLEARED"
@@ -115,7 +115,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUifQ=="
+          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUiLCJXaXRoRGVjcnlwdGlvbiI6dHJ1ZX0="
         ]
       },
       "Response": {
@@ -128,23 +128,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "227"
+            "234"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:53 GMT"
           ],
           "X-Amzn-Requestid": [
-            "c29b616b-4454-41f8-bcf7-963070303451"
+            "8cc2aa05-0d80-4327-aeb2-0b35cb4b4da3"
           ]
         },
-        "Body": "H4sIAAAAAAAAAHWOMW/CMBCF/0p0S5eENiYJ7S1VpTK1RQgQDDXDlRxgQWxkmwKK8t9xQCxILHe69/S9dzUMyVLFni1gDR+jASCQ1UgHh85VuHcJk/OJwKwQ3dcXIfKeELi7Uc+eg7sweqlWyT9ZRX9bhhi+A/RjSrVUXH6SZ8C0kxd5t+hlaZFmov8WwyBEhLoHCZPTrnXH3iq9CveUtvtW+JW6lhdWAkYS+qWEOOwJH/1V+dJmsYk27exIaOI7YEzVPTFbmycX+TVbfg+E1PO2kK1TRofPm+YMiTFv5ygBAAA="
+        "Body": "H4sIAAAAAAAAAG2OPW/CMBCG/0p0S5eEUpcQ4qWqBBMFoYJgqDtcyQEWxEa2+VKU/84F2gV1OeveV89zrmCCDksK5EBW8P45BgnojMSTl96X8uATQh8SITtd8dprC5FmQsj9H/UciNulNSu9To7oNP7sCGLoY8DZZU+sC3QOnHywZmQLvdJUcMvNSyvtpVkm2nlH5Okgj2HM0hvxr/PXNw1OmzXvc9wdmuBLmUrdWAUyUjAoFMT8zvjwPRkau9xG22a2FNTxAzDF8pFYbOyTj8KGHL0xocx3c5Cc19bwz+v6CjdGpV86AQAA"
       }
     },
     {
-      "ID": "24546f157f35aed6",
+      "ID": "08e57cd36dd7a499",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -180,23 +180,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "180"
+            "189"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:53 GMT"
           ],
           "X-Amzn-Requestid": [
-            "ca609afb-bfad-497f-b81c-f359d6f08f76"
+            "a1666e6a-2ee7-4e8a-b224-51645bd64a5c"
           ]
         },
-        "Body": "H4sIAAAAAAAAAFWOPQ+CMBCG/8vNoFK+tLNuakhEF8Nw0oNcAsW0FWMI/93K5njv1z0TFGiwJ0fGgrxPcETrToPihknt0RHIaJVmaZzlSZRFiTjsgr/M1ZIBCWi0xLeVjL2USSbi7UaINBdCvnxgbUbULWkHAZz9N19wZF1YD7rhNhzRMD468m4xdFwz/ViqAEpexi8OtUKjvF9+nrQohnXr75vn5kF7yrmav1ourBTNAAAA"
+        "Body": "H4sIAAAAAAAAAFWPOQ4CMQxF7+KaYQmEYVJDBwiJpUEUZmJGliBBTtiEuDsG0VBa79v/+QkLFDxRJkngtk8YY8bV40zgINM9QwummPIsej4weaVKem07smVputXAVHZS/WfWiUS3UYLDW3KMJ+cGQ9MfdY2xpTHuooGOXDE0FD4Fc+3/1qVc1DEcuCmuKIz7IyldxCPXTB+7XQtW/D2+zBg8ilf+k11m4dDovNFPOAa1fO1ebz5OFl7fAAAA"
       }
     },
     {
-      "ID": "ad7c483713e58d80",
+      "ID": "a7bb0eafd1099d5d",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -238,10 +238,10 @@
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:53 GMT"
           ],
           "X-Amzn-Requestid": [
-            "404ff769-9775-4ecb-a5c8-6c0ed94296d1"
+            "8737e159-90f3-4938-b4a0-1261605e0759"
           ]
         },
         "Body": "H4sIAAAAAAAAAKuuBQBDv6ajAgAAAA=="

--- a/runtimevar/awsparamstore/testdata/TestConformance/TestNonExistentVariable.replay
+++ b/runtimevar/awsparamstore/testdata/TestConformance/TestNonExistentVariable.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7U35NxAjBc8/5c",
+  "Initial": "AQAAAA7WFu03Jr4fMv5c",
   "Version": "0.2",
   "Converter": {
     "ClearHeaders": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "c091dc8549050aea",
+      "ID": "ef125736c1ba538c",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -49,7 +49,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "25"
+            "47"
           ],
           "User-Agent": [
             "CLEARED"
@@ -63,7 +63,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoiZG9lcy1ub3QtZXhpc3QifQ=="
+          "eyJOYW1lIjoiZG9lcy1ub3QtZXhpc3QiLCJXaXRoRGVjcnlwdGlvbiI6dHJ1ZX0="
         ]
       },
       "Response": {
@@ -82,10 +82,10 @@
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:49 GMT"
+            "Wed, 01 Apr 2020 20:14:47 GMT"
           ],
           "X-Amzn-Requestid": [
-            "3c088b95-ec14-4658-9e31-77d23afe2289"
+            "34751bfa-23d2-42de-b49f-5310155b5f3c"
           ]
         },
         "Body": "H4sIAAAAAAAAAKtWio8vqSxIVbJSCkgsSsxNLUkt8ssvccsvzUtRqgUAF48DRR4AAAA="

--- a/runtimevar/awsparamstore/testdata/TestConformance/TestString.replay
+++ b/runtimevar/awsparamstore/testdata/TestConformance/TestString.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7U35NyCelm9v5c",
+  "Initial": "AQAAAA7WFu04FlMfx/5c",
   "Version": "0.2",
   "Converter": {
     "ClearHeaders": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "2a043afaa7a3d893",
+      "ID": "a004c98a881a1aa2",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -76,23 +76,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "33"
+            "51"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:50 GMT"
+            "Wed, 01 Apr 2020 20:14:48 GMT"
           ],
           "X-Amzn-Requestid": [
-            "dfd87c4e-5e2a-464a-9e71-1d0d144c4bf7"
+            "1d0498de-d8d3-4c19-9e98-09c8622d1e70"
           ]
         },
-        "Body": "H4sIAAAAAAAAAKtWCkstKs7Mz1OyMqwFAOQVrPcNAAAA"
+        "Body": "H4sIAAAAAAAAAKtWCslMLVKyUgouScxLSSxKUdJRCkstKs7Mz1OyMqwFAFB+6N8fAAAA"
       }
     },
     {
-      "ID": "40cea3df477cef02",
+      "ID": "db13089c4a4a9d59",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -101,7 +101,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "31"
+            "53"
           ],
           "User-Agent": [
             "CLEARED"
@@ -115,7 +115,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUifQ=="
+          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUiLCJXaXRoRGVjcnlwdGlvbiI6dHJ1ZX0="
         ]
       },
       "Response": {
@@ -128,23 +128,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "174"
+            "182"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:50 GMT"
+            "Wed, 01 Apr 2020 20:14:48 GMT"
           ],
           "X-Amzn-Requestid": [
-            "b2c65434-939c-4a0f-91e8-ef97e0acde57"
+            "fc1c3eb2-792b-4bce-bdc8-a6bc34db85a5"
           ]
         },
-        "Body": "H4sIAAAAAAAAAHWNwQ6CMBBEf8XsGRQKRe3NRG9KjBrvqyzYpLSkLRJD+HfLwaPHmcl7M8IZLbbkyYIYYXcpQQBaLXBwwrlW9C4mdD5mIi9YtkkY42vGRPejVp7C+jS6lk38RivxoQgiOAboZCpZS6r26AlEuuQFz4p1niY554dtBGVQhLs/htunm9ert1I3Id9R9XPxIqXMYjBWVXNL1kmjg36avpmN2ZLNAAAA"
+        "Body": "H4sIAAAAAAAAAG2Myw6CMBBFf8V0LQpVHnZnojslRo37UQZsUlrSFtEQ/t3B6M7lPSf39OwAFmr0aJno2fqYM8HAagGdE87VonUBgvMBF8uEL7KQ8zjlXDS/19wj2ZvRpayCB1gJV4Vsyjbg4fxqkHIen57IjjJ7U8hSYkGWTDSLszhNeZhlSRJtV1OWU/Tz+Nv89k7eSl3RvoBqR3BHpcykM1YVI0XrpNGUH4Y3jXgpC98AAAA="
       }
     },
     {
-      "ID": "b6f6d38979fc09c7",
+      "ID": "339bdac112b73142",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -180,23 +180,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "181"
+            "190"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:50 GMT"
+            "Wed, 01 Apr 2020 20:14:48 GMT"
           ],
           "X-Amzn-Requestid": [
-            "0bcf03af-e72b-4f46-a952-3efbe886743f"
+            "265b3818-0610-4095-9d13-d9b8999fe2f1"
           ]
         },
-        "Body": "H4sIAAAAAAAAAFWOPQ+CMBCG/8vNoFAoamfd1JCILobhhINcAsW0FWMI/93K5njv1z0T5GiwJ0fGgrpPcETrTkPNDVO9R0eg4pXMZJJt0jhKpTzsgr/M1ZIBBWi0wrdVjL1SaSaSbSSE3AihXj6wNiPqlrSDAM7+my84si6sBt1wG45oGB8deTcfOq6YfixlAAUv4xeHukZTe7/4PGlRDOvW3zfPzYP2lHM5fwEO88q+zQAAAA=="
+        "Body": "H4sIAAAAAAAAAFWPTQ+CMAyG/8vO+DUF5s56U0MCejEeqhTSBDazTdQQ/7uFePHYPG/7Pu1FBg5aDOi80OdebCBA8b6j0CLgK4hI7MCHvS2pIiyZMllMYxWnqZwrlSSL7fo/c/ToeBuc0fD0mqDVepXIpZpLGadS6gcHZq4DU6MZCg7cP9b5MLlZU1E96cARXBtkmtmGboSD3SUSBY3H8wCmBFcy/8nmwZGpeT7xJ2QNW34uny8Izkuv3wAAAA=="
       }
     },
     {
-      "ID": "2939f96ffea269a5",
+      "ID": "52a8904ef79cfb3f",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -238,10 +238,10 @@
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:55 GMT"
+            "Wed, 01 Apr 2020 20:14:53 GMT"
           ],
           "X-Amzn-Requestid": [
-            "9686eedc-6c1f-4614-bbbd-101c8f757005"
+            "c80a14ff-65d1-405a-b0d4-27705e8296e3"
           ]
         },
         "Body": "H4sIAAAAAAAAAKuuBQBDv6ajAgAAAA=="

--- a/runtimevar/awsparamstore/testdata/TestConformance/TestUpdate.replay
+++ b/runtimevar/awsparamstore/testdata/TestConformance/TestUpdate.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7U35N5CRdXzP5c",
+  "Initial": "AQAAAA7WFu0/EVabeP5c",
   "Version": "0.2",
   "Converter": {
     "ClearHeaders": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "4fd2814e9d87f667",
+      "ID": "7252904e84807568",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -76,23 +76,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "33"
+            "51"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:54 GMT"
           ],
           "X-Amzn-Requestid": [
-            "153db259-42ab-4426-9a29-14a60701d00e"
+            "cc3ecff7-080d-43b1-922d-1e6807997c08"
           ]
         },
-        "Body": "H4sIAAAAAAAAAKtWCkstKs7Mz1OyMqwFAOQVrPcNAAAA"
+        "Body": "H4sIAAAAAAAAAKtWCslMLVKyUgouScxLSSxKUdJRCkstKs7Mz1OyMqwFAFB+6N8fAAAA"
       }
     },
     {
-      "ID": "6bcaf8deb0e65ace",
+      "ID": "40728123d3a9aee9",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -101,7 +101,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "31"
+            "53"
           ],
           "User-Agent": [
             "CLEARED"
@@ -115,7 +115,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUifQ=="
+          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUiLCJXaXRoRGVjcnlwdGlvbiI6dHJ1ZX0="
         ]
       },
       "Response": {
@@ -128,23 +128,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "174"
+            "181"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:54 GMT"
           ],
           "X-Amzn-Requestid": [
-            "f25f7556-b5fc-4808-b2bb-4e9c3b0c3680"
+            "48e0702a-eb7c-4421-8229-6a858f9c73a3"
           ]
         },
-        "Body": "H4sIAAAAAAAAAHWNyw6CMBREf8XcNaiUd3cmulNi1Li/ygWblJa0RWII/25ZuHQ5MzlnJjijwY4cGeAT7C4VcECjOI6WW9vxwYaE1oWMJxmLiy1jac4Y73/UxpFfn1o1og3faAQ+JEEARw+ddC0aQfUeHQGP1mmWxlmeRHlSFocygMor/N0fw+3TL+vVGaFan+8oh6V4kZR6NWoj66UlY4VWXj/PX6d8vp7NAAAA"
+        "Body": "H4sIAAAAAAAAAG2MwQ6CMBAFf8X0DIrVCvRmojclRo33VRZsUihpi2gI/+5i9ObxzeRNzw5goUKPlsmerY8ZkwxsLaFz0rlKti5EcD7kcrniiyTiXMScy+b3mnkkezN1ocrwAVbBVSML2AY8nF8NUs7j0xPZUWZvclUozMmSmU9FIuKYR6kQIt2mAcso+nn8bX57J29VXdK+gG5HcEetzaQzVucjReuUqSk/DG8Yx9hq3wAAAA=="
       }
     },
     {
-      "ID": "7c77127f6289b746",
+      "ID": "c3a34162870928f8",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -180,23 +180,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "180"
+            "189"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:54 GMT"
           ],
           "X-Amzn-Requestid": [
-            "6c77e51b-0566-49aa-b45b-fa0ac08fe078"
+            "9e8bd6bd-6606-47de-9314-c49d1834a033"
           ]
         },
-        "Body": "H4sIAAAAAAAAAFWOPQ+CMBCG/8vNoFK+tLNuakhEF8Nw0oNcAsW0FWMI/93K5njv1z0TFGiwJ0fGgrxPcETrToPihknt0RHIaJVmaZzlSZRFiTjsgr/M1ZIBCWi0xLeVjL2USSbi7UaINBdCvnxgbUbULWkHAZz9N19wZF1YD7rhNhzRMD468m4xdFwz/ViqAEpexi8OtUKjvF9+nrQohnXr75vn5kF7yrmav1ourBTNAAAA"
+        "Body": "H4sIAAAAAAAAAFWPOQ4CMQxF7+KaYQmEYVJDBwiJpUEUZmJGliBBTtiEuDsG0VBa79v/+QkLFDxRJkngtk8YY8bV40zgINM9QwummPIsej4weaVKem07smVputXAVHZS/WfWiUS3UYLDW3KMJ+cGQ9MfdY2xpTHuooGOXDE0FD4Fc+3/1qVc1DEcuCmuKIz7IyldxCPXTB+7XQtW/D2+zBg8ilf+k11m4dDovNFPOAa1fO1ebz5OFl7fAAAA"
       }
     },
     {
-      "ID": "94488f6079991852",
+      "ID": "8de37dc8a8aa8298",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -205,7 +205,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "31"
+            "53"
           ],
           "User-Agent": [
             "CLEARED"
@@ -219,7 +219,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUifQ=="
+          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUiLCJXaXRoRGVjcnlwdGlvbiI6dHJ1ZX0="
         ]
       },
       "Response": {
@@ -232,23 +232,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "174"
+            "181"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:54 GMT"
           ],
           "X-Amzn-Requestid": [
-            "b9532148-e523-40e7-ae49-65bd0af0c41d"
+            "aa7390c3-4be5-4e3b-8ded-c812fb92d5eb"
           ]
         },
-        "Body": "H4sIAAAAAAAAAHWNyw6CMBREf8XcNaiUd3cmulNi1Li/ygWblJa0RWII/25ZuHQ5MzlnJjijwY4cGeAT7C4VcECjOI6WW9vxwYaE1oWMJxmLiy1jac4Y73/UxpFfn1o1og3faAQ+JEEARw+ddC0aQfUeHQGP1mmWxlmeRHlSFocygMor/N0fw+3TL+vVGaFan+8oh6V4kZR6NWoj66UlY4VWXj/PX6d8vp7NAAAA"
+        "Body": "H4sIAAAAAAAAAG2MwQ6CMBAFf8X0DIrVCvRmojclRo33VRZsUihpi2gI/+5i9ObxzeRNzw5goUKPlsmerY8ZkwxsLaFz0rlKti5EcD7kcrniiyTiXMScy+b3mnkkezN1ocrwAVbBVSML2AY8nF8NUs7j0xPZUWZvclUozMmSmU9FIuKYR6kQIt2mAcso+nn8bX57J29VXdK+gG5HcEetzaQzVucjReuUqSk/DG8Yx9hq3wAAAA=="
       }
     },
     {
-      "ID": "94040381d26cefc0",
+      "ID": "361c4692dceaf0b8",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -284,23 +284,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "33"
+            "51"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:56 GMT"
+            "Wed, 01 Apr 2020 20:14:55 GMT"
           ],
           "X-Amzn-Requestid": [
-            "51c0f301-ba42-4221-8149-e9fac07e1983"
+            "5d51f803-656e-49e8-98db-cb8819dff590"
           ]
         },
-        "Body": "H4sIAAAAAAAAAKtWCkstKs7Mz1OyMqoFACdGgdwNAAAA"
+        "Body": "H4sIAAAAAAAAAKtWCslMLVKyUgouScxLSSxKUdJRCkstKs7Mz1OyMqoFAJMtxfQfAAAA"
       }
     },
     {
-      "ID": "c5e85c393dbe8fa8",
+      "ID": "8d457e1f64a7c051",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -309,7 +309,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "31"
+            "53"
           ],
           "User-Agent": [
             "CLEARED"
@@ -323,7 +323,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUifQ=="
+          "eyJOYW1lIjoidGVzdC1jb25maWctdmFyaWFibGUiLCJXaXRoRGVjcnlwdGlvbiI6dHJ1ZX0="
         ]
       },
       "Response": {
@@ -336,23 +336,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "176"
+            "183"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:57 GMT"
+            "Wed, 01 Apr 2020 20:14:55 GMT"
           ],
           "X-Amzn-Requestid": [
-            "c969f616-4d57-4456-92dd-2acf451966d4"
+            "a70076c1-75cc-4db6-a5da-a1dbc543707a"
           ]
         },
-        "Body": "H4sIAAAAAAAAAHWNPQ+CQBBE/4rZWlSO7+1MtFNi1NgvspBLgCN3h4QQ/rtHYWk58zJvZriRppYta8AZjvccEEh3SKNBY1ocjMdkrCcwjEWQHoSIEiGw/632lh19q66StfchLaloGLZwcaOrKmUluTyRZUB/F8VRECehn6SZf862kDuFu/tjeE79Sh9Wy652+UXNsBa1UmUx8WZUuinXnrWRqgMUy/IFljGDOs8AAAA="
+        "Body": "H4sIAAAAAAAAAG2MwQ6CMBAFf8XsGRSqCPRmojclRo33xS6kCVDSFpEQ/t1i9ObxzeTNCGfUWJMlDXyE3SUDDqgbjr3hxtS8Mz6hsT7jmy1bJwFjUcwYb3+vlSVnH6opZOk/UUvMKwIP9mjxNrTkcpZe1pGjy5yUkIUk4awz4TJKojhmQRqlQXhIPchc9PP42/z2rlbLpnT7jlU3g1IpkQ+06JWuxMxJG6ka4Gya3stPMXvhAAAA"
       }
     },
     {
-      "ID": "5dc4dc1352bb0a38",
+      "ID": "07364b8bdcdc1d80",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -388,23 +388,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "180"
+            "189"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:57 GMT"
+            "Wed, 01 Apr 2020 20:14:55 GMT"
           ],
           "X-Amzn-Requestid": [
-            "a1b1fc4a-51f1-4884-a943-bc14499df56d"
+            "bd8070e6-7318-46dc-ae7b-2c40ed0dd00e"
           ]
         },
-        "Body": "H4sIAAAAAAAAAFWOPQ+CMBCG/8vNoFK+tLNuakhEF8Nw0oNcAsW0FWMI/93K5njv1z0TFGiwJ0fGgrxPcETrToPihknt0RHIaJVmaZzlSZRFiTjsgr/M1ZIBCWi0xLeVjL2USSbi7UaINBdCvnxgbUbULWkHAZz9N19wZF1YD7rhNhzRMD468m4xdFwz/ViqAEpexi8OtUKjvF9+nrQohnXr75vn5kF7yrmav1ourBTNAAAA"
+        "Body": "H4sIAAAAAAAAAFWPOQ4CMQxF7+KaYQmEYVJDBwiJpUEUZmJGliBBTtiEuDsG0VBa79v/+QkLFDxRJkngtk8YY8bV40zgINM9QwummPIsej4weaVKem07smVputXAVHZS/WfWiUS3UYLDW3KMJ+cGQ9MfdY2xpTHuooGOXDE0FD4Fc+3/1qVc1DEcuCmuKIz7IyldxCPXTB+7XQtW/D2+zBg8ilf+k11m4dDovNFPOAa1fO1ebz5OFl7fAAAA"
       }
     },
     {
-      "ID": "29e62fe1140cd6ec",
+      "ID": "b2f1eb19d802d27c",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -446,10 +446,10 @@
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:57 GMT"
+            "Wed, 01 Apr 2020 20:14:55 GMT"
           ],
           "X-Amzn-Requestid": [
-            "42aee7bf-7f52-4b70-a2fd-ba622bb95dc9"
+            "c9ede5ba-3e9a-4a18-8d76-742ac85291f0"
           ]
         },
         "Body": "H4sIAAAAAAAAAKuuBQBDv6ajAgAAAA=="

--- a/runtimevar/awsparamstore/testdata/TestConformance/TestUpdateWithErrors.replay
+++ b/runtimevar/awsparamstore/testdata/TestConformance/TestUpdateWithErrors.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7U35N7MO9lbP5c",
+  "Initial": "AQAAAA7WFu1BItOFBf5c",
   "Version": "0.2",
   "Converter": {
     "ClearHeaders": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "e90cd1d142d13127",
+      "ID": "665db8391b965ede",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -76,23 +76,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "34"
+            "52"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:57 GMT"
           ],
           "X-Amzn-Requestid": [
-            "cb958af0-9c80-4182-9baa-20ca46ce4a32"
+            "c102192c-d48c-4f7f-830f-36795dc50599"
           ]
         },
-        "Body": "H4sIAAAAAAAAAKtWCkstKs7Mz1OyMjGoBQDbmzoYDgAAAA=="
+        "Body": "H4sIAAAAAAAAAKtWCslMLVKyUgouScxLSSxKUdJRCkstKs7Mz1OyMrGsBQBsE9wFIAAAAA=="
       }
     },
     {
-      "ID": "1220423caae270ed",
+      "ID": "4b2b558311d45759",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -101,7 +101,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "42"
+            "64"
           ],
           "User-Agent": [
             "CLEARED"
@@ -115,7 +115,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidGVzdC11cGRhdGluZy12YXJpYWJsZS10by1lcnJvciJ9"
+          "eyJOYW1lIjoidGVzdC11cGRhdGluZy12YXJpYWJsZS10by1lcnJvciIsIldpdGhEZWNyeXB0aW9uIjp0cnVlfQ=="
         ]
       },
       "Response": {
@@ -128,23 +128,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "204"
+            "211"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:57 GMT"
           ],
           "X-Amzn-Requestid": [
-            "119ac103-bfd2-496c-b387-0ec469b36238"
+            "b93607cc-fddb-4fe6-9187-7c631a88ea50"
           ]
         },
-        "Body": "H4sIAAAAAAAAAIWNy27CQAxFfwV5nSlhyAO8oyqsWlRRxIZhYRSDRoJM5Jn0oSj/3gmINTv7+p7jDj5J6MqBBbCDxWYNCCQ10o9H76/YesXkg9KYFXo6S7XOS62xeVDjwPHaNhUFW5/VN4ml44VVcIpFnEAC75H/cJU9Wa7eKDDg5CUv8mlRZjpN5+VynsA62uLn57LtXzMUv4LERtx3dGmHYN+Zm8QAjgysnDOQxGHLv+EevZIY6A8DwuKtqwGztO//ARBiZlIBAQAA"
+        "Body": "H4sIAAAAAAAAAIWOy07DQAxFfwV5nYEyJCTxjgpYQYWgYsN0YRRTjdRmIo/DQ1H+HbfAmp19r8+RJ3ggoT0rC+AEV48rQCDpkT4y5rzHMTumrM5jeekvmoX3Ve09Dn/UmbK149CRxn7r3kkive7YaXIskgQKuCal9dfAZlb+VEvuzHifuvgWubPWmvPTqqnq2i/auqnKm7aAlfmPxH/6X/WTil3Y/ky78RC8TOEoCYAnAW5TClDYsLYXfqIlSYB5c0BYckw9YNnO8zdlS6AsEwEAAA=="
       }
     },
     {
-      "ID": "884f3387373f16dd",
+      "ID": "11dbeedafbdbe109",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -180,23 +180,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "189"
+            "199"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:57 GMT"
           ],
           "X-Amzn-Requestid": [
-            "6956b167-51e0-4add-b719-ec2bdbf2a85d"
+            "c6a1d478-15cc-40b7-a55a-c7672ade5fd1"
           ]
         },
-        "Body": "H4sIAAAAAAAAAFWPTc9BQQyF/0vX93KN+0HX7BDJi41YlClpwox0yhsR/92wszw9T3t6nrAkpQsbawLcPmFGyebRy1HYT8gYcNBr2mbYdrWrqnE3HRc/zDqxAgJpQPpPKHRBrFs3HFXONZ1zeMtAX+8UThwMCljktLxgnKy8XT2ZhFN5JxXan7m0WLJq1Awu41kOwp+3dgWs5JvzZxQ8qc/+6nHl70Tzhaw3uYLEAFhXr93rDfm3PfnZAAAA"
+        "Body": "H4sIAAAAAAAAAFWPsW7CQAyG38UzoXAkJLkZNkCRgC4Vg+EMsgR3yGfSVoh3r0FdGK3/s7/fd+hQ8EJKksF/3WGGipvfK4EHpR+FASww6zIFPjIFSy0ZD6umqms3auumKuftO7PNJLaNEj1+Z8948b6cukkzcq6qnfM3Az6kx3ii+BSszP/SZS1u14DK8VT0KIz7MxWaChJJYmCXznxgehbdDWDDL89aMQaUYPl/77WKXbD5057iFMGX7WP3+APv5nGA6wAAAA=="
       }
     },
     {
-      "ID": "75fa600d93518dde",
+      "ID": "844bb980c377f776",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -232,23 +232,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "34"
+            "52"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:57 GMT"
           ],
           "X-Amzn-Requestid": [
-            "7a8458e1-b4fd-42bb-af65-c35b2610e257"
+            "16fa9151-0c5c-4b40-9648-6991d536cffd"
           ]
         },
-        "Body": "H4sIAAAAAAAAAKtWCkstKs7Mz1OyMjGsBQCaqiEBDgAAAA=="
+        "Body": "H4sIAAAAAAAAAKtWCslMLVKyUgouScxLSSxKUdJRCkstKs7Mz1OyMjWoBQASwtzVIAAAAA=="
       }
     },
     {
-      "ID": "3d06f5de5fcafb8d",
+      "ID": "67812f0bbb854432",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -257,7 +257,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "42"
+            "64"
           ],
           "User-Agent": [
             "CLEARED"
@@ -271,7 +271,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidGVzdC11cGRhdGluZy12YXJpYWJsZS10by1lcnJvciJ9"
+          "eyJOYW1lIjoidGVzdC11cGRhdGluZy12YXJpYWJsZS10by1lcnJvciIsIldpdGhEZWNyeXB0aW9uIjp0cnVlfQ=="
         ]
       },
       "Response": {
@@ -284,23 +284,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "177"
+            "188"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:58 GMT"
           ],
           "X-Amzn-Requestid": [
-            "ab9ae18a-e0f2-42bf-88f3-e2775dead375"
+            "b99d9d7f-fd4a-4602-8939-ba9b0fa6e8cc"
           ]
         },
-        "Body": "H4sIAAAAAAAAAIVNuQrCQBD9l6mzmmxOpxO00yAq9iMZZSUXs5uIhPy7m8La7t1vghMJNexYACfYnktAIGmR3hatbXCwisk6pTHJdFyEWqe51tj/WmvH3h36ipxpn2okMXSvWblOsUgnEMDB949dZR6Gqx05BoxWaZbGWZ7oMAmL/SaA0q/55/9j10+/BC9OfMLzG9XDIph2pNpU6mW7dpFZrPEIk2iev6jg04zlAAAA"
+        "Body": "H4sIAAAAAAAAAIWMyw6CQAxF/2XWjMIogrMz0Z0So8Z9DdWM4ZVOQQ3h3y1G1+7ae+49vdoDQYmMpGyvVodMWQVUWXh4631pW68RPGtj5wszS0Nj4sQY2/xWU0ahbZMDu+qmOyAHlwI11xqJalKBWgPD6dWgmBmfLMlWjLs6d1eHuVAh0SRO4yQx4TKNTLJZBioT/2fxT/9VH5mkIf8ZinYMXNVB4XJ993U1xkjeyWXjcBje82YFcfcAAAA="
       }
     },
     {
-      "ID": "d74bc996a0d51350",
+      "ID": "09974e5439b6fe2c",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -336,23 +336,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "189"
+            "199"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:58 GMT"
           ],
           "X-Amzn-Requestid": [
-            "4e6ff1fa-e3a3-42df-9894-70c87c5e430f"
+            "f94e80aa-696d-41f8-8b6b-a6131276ed48"
           ]
         },
-        "Body": "H4sIAAAAAAAAAFWPTc9BQQyF/0vX93KN+0HX7BDJi41YlClpwox0yhsR/92wszw9T3t6nrAkpQsbawLcPmFGyebRy1HYT8gYcNBr2mbYdrWrqnE3HRc/zDqxAgJpQPpPKHRBrFs3HFXONZ1zeMtAX+8UThwMCljktLxgnKy8XT2ZhFN5JxXan7m0WLJq1Awu41kOwp+3dgWs5JvzZxQ8qc/+6nHl70Tzhaw3uYLEAFhXr93rDfm3PfnZAAAA"
+        "Body": "H4sIAAAAAAAAAFWPsW7CQAyG38UzoXAkJLkZNkCRgC4Vg+EMsgR3yGfSVoh3r0FdGK3/s7/fd+hQ8EJKksF/3WGGipvfK4EHpR+FASww6zIFPjIFSy0ZD6umqms3auumKuftO7PNJLaNEj1+Z8948b6cukkzcq6qnfM3Az6kx3ii+BSszP/SZS1u14DK8VT0KIz7MxWaChJJYmCXznxgehbdDWDDL89aMQaUYPl/77WKXbD5057iFMGX7WP3+APv5nGA6wAAAA=="
       }
     },
     {
-      "ID": "5c7c9ef0895420a7",
+      "ID": "662e83e124f94933",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -388,23 +388,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "34"
+            "52"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:58 GMT"
           ],
           "X-Amzn-Requestid": [
-            "73553143-0da6-4c1d-80ef-1f7198cc0ee3"
+            "e4c348af-192e-4401-8965-1d7a7eada72b"
           ]
         },
-        "Body": "H4sIAAAAAAAAAKtWCkstKs7Mz1OyMjGqBQBZ+QwqDgAAAA=="
+        "Body": "H4sIAAAAAAAAAKtWCslMLVKyUgouScxLSSxKUdJRCkstKs7Mz1OyMjWsBQBT88fMIAAAAA=="
       }
     },
     {
-      "ID": "8135ce2e0b8da8c2",
+      "ID": "3fde6839ce0a22fe",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -413,7 +413,7 @@
             "gzip"
           ],
           "Content-Length": [
-            "42"
+            "64"
           ],
           "User-Agent": [
             "CLEARED"
@@ -427,7 +427,7 @@
         },
         "MediaType": "application/x-amz-json-1.1",
         "BodyParts": [
-          "eyJOYW1lIjoidGVzdC11cGRhdGluZy12YXJpYWJsZS10by1lcnJvciJ9"
+          "eyJOYW1lIjoidGVzdC11cGRhdGluZy12YXJpYWJsZS10by1lcnJvciIsIldpdGhEZWNyeXB0aW9uIjp0cnVlfQ=="
         ]
       },
       "Response": {
@@ -440,23 +440,23 @@
             "gzip"
           ],
           "Content-Length": [
-            "181"
+            "192"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:58 GMT"
           ],
           "X-Amzn-Requestid": [
-            "e94737fa-f304-4daf-9f25-decc6e612b76"
+            "db7c0d51-09f9-4263-8568-1506abbc6066"
           ]
         },
-        "Body": "H4sIAAAAAAAAAIWNzQ4BQRCE36XPhtX2h75JuCGCuLdsk5HdmU3PLBHx7mYPzo5V9VXVG/as3EoUBXrD8rADAlZH/AwUQkt9MMIhGqS8xNk8QywqROp+rUmUlPZdzdG6m3mwWr40YqI3ouoVRrBJ/a2v7dVKveIoQNNxURazssoxq7JyvRjBLq2l5/9jp1c3gMeoiUj6zE0/GNY9uLG1uQfvcPBFg/UOKMfP5wui997C5gAAAA=="
+        "Body": "H4sIAAAAAAAAAIWMQU+DQBBG/8ucWVsWEdibid6UNNX0Pg3TZg3sktkBbQj/3amx5x7nvfneAjtkHEiIwS3wvG/BAXJw+J1cSoObkiFMYqx7fLJFvbW2rKx14221EVI7jR2KD2czI3s89mQkGmKODBm8oODnZSQtC/2IkjctvsfOnzx1atXkD2VdVpXdNnXR5K9NBq32/xb38v/pD2H90PuA/XQFPszY+858pRjslRMnHwO4Ml/XX1cqJ834AAAA"
       }
     },
     {
-      "ID": "8bb35b0a24b64c73",
+      "ID": "ae49ef7c853572e9",
       "Request": {
         "Method": "POST",
         "URL": "https://ssm.us-east-2.amazonaws.com/",
@@ -492,19 +492,19 @@
             "gzip"
           ],
           "Content-Length": [
-            "189"
+            "199"
           ],
           "Content-Type": [
             "application/x-amz-json-1.1"
           ],
           "Date": [
-            "Fri, 09 Aug 2019 16:16:59 GMT"
+            "Wed, 01 Apr 2020 20:14:58 GMT"
           ],
           "X-Amzn-Requestid": [
-            "9f9c6a86-1695-4de3-875d-ec44f7f27b36"
+            "b1e19cc8-5c07-4d55-9de2-c29f168b2168"
           ]
         },
-        "Body": "H4sIAAAAAAAAAFWPTc9BQQyF/0vX93KN+0HX7BDJi41YlClpwox0yhsR/92wszw9T3t6nrAkpQsbawLcPmFGyebRy1HYT8gYcNBr2mbYdrWrqnE3HRc/zDqxAgJpQPpPKHRBrFs3HFXONZ1zeMtAX+8UThwMCljktLxgnKy8XT2ZhFN5JxXan7m0WLJq1Awu41kOwp+3dgWs5JvzZxQ8qc/+6nHl70Tzhaw3uYLEAFhXr93rDfm3PfnZAAAA"
+        "Body": "H4sIAAAAAAAAAFWPsW7CQAyG38UzoXAkJLkZNkCRgC4Vg+EMsgR3yGfSVoh3r0FdGK3/s7/fd+hQ8EJKksF/3WGGipvfK4EHpR+FASww6zIFPjIFSy0ZD6umqms3auumKuftO7PNJLaNEj1+Z8948b6cukkzcq6qnfM3Az6kx3ii+BSszP/SZS1u14DK8VT0KIz7MxWaChJJYmCXznxgehbdDWDDL89aMQaUYPl/77WKXbD5057iFMGX7WP3+APv5nGA6wAAAA=="
       }
     }
   ]


### PR DESCRIPTION
`WithDecryption=true` has no effect if the parameter is not encrypted, so it's safe to just always set it.

Fixes #2764.