### PR TITLE
blob/gcsblob: set defaults for SignURL

### DIFF
--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -26,6 +26,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/google/go-cmp/cmp"
@@ -565,6 +566,30 @@ func TestURLOpenerForParams(t *testing.T) {
 			},
 			wantOpts: Options{PrivateKey: privateKey},
 		},
+		{
+			name:     "PrivateKey cleared",
+			currOpts: Options{PrivateKey: privateKey},
+			query: url.Values{
+				"private_key_path": {""},
+			},
+			wantOpts: Options{},
+		},
+		{
+			name: "AccessID change clears PrivateKey and MakeSignBytes",
+			currOpts: Options{
+				GoogleAccessID: "foo",
+				PrivateKey:     privateKey,
+				MakeSignBytes: func(context.Context) SignBytesFunc {
+					return func([]byte) ([]byte, error) {
+						return nil, context.DeadlineExceeded
+					}
+				},
+			},
+			query: url.Values{
+				"access_id": {"bar"},
+			},
+			wantOpts: Options{GoogleAccessID: "bar"},
+		},
 	}
 
 	for _, test := range tests {
@@ -607,6 +632,8 @@ func TestOpenBucketFromURL(t *testing.T) {
 		{"gs://mybucket?access_id=foo", false},
 		// OK, setting private_key_path.
 		{"gs://mybucket?private_key_path=" + pkFile.Name(), false},
+		// OK, clearing any pre-existing private key.
+		{"gs://mybucket?private_key_path=", false},
 		// Invalid private_key_path.
 		{"gs://mybucket?private_key_path=invalid-path", true},
 		// Invalid parameter.
@@ -685,5 +712,84 @@ func TestReadDefaultCredentials(t *testing.T) {
 				test.WantAccessID, test.WantPrivateKey,
 			)
 		}
+	}
+}
+
+func TestRemainingSignedURLSchemes(t *testing.T) {
+	tests := []struct {
+		name          string
+		currOpts      Options
+		wantSignedURL string // Not the actual URL, which is subject to change, but a mimickry.
+		wantErr       bool
+	}{
+		{
+			name:    "no scheme available, error",
+			wantErr: true,
+		},
+		{
+			name: "too many schemes configured",
+			currOpts: Options{
+				GoogleAccessID: "foo",
+				PrivateKey:     []byte("private-key"),
+				SignBytes: func([]byte) ([]byte, error) {
+					return []byte("signed"), nil
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "SignBytes",
+			currOpts: Options{
+				GoogleAccessID: "foo",
+				SignBytes: func([]byte) ([]byte, error) {
+					return []byte("signed"), nil
+				},
+			},
+			wantSignedURL: "https://host/go-cloud-blob-test-bucket/some-key?GoogleAccessId=foo&Signature=c2lnbmVk",
+		},
+		{
+			name: "MakeSignBytes is being used",
+			currOpts: Options{
+				GoogleAccessID: "foo",
+				MakeSignBytes: func(context.Context) SignBytesFunc {
+					return func([]byte) ([]byte, error) {
+						return []byte("signed"), nil
+					}
+				},
+			},
+			wantSignedURL: "https://host/go-cloud-blob-test-bucket/some-key?GoogleAccessId=foo&Signature=c2lnbmVk",
+		},
+	}
+
+	ctx := context.Background()
+	signOpts := &driver.SignedURLOptions{
+		Expiry: 30 * time.Second,
+		Method: http.MethodGet,
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bucket := bucket{name: bucketName, opts: &test.currOpts}
+
+			// SignedURL doesn't check whether a key exists.
+			gotURL, gotErr := bucket.SignedURL(ctx, "some-key", signOpts)
+			if (gotErr != nil) != test.wantErr {
+				t.Errorf("Got unexpected error %v", gotErr)
+			}
+			if test.wantSignedURL == "" {
+				return
+			}
+
+			got, _ := url.Parse(gotURL)
+			want, _ := url.Parse(test.wantSignedURL)
+			gotParams, wantParams := got.Query(), want.Query()
+			for _, param := range []string{"GoogleAccessId", "Signature"} {
+				if gotParams.Get(param) != wantParams.Get(param) {
+					// Print the full URL because the parameter might've not been set at all.
+					t.Errorf("Query parameter in SignedURL differs: %v\n -- got URL:  %v\n -- want URL: %v",
+						param, got, want)
+				}
+			}
+		})
 	}
 }

