### PR TITLE
secrets/localsecret: Provide key decoders for URL and Std base64, and use the former for URLs

### DIFF
--- a/secrets/localsecrets/localsecrets.go
+++ b/secrets/localsecrets/localsecrets.go
@@ -93,11 +93,23 @@ func NewKeeper(sk [32]byte) *secrets.Keeper {
 	)
 }
 
+// Base64KeyStd takes a secret key as a base64 string and converts it
+// to a [32]byte, erroring if the decoded data is not 32 bytes.
+// It uses base64.StdEncoding.
+func Base64KeyStd(base64str string) ([32]byte, error) {
+	return base64Key(base64str, base64.StdEncoding)
+}
+
 // Base64Key takes a secret key as a base64 string and converts it
 // to a [32]byte, erroring if the decoded data is not 32 bytes.
+// It uses base64.URLEncoding.
 func Base64Key(base64str string) ([32]byte, error) {
+	return base64Key(base64str, base64.URLEncoding)
+}
+
+func base64Key(base64str string, encoding *base64.Encoding) ([32]byte, error) {
 	var sk32 [32]byte
-	key, err := base64.StdEncoding.DecodeString(base64str)
+	key, err := encoding.DecodeString(base64str)
 	if err != nil {
 		return sk32, err
 	}

--- a/secrets/localsecrets/localsecrets_test.go
+++ b/secrets/localsecrets/localsecrets_test.go
@@ -130,6 +130,8 @@ func TestOpenKeeper(t *testing.T) {
 		{"base64key://c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c3NlY3JldHNlY3JldHNlY3JldHNlY3JldHNlY3JldHM=", true},
 		// Invalid base64 key.
 		{"base64key://not-valid-base64", true},
+		// Valid base64 key (but invalid if using Std encoding instead of URL encoding).
+		{"base64Key://UKcmEoZW7nKl0uPHr8yV__KJm0ANhiFz8PzDN-gYWq8=", false},
 		// Invalid parameter.
 		{"base64key://?param=value", true},
 	}


### PR DESCRIPTION
Fixes #2826.