### PR TITLE
doctore: use gcerrors in driver interface

### DIFF
--- a/docstore/awsdynamodb/dynamo.go
+++ b/docstore/awsdynamodb/dynamo.go
@@ -698,30 +698,30 @@ func (c *collection) ErrorAs(err error, i interface{}) bool {
 	return true
 }
 
-func (c *collection) ErrorCode(err error) gcerr.ErrorCode {
+func (c *collection) ErrorCode(err error) gcerrors.ErrorCode {
 	ae, ok := err.(awserr.Error)
 	if !ok {
-		return gcerr.Unknown
+		return gcerrors.Unknown
 	}
 	ec, ok := errorCodeMap[ae.Code()]
 	if !ok {
-		return gcerr.Unknown
+		return gcerrors.Unknown
 	}
 	return ec
 }
 
 var errorCodeMap = map[string]gcerrors.ErrorCode{
-	dyn.ErrCodeConditionalCheckFailedException:          gcerr.FailedPrecondition,
-	dyn.ErrCodeProvisionedThroughputExceededException:   gcerr.ResourceExhausted,
-	dyn.ErrCodeResourceNotFoundException:                gcerr.NotFound,
-	dyn.ErrCodeItemCollectionSizeLimitExceededException: gcerr.ResourceExhausted,
-	dyn.ErrCodeTransactionConflictException:             gcerr.Internal,
-	dyn.ErrCodeRequestLimitExceeded:                     gcerr.ResourceExhausted,
-	dyn.ErrCodeInternalServerError:                      gcerr.Internal,
-	dyn.ErrCodeTransactionCanceledException:             gcerr.FailedPrecondition,
-	dyn.ErrCodeTransactionInProgressException:           gcerr.InvalidArgument,
-	dyn.ErrCodeIdempotentParameterMismatchException:     gcerr.InvalidArgument,
-	"ValidationException":                               gcerr.InvalidArgument,
+	dyn.ErrCodeConditionalCheckFailedException:          gcerrors.FailedPrecondition,
+	dyn.ErrCodeProvisionedThroughputExceededException:   gcerrors.ResourceExhausted,
+	dyn.ErrCodeResourceNotFoundException:                gcerrors.NotFound,
+	dyn.ErrCodeItemCollectionSizeLimitExceededException: gcerrors.ResourceExhausted,
+	dyn.ErrCodeTransactionConflictException:             gcerrors.Internal,
+	dyn.ErrCodeRequestLimitExceeded:                     gcerrors.ResourceExhausted,
+	dyn.ErrCodeInternalServerError:                      gcerrors.Internal,
+	dyn.ErrCodeTransactionCanceledException:             gcerrors.FailedPrecondition,
+	dyn.ErrCodeTransactionInProgressException:           gcerrors.InvalidArgument,
+	dyn.ErrCodeIdempotentParameterMismatchException:     gcerrors.InvalidArgument,
+	"ValidationException":                               gcerrors.InvalidArgument,
 }
 
 // Close implements driver.Collection.Close.

--- a/docstore/driver/driver.go
+++ b/docstore/driver/driver.go
@@ -20,7 +20,7 @@ package driver // import "gocloud.dev/docstore/driver"
 import (
 	"context"
 
-	"gocloud.dev/internal/gcerr"
+	"gocloud.dev/gcerrors"
 )
 
 // A Collection is a set of documents.
@@ -88,7 +88,7 @@ type Collection interface {
 
 	// ErrorCode should return a code that describes the error, which was returned by
 	// one of the other methods in this interface.
-	ErrorCode(error) gcerr.ErrorCode
+	ErrorCode(error) gcerrors.ErrorCode
 
 	// Close cleans up any resources used by the Collection. Once Close is called,
 	// there will be no method calls to the Collection other than As, ErrorAs, and

--- a/docstore/gcpfirestore/fs.go
+++ b/docstore/gcpfirestore/fs.go
@@ -80,6 +80,7 @@ import (
 	"github.com/google/wire"
 	"gocloud.dev/docstore"
 	"gocloud.dev/docstore/driver"
+	"gocloud.dev/gcerrors"
 	"gocloud.dev/gcp"
 	"gocloud.dev/internal/gcerr"
 	"gocloud.dev/internal/useragent"
@@ -725,7 +726,7 @@ func preconditionFromTimestamp(ts *tspb.Timestamp) *pb.Precondition {
 	return &pb.Precondition{ConditionType: &pb.Precondition_UpdateTime{ts}}
 }
 
-func (c *collection) ErrorCode(err error) gcerr.ErrorCode {
+func (c *collection) ErrorCode(err error) gcerrors.ErrorCode {
 	return gcerr.GRPCCode(err)
 }
 

--- a/docstore/memdocstore/mem.go
+++ b/docstore/memdocstore/mem.go
@@ -162,7 +162,7 @@ func (c *collection) RevisionField() string {
 }
 
 // ErrorCode implements driver.ErrorCode.
-func (c *collection) ErrorCode(err error) gcerr.ErrorCode {
+func (c *collection) ErrorCode(err error) gcerrors.ErrorCode {
 	return gcerrors.Code(err)
 }
 


### PR DESCRIPTION
Using the internal type in the interface makes it impossible to write external drivers.

Fixes #2779.