### PR TITLE
pubsub/mem: fix race on msg.AsFunc access

### DIFF
--- a/pubsub/mempubsub/mem.go
+++ b/pubsub/mempubsub/mem.go
@@ -151,6 +151,7 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 	// but that would require copying all the messages.
 	for i, m := range ms {
 		m.AckID = t.nextAckID + i
+		m.AsFunc = func(interface{}) bool { return false }
 
 		if m.BeforeSend != nil {
 			if err := m.BeforeSend(func(interface{}) bool { return false }); err != nil {
@@ -239,7 +240,6 @@ func (s *subscription) add(ms []*driver.Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, m := range ms {
-		m.AsFunc = func(interface{}) bool { return false }
 		// The new message will expire at the zero time, which means it will be
 		// immediately eligible for delivery.
 		s.msgs[m.AckID] = &message{msg: m}


### PR DESCRIPTION
mempubsub.(*subscription).add() which is called on every subscription
for topic updates driver.Message.AsFunc while pubsub.(*Subscription).Receive()
reads its value.

WARNING: DATA RACE
Read at 0x00c0004bb030 by goroutine 134:
  gocloud.dev/pubsub.(*Subscription).Receive()
      /Users/alexsn/go/pkg/mod/gocloud.dev@v0.19.0/pubsub/pubsub.go:586 +0x935

Previous write at 0x00c0004bb030 by goroutine 114:
  gocloud.dev/pubsub/mempubsub.(*subscription).add()
      /Users/alexsn/go/pkg/mod/gocloud.dev@v0.19.0/pubsub/mempubsub/mem.go:242 +0xee
  gocloud.dev/pubsub/mempubsub.(*topic).SendBatch()
      /Users/alexsn/go/pkg/mod/gocloud.dev@v0.19.0/pubsub/mempubsub/mem.go:163 +0x323
  gocloud.dev/pubsub.newSendBatcher.func1.1()
      /Users/alexsn/go/pkg/mod/gocloud.dev@v0.19.0/pubsub/pubsub.go:309 +0x1c1
  gocloud.dev/internal/retry.call()
      /Users/alexsn/go/pkg/mod/gocloud.dev@v0.19.0/internal/retry/retry.go:51 +0x65
  gocloud.dev/internal/retry.Call()
      /Users/alexsn/go/pkg/mod/gocloud.dev@v0.19.0/internal/retry/retry.go:40 +0x1de
  gocloud.dev/pubsub.newSendBatcher.func1()
      /Users/alexsn/go/pkg/mod/gocloud.dev@v0.19.0/pubsub/pubsub.go:306 +0xaf
  gocloud.dev/internal/batcher.(*Batcher).callHandler()
      /Users/alexsn/go/pkg/mod/gocloud.dev@v0.19.0/internal/batcher/batcher.go:198 +0x1d0
  gocloud.dev/internal/batcher.(*Batcher).AddNoWait.func1()
      /Users/alexsn/go/pkg/mod/gocloud.dev@v0.19.0/internal/batcher/batcher.go:159 +0x56

Signed-off-by: Alex Snast <alexsn@fb.com>

Please use a title starting with the name of the affected package, or \"all\",
followed by a colon, followed by a short summary of the issue. Example:
`blob/gcsblob: fix typo in documentation`.

Please reference any Issue related to this Pull Request. Example: `Fixes #1`.

See
[here](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
for tips on good Pull Request description.
