### PR TITLE
pubsub/natspubsub: Implement QueueSubscription

### DIFF
--- a/internal/website/data/examples.json
+++ b/internal/website/data/examples.json
@@ -255,6 +255,10 @@
 		"imports": "import (\n\t\"context\"\n\n\t\"github.com/nats-io/nats.go\"\n\t\"gocloud.dev/pubsub/natspubsub\"\n)",
 		"code": "natsConn, err := nats.Connect(\"nats://nats.example.com\")\nif err != nil {\n\treturn err\n}\ndefer natsConn.Close()\n\nsubscription, err := natspubsub.OpenSubscription(\n\tnatsConn,\n\t\"example.mysubject\",\n\tnil)\nif err != nil {\n\treturn err\n}\ndefer subscription.Shutdown(ctx)"
 	},
+	"gocloud.dev/pubsub/natspubsub.ExampleOpenQueueSubscription": {
+		"imports": "import (\n\t\"context\"\n\n\t\"github.com/nats-io/nats.go\"\n\t\"gocloud.dev/pubsub/natspubsub\"\n)",
+		"code": "natsConn, err := nats.Connect(\"nats://nats.example.com\")\nif err != nil {\n\treturn err\n}\ndefer natsConn.Close()\n\nsubscription, err := natspubsub.OpenSubscription(\n\tnatsConn,\n\t\"example.mysubject\",\n\t&natspubsub.SubscriptionOptions{Queue: \"queue1\"})\nif err != nil {\n\treturn err\n}\ndefer subscription.Shutdown(ctx)"
+	},
 	"gocloud.dev/pubsub/natspubsub.ExampleOpenTopic": {
 		"imports": "import (\n\t\"context\"\n\n\t\"github.com/nats-io/nats.go\"\n\t\"gocloud.dev/pubsub/natspubsub\"\n)",
 		"code": "natsConn, err := nats.Connect(\"nats://nats.example.com\")\nif err != nil {\n\treturn err\n}\ndefer natsConn.Close()\n\ntopic, err := natspubsub.OpenTopic(natsConn, \"example.mysubject\", nil)\nif err != nil {\n\treturn err\n}\ndefer topic.Shutdown(ctx)"

--- a/internal/website/data/examples.json
+++ b/internal/website/data/examples.json
@@ -251,13 +251,13 @@
 		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/pubsub\"\n\t_ \"gocloud.dev/pubsub/mempubsub\"\n)",
 		"code": "topic, err := pubsub.OpenTopic(ctx, \"mem://topicA\")\nif err != nil {\n\treturn err\n}\ndefer topic.Shutdown(ctx)"
 	},
