### PR TITLE
mysql: add FromScheme allowing us to get opener my scheme

### DIFF
--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -106,6 +106,15 @@ func (mux *URLMux) OpenMySQLURL(ctx context.Context, u *url.URL) (*sql.DB, error
 	return opener.(MySQLURLOpener).OpenMySQLURL(ctx, u)
 }
 
+// FromScheme returns a opener for a given scheme.
+func (mux *URLMux) FromScheme(scheme string) (MySQLURLOpener, error) {
+	opener, err := mux.schemes.FromURL("DB", &url.URL{Scheme: scheme})
+	if err != nil {
+		return nil, err
+	}
+	return opener.(MySQLURLOpener), nil
+}
+
 var defaultURLMux = new(URLMux)
 
 // DefaultURLMux returns the URLMux used by OpenMySql.

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -34,3 +34,16 @@ func TestOpen(t *testing.T) {
 		t.Error("Close:", err)
 	}
 }
+
+func TestURLMuxFromScheme(t *testing.T) {
+	opener, err := DefaultURLMux().FromScheme(Scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opener == nil {
+		t.Fatal("got nil opener")
+	}
+	if _, ok := opener.(*URLOpener); !ok {
+		t.Errorf("wanted *URLOpener, got %T", opener)
+	}
+}


### PR DESCRIPTION
Add the ability to fetch `MySQLURLOpener` by scheme. This can be used to patch underlying URLOpeners with additional configs.

For example say we want to customize the trace options awsmysql driver uses:

```go
import (
  "gocloud.dev/mysql"
  "gocloud.dev/mysql/awsmysql"
  "contrib.go.opencensus.io/integrations/ocsql"
)

func init() {
  opener, _ := mysql.DefaultURLMux().FromScheme(awsmysql.Scheme)
  opener.(*awsmysql.URLOpener).TraceOpts = []ocsql.TraceOption{
    ocsql.WithAllowRoot(true),
  }
}
```
