### PR TITLE
secrets/azurekeyvault: add support for other azure keyvault regions

### DIFF
--- a/secrets/azurekeyvault/akv.go
+++ b/secrets/azurekeyvault/akv.go
@@ -208,7 +208,7 @@ func dial(useCLI bool) (*keyvault.BaseClient, error) {
 
 var (
 	// Note that the last binding may be just a key, or key/version.
-	keyIDRE = regexp.MustCompile("^(https://.+\\.vault\\.azure\\.net/)keys/(.+)$")
+	keyIDRE = regexp.MustCompile(`^(https://.+\.vault\.(?:azure\.net|azure\.cn|usgovcloudapi\.net|microsoftazure\.de)/)keys/(.+)$`)
 )
 
 // OpenKeeper returns a *secrets.Keeper that uses Azure keyVault.


### PR DESCRIPTION
Azure keyvault has multiple regions, as described [here](https://docs.microsoft.com/en-us/azure/key-vault/general/secure-your-key-vault#resource-endpoints)

This PR updates the regex currently used to detect a valid azure
keyvault region to include:

- Azure US Government: https://<vault-name>.vault.usgovcloudapi.net
- Azure China 21Vianet: https://<vault-name>.vault.azure.cn:443
- Azure Germany: https://.vault.microsoftazure.de:443


Please use a title starting with the name of the affected package, or \"all\",
followed by a colon, followed by a short summary of the issue. Example:
`blob/gcsblob: fix typo in documentation`.

Please reference any Issue related to this Pull Request. Example: `Fixes #1`.

See
[here](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
for tips on good Pull Request description.