+	"gocloud.dev/pubsub/natspubsub.ExampleOpenQueueSubscription": {
+		"imports": "import (\n\t\"context\"\n\n\t\"github.com/nats-io/nats.go\"\n\t\"gocloud.dev/pubsub/natspubsub\"\n)",
+		"code": "natsConn, err := nats.Connect(\"nats://nats.example.com\")\nif err != nil {\n\treturn err\n}\ndefer natsConn.Close()\n\nsubscription, err := natspubsub.OpenSubscription(\n\tnatsConn,\n\t\"example.mysubject\",\n\t\u0026natspubsub.SubscriptionOptions{Queue: \"queue1\"})\nif err != nil {\n\treturn err\n}\ndefer subscription.Shutdown(ctx)"
+	},
 	"gocloud.dev/pubsub/natspubsub.ExampleOpenSubscription": {
 		"imports": "import (\n\t\"context\"\n\n\t\"github.com/nats-io/nats.go\"\n\t\"gocloud.dev/pubsub/natspubsub\"\n)",
 		"code": "natsConn, err := nats.Connect(\"nats://nats.example.com\")\nif err != nil {\n\treturn err\n}\ndefer natsConn.Close()\n\nsubscription, err := natspubsub.OpenSubscription(\n\tnatsConn,\n\t\"example.mysubject\",\n\tnil)\nif err != nil {\n\treturn err\n}\ndefer subscription.Shutdown(ctx)"
-	},
-	"gocloud.dev/pubsub/natspubsub.ExampleOpenQueueSubscription": {
-		"imports": "import (\n\t\"context\"\n\n\t\"github.com/nats-io/nats.go\"\n\t\"gocloud.dev/pubsub/natspubsub\"\n)",
-		"code": "natsConn, err := nats.Connect(\"nats://nats.example.com\")\nif err != nil {\n\treturn err\n}\ndefer natsConn.Close()\n\nsubscription, err := natspubsub.OpenSubscription(\n\tnatsConn,\n\t\"example.mysubject\",\n\t&natspubsub.SubscriptionOptions{Queue: \"queue1\"})\nif err != nil {\n\treturn err\n}\ndefer subscription.Shutdown(ctx)"
 	},
 	"gocloud.dev/pubsub/natspubsub.ExampleOpenTopic": {
 		"imports": "import (\n\t\"context\"\n\n\t\"github.com/nats-io/nats.go\"\n\t\"gocloud.dev/pubsub/natspubsub\"\n)",

--- a/pubsub/natspubsub/example_test.go
+++ b/pubsub/natspubsub/example_test.go
@@ -62,6 +62,27 @@ func ExampleOpenSubscription() {
 	defer subscription.Shutdown(ctx)
 }
 
+func ExampleOpenQueueSubscription() {
+	// PRAGMA: This example is used on gocloud.dev; PRAGMA comments adjust how it is shown and can be ignored.
+	// PRAGMA: On gocloud.dev, hide lines until the next blank line.
+	ctx := context.Background()
+
+	natsConn, err := nats.Connect("nats://nats.example.com")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer natsConn.Close()
+
+	subscription, err := natspubsub.OpenSubscription(
+		natsConn,
+		"example.mysubject",
+		&natspubsub.SubscriptionOptions{Queue: "queue1"})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer subscription.Shutdown(ctx)
+}
+
 func Example_openTopicFromURL() {
 	// PRAGMA: This example is used on gocloud.dev; PRAGMA comments adjust how it is shown and can be ignored.
 	// PRAGMA: On gocloud.dev, add a blank import: _ "gocloud.dev/pubsub/natspubsub"

--- a/pubsub/natspubsub/nats_test.go
+++ b/pubsub/natspubsub/nats_test.go
@@ -68,7 +68,21 @@ func (h *harness) MakeNonexistentTopic(ctx context.Context) (driver.Topic, error
 }
 
 func (h *harness) CreateSubscription(ctx context.Context, dt driver.Topic, testName string) (driver.Subscription, func(), error) {
-	ds, err := openSubscription(h.nc, testName)
+	ds, err := openSubscription(h.nc, testName, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanup := func() {
+		var sub *nats.Subscription
+		if ds.As(&sub) {
+			sub.Unsubscribe()
+		}
+	}
+	return ds, cleanup, nil
+}
+
+func (h *harness) CreateQueueSubscription(ctx context.Context, dt driver.Topic, testName string) (driver.Subscription, func(), error) {
+	ds, err := openSubscription(h.nc, testName, &SubscriptionOptions{Queue: testName})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -248,7 +262,7 @@ func TestErrorCode(t *testing.T) {
 	}
 
 	// Subscriptions
-	ds, err := openSubscription(h.nc, "bar")
+	ds, err := openSubscription(h.nc, "bar", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,6 +293,74 @@ func TestErrorCode(t *testing.T) {
 	if gce := ds.ErrorCode(nats.ErrTimeout); gce != gcerrors.DeadlineExceeded {
 		t.Fatalf("Expected %v, got %v", gcerrors.DeadlineExceeded, gce)
 	}
+
+	// Queue Subscription
+	qs, err := openSubscription(h.nc, "bar", &SubscriptionOptions{Queue: t.Name()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gce := qs.ErrorCode(nil); gce != gcerrors.OK {
+		t.Fatalf("Expected %v, got %v", gcerrors.OK, gce)
+	}
+	if gce := qs.ErrorCode(context.Canceled); gce != gcerrors.Canceled {
+		t.Fatalf("Expected %v, got %v", gcerrors.Canceled, gce)
+	}
+	if gce := qs.ErrorCode(nats.ErrBadSubject); gce != gcerrors.FailedPrecondition {
+		t.Fatalf("Expected %v, got %v", gcerrors.FailedPrecondition, gce)
+	}
+	if gce := qs.ErrorCode(nats.ErrBadSubscription); gce != gcerrors.NotFound {
+		t.Fatalf("Expected %v, got %v", gcerrors.NotFound, gce)
+	}
+	if gce := qs.ErrorCode(nats.ErrTypeSubscription); gce != gcerrors.FailedPrecondition {
+		t.Fatalf("Expected %v, got %v", gcerrors.FailedPrecondition, gce)
+	}
+	if gce := qs.ErrorCode(nats.ErrAuthorization); gce != gcerrors.PermissionDenied {
+		t.Fatalf("Expected %v, got %v", gcerrors.PermissionDenied, gce)
+	}
+	if gce := qs.ErrorCode(nats.ErrMaxMessages); gce != gcerrors.ResourceExhausted {
+		t.Fatalf("Expected %v, got %v", gcerrors.ResourceExhausted, gce)
+	}
+	if gce := qs.ErrorCode(nats.ErrSlowConsumer); gce != gcerrors.ResourceExhausted {
+		t.Fatalf("Expected %v, got %v", gcerrors.ResourceExhausted, gce)
+	}
+	if gce := qs.ErrorCode(nats.ErrTimeout); gce != gcerrors.DeadlineExceeded {
+		t.Fatalf("Expected %v, got %v", gcerrors.DeadlineExceeded, gce)
+	}
+}
+
+func BenchmarkNatsQueuePubSub(b *testing.B) {
+	ctx := context.Background()
+
+	opts := gnatsd.DefaultTestOptions
+	opts.Port = benchPort
+	s := gnatsd.RunServer(&opts)
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(fmt.Sprintf("nats://127.0.0.1:%d", benchPort))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer nc.Close()
+
+	h := &harness{s, nc}
+	dt, cleanup, err := h.CreateTopic(ctx, b.Name())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cleanup()
+
+	qs, cleanup, err := h.CreateQueueSubscription(ctx, dt, b.Name())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cleanup()
+
+	topic := pubsub.NewTopic(dt, nil)
+	defer topic.Shutdown(ctx)
+	queueSub := pubsub.NewSubscription(qs, recvBatcherOpts, nil)
+	defer queueSub.Shutdown(ctx)
+
+	drivertest.RunBenchmarks(b, topic, queueSub)
 }
 
 func BenchmarkNatsPubSub(b *testing.B) {


### PR DESCRIPTION
This Pull Request implements the **QueueSubscription** method from **NATS on pubsub/natspubsub package**.

The implementation takes advantage of the SubscriptionOptions used as a parameter for OpenSubscription.

Until now, only nil has been passed on.

A user can now define a specific Queue, in order to use QueueSubscription from NATS.

A Benchmark has been created for QueueSubscriptions and the TestErrorCode has been updated, in order to test QueueSubscriptions.

An example code has been created on example_test.go