### PR TITLE
all: update to testing with go 1.14 and go 1.15, dropping go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,13 @@ env:
 
 jobs:
   include:
-    - go: "1.13.x"
-      os: linux
     - go: "1.14.x"
       os: linux
-    - go: "1.14.x"
+    - go: "1.15.x"
+      os: linux
+    - go: "1.15.x"
       os: osx
-    - go: "1.14.x"
+    - go: "1.15.x"
       os: windows
       # TODO(rvangent): Remove filter_secrets: false once the Travis issue is fixed:
       # https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264/10

--- a/internal/testing/runchecks.sh
+++ b/internal/testing/runchecks.sh
@@ -80,7 +80,7 @@ rootdir="$(pwd)"
 # new Go version. Some checks below we only run
 # for the latest Go version.
 latest_go_version=0
-if [[ $(go version) == *go1\.14* ]]; then
+if [[ $(go version) == *go1\.15* ]]; then
   latest_go_version=1
 fi
 


### PR DESCRIPTION
Fixes #2843.