### PR TITLE
internal/testing: replace use of grep -P with piped grep; grep -P is no longer supported on windows

### DIFF
--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -51,7 +51,7 @@ if [[ ! -z "${TRAVIS_BRANCH:-}" ]] && [[ ! -z "${TRAVIS_PULL_REQUEST_SHA:-}" ]];
   # tests.
   echo "The following files changed:"
   cat "$tmpfile"
-  if grep -vP "(^internal/website|.md$)" "$tmpfile"; then
+  if grep -v "^internal/website" "$tmpfile" | grep -v ".md$"; then
     echo "--> Found some non-trivial changes, running tests"
   else
     echo "--> Diff doesn't affect tests; not running them"


### PR DESCRIPTION
The Windows build was reporting:

`grep: -P supports only unibyte and UTF-8 locales`

and skipping all tests.