--- a/blob/gcsblob/iam.go
+++ b/blob/gcsblob/iam.go
@@ -1,0 +1,74 @@
+// Copyright 2020 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is an implementation for Options.MakeSignBytes
+// that serves as example for how to keep a private key in a separate
+// process, service, or HSM/TPM, yet use it as signer for blob.Bucket.
+
+package gcsblob
+
+import (
+	"context"
+	"sync"
+
+	credentials "cloud.google.com/go/iam/credentials/apiv1"
+	gax "github.com/googleapis/gax-go/v2"
+	credentialspb "google.golang.org/genproto/googleapis/iam/credentials/v1"
+)
+
+// credentialsClient wraps the IAM Credentials API client for a lazy initialization
+// and expresses it in the reduced format expected by SignBytes.
+// See https://cloud.google.com/iam/docs/reference/credentials/rest
+type credentialsClient struct {
+	init sync.Once
+	err  error
+
+	// client as reduced surface of credentials.IamCredentialsClient
+	// enables us to use a mock in tests.
+	client interface {
+		SignBlob(context.Context, *credentialspb.SignBlobRequest, ...gax.CallOption) (*credentialspb.SignBlobResponse, error)
+	}
+}
+
+// CreateMakeSignBytesWith produces a MakeSignBytes variant from an expanded parameter set.
+// It essentially adapts a remote call to the IAM Credentials API
+// to the function signature expected by storage.SignedURLOptions.SignBytes.
+func (c *credentialsClient) CreateMakeSignBytesWith(lifetimeCtx context.Context, googleAccessID string) func(context.Context) SignBytesFunc {
+	return func(requestCtx context.Context) SignBytesFunc {
+		c.init.Do(func() {
+			if c.client != nil {
+				// Set previously, likely to a mock implementation for tests.
+				return
+			}
+			c.client, c.err = credentials.NewIamCredentialsClient(lifetimeCtx)
+		})
+
+		return func(p []byte) ([]byte, error) {
+			if c.err != nil {
+				return nil, c.err
+			}
+
+			resp, err := c.client.SignBlob(
+				requestCtx,
+				&credentialspb.SignBlobRequest{
+					Name:    googleAccessID,
+					Payload: p,
+				})
+			if err != nil {
+				return nil, err
+			}
+			return resp.GetSignedBlob(), nil
+		}
+	}
+}

--- a/blob/gcsblob/iam_test.go
+++ b/blob/gcsblob/iam_test.go
@@ -1,0 +1,94 @@
+// Copyright 2020 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcsblob
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	gax "github.com/googleapis/gax-go/v2"
+	credentialspb "google.golang.org/genproto/googleapis/iam/credentials/v1"
+)
+
+const (
+	mockKey       = "key0000"
+	mockSignature = "signature"
+)
+
+type mockIAMClient struct {
+	requestErr error
+}
+
+func (m mockIAMClient) SignBlob(context.Context, *credentialspb.SignBlobRequest, ...gax.CallOption) (*credentialspb.SignBlobResponse, error) {
+	if m.requestErr != nil {
+		return nil, m.requestErr
+	}
+	return &credentialspb.SignBlobResponse{KeyId: mockKey, SignedBlob: []byte(mockSignature)}, nil
+}
+
+func TestIAMCredentialsClient(t *testing.T) {
+	tests := []struct {
+		name       string
+		connectErr error
+		mockClient interface {
+			SignBlob(context.Context, *credentialspb.SignBlobRequest, ...gax.CallOption) (*credentialspb.SignBlobResponse, error)
+		}
+
+		// These are for the produced SignBytesFunc
+		input      []byte
+		wantOutput []byte
+		requestErr error
+	}{
+		{"happy path: signing", nil,
+			mockIAMClient{},
+			[]byte("payload"), []byte(mockSignature), nil,
+		},
+		{"won't connect", errors.New("Missing role: serviceAccountTokenCreator"),
+			mockIAMClient{},
+			[]byte("payload"), nil, nil,
+		},
+		{"request fails", nil,
+			mockIAMClient{requestErr: context.Canceled},
+			[]byte("payload"), nil, context.Canceled,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := credentialsClient{err: test.connectErr, client: test.mockClient}
+			makeSignBytesFn := c.CreateMakeSignBytesWith(nil, serviceAccountID)
+
+			signBytesFn := makeSignBytesFn(nil) // Our mocks don't read any context.
+			haveOutput, haveErr := signBytesFn(test.input)
+
+			if len(test.wantOutput) > 0 && string(haveOutput) != string(test.wantOutput) {
+				t.Errorf("Unexpected output:\n -- have: %v\n -- want: %v",
+					string(haveOutput), string(test.wantOutput))
+				return
+			}
+
+			if test.connectErr == nil && test.requestErr == nil {
+				return
+			}
+			if test.connectErr != nil && haveErr != test.connectErr {
+				t.Error("The connection error, a permanent error, has not been returned but should.")
+			}
+			if test.requestErr != nil && haveErr != test.requestErr {
+				t.Error("The per-request error has not been returned but should.")
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/google/wire v0.3.0
 	github.com/googleapis/gax-go v2.0.2+incompatible
+	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/lib/pq v1.1.1
 	go.opencensus.io v0.22.2
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413


### PR DESCRIPTION
This enables to use blob.SignURL out-of-the-box by setting the required values, primarily the GoogleAccessID and a PrivateKey—where available—, and a default signing behaviour.

By moving the IAM Credentials API client into the bucket, it's henceforth possible to use it in `bucket.Options.SignBytes()` without any external wrapper.

Previously users ran into `SignURL` working properly with the likes of S3 without doing anything special, and GCS has been the outlier that needed additional work degrading productivity and developer experience.

closes #2653 
