### PR TITLE
mysql: add trace options to default mysql opener

### DIFF
--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -38,28 +38,29 @@ func init() {
 
 // URLOpener opens URLs like "mysql://" by using the underlying MySQL driver.
 // See https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters for details.
-type URLOpener struct{}
-
-// OpenMySQLURL opens a new database connection wrapped with OpenCensus instrumentation.
-func (*URLOpener) OpenMySQLURL(ctx context.Context, u *url.URL) (*sql.DB, error) {
-	db, err := openWithURL(u)
-	return db, err
+type URLOpener struct {
+	TraceOpts []ocsql.TraceOption
 }
 
-func openWithURL(url *url.URL) (*sql.DB, error) {
-	return sql.OpenDB(connector{dsn: strings.TrimPrefix(url.String(), Scheme+"://")}), nil
+// OpenMySQLURL opens a new database connection wrapped with OpenCensus instrumentation.
+func (uo *URLOpener) OpenMySQLURL(_ context.Context, u *url.URL) (*sql.DB, error) {
+	return sql.OpenDB(connector{
+		dsn:       strings.TrimPrefix(u.String(), Scheme+"://"),
+		traceOpts: append([]ocsql.TraceOption(nil), uo.TraceOpts...),
+	}), nil
 }
 
 type connector struct {
-	dsn string
+	dsn       string
+	traceOpts []ocsql.TraceOption
 }
 
-func (c connector) Connect(ctx context.Context) (driver.Conn, error) {
+func (c connector) Connect(context.Context) (driver.Conn, error) {
 	return c.Driver().Open(c.dsn)
 }
 
 func (c connector) Driver() driver.Driver {
-	return ocsql.Wrap(mysql.MySQLDriver{})
+	return ocsql.Wrap(mysql.MySQLDriver{}, c.traceOpts...)
 }
 
 // A type that implements MySQLURLOpener can open connection based on a URL.


### PR DESCRIPTION
Add ocsql.TraceOpts to default opener as we do for cloud specific ones.
