### PR TITLE
docstore/mongodocstore: don't include revision field projection twice; Mongo 4.4 rejects that

### DIFF
--- a/docstore/mongodocstore/mongo.go
+++ b/docstore/mongodocstore/mongo.go
@@ -294,7 +294,10 @@ func (c *collection) bulkFind(ctx context.Context, gets []*driver.Action, errs [
 func (c *collection) projectionDoc(fps [][]string) bson.D {
 	proj := bson.D{{Key: c.revisionField, Value: 1}}
 	for _, fp := range fps {
-		proj = append(proj, bson.E{Key: c.toMongoFieldPath(fp), Value: 1})
+		path := c.toMongoFieldPath(fp)
+		if path != c.revisionField {
+			proj = append(proj, bson.E{Key: path, Value: 1})
+		}
 	}
 	return proj
 }


### PR DESCRIPTION
Fixes #2842 

With some extra logging, before this PR the test fails with:

```
PROJECTION [{DocstoreRevision 1} {f 1} {m.b 1} {DocstoreRevision 1}] 
--- FAIL: TestConformance (0.12s)                                                                                                        
    --- FAIL: TestConformance/V3 (0.12s)                                                                                                 
        --- FAIL: TestConformance/V3/Get (0.05s)                                                                                                                                                                                                                                  
            --- FAIL: TestConformance/V3/Get/StdRev (0.05s)                                                                              
                drivertest.go:645: docstore (code=Unknown): (Location31250) Path collision at DocstoreRevision
```

This is due to a breaking change in Mongo 4.4:
https://docs.mongodb.com/manual/release-notes/4.4-compatibility/#path-collision-restrictions

This PR avoids the problem by not projecting the same field twice.