### PR TITLE
pubsub/awssnssqs/example_test.go:remove http:// protocol from URL in Example_openSQSTopicFromURL

### DIFF
--- a/internal/website/data/examples.json
+++ b/internal/website/data/examples.json
@@ -181,7 +181,7 @@
 	},
 	"gocloud.dev/pubsub/awssnssqs.Example_openSQSTopicFromURL": {
 		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/pubsub\"\n\t_ \"gocloud.dev/pubsub/awssnssqs\"\n)",
-		"code": "// https://docs.aws.amazon.com/sdk-for-net/v2/developer-guide/QueueURL.html\nconst queueURL = \"https://sqs.us-east-2.amazonaws.com/123456789012/myqueue\"\ntopic, err := pubsub.OpenTopic(ctx, \"awssqs://\"+queueURL+\"?region=us-east-2\")\nif err != nil {\n\treturn err\n}\ndefer topic.Shutdown(ctx)"
+		"code": "// https://docs.aws.amazon.com/sdk-for-net/v2/developer-guide/QueueURL.html\nconst queueURL = \"sqs.us-east-2.amazonaws.com/123456789012/myqueue\"\ntopic, err := pubsub.OpenTopic(ctx, \"awssqs://\"+queueURL+\"?region=us-east-2\")\nif err != nil {\n\treturn err\n}\ndefer topic.Shutdown(ctx)"
 	},
 	"gocloud.dev/pubsub/awssnssqs.Example_openSubscriptionFromURL": {
 		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/pubsub\"\n\t_ \"gocloud.dev/pubsub/awssnssqs\"\n)",

--- a/pubsub/awssnssqs/example_test.go
+++ b/pubsub/awssnssqs/example_test.go
@@ -89,7 +89,7 @@ func Example_openSQSTopicFromURL() {
 	ctx := context.Background()
 
 	// https://docs.aws.amazon.com/sdk-for-net/v2/developer-guide/QueueURL.html
-	const queueURL = "https://sqs.us-east-2.amazonaws.com/123456789012/myqueue"
+	const queueURL = "sqs.us-east-2.amazonaws.com/123456789012/myqueue"
 	topic, err := pubsub.OpenTopic(ctx, "awssqs://"+queueURL+"?region=us-east-2")
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
remove "http://" from queueURL so we get the correct awssqs://sqs.us-east-... url in the OpenTopic function call.
