### PR TITLE
mysql: fix DSN parsing from URL

### DIFF
--- a/mysql/awsmysql/awsmysql_test.go
+++ b/mysql/awsmysql/awsmysql_test.go
@@ -17,7 +17,6 @@ package awsmysql
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"testing"
 
 	"gocloud.dev/internal/testing/terraform"
@@ -55,23 +54,5 @@ func TestOpen(t *testing.T) {
 	}
 	if err := db.Close(); err != nil {
 		t.Error("Close:", err)
-	}
-}
-
-func TestConfigFromURL(t *testing.T) {
-	const urlstr = "awsmysql://localhost/db?parseTime=true&interpolateParams=true"
-	u, err := url.Parse(urlstr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cfg, err := configFromURL(u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !cfg.ParseTime {
-		t.Error("ParseTime is false, want true")
-	}
-	if !cfg.InterpolateParams {
-		t.Error("InterpolateParams is false, want true")
 	}
 }

--- a/mysql/main.tf
+++ b/mysql/main.tf
@@ -1,0 +1,86 @@
+# Copyright 2020 The Go Cloud Development Kit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Harness for MySQL tests.
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    docker = {
+      source  = "terraform-providers/docker"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 2.0"
+    }
+  }
+}
+
+variable port {
+  type        = number
+  description = "Port exposed out of the MySQL container."
+  default     = 3306
+}
+
+resource random_pet mysql {}
+
+resource random_password db_password {
+  special = false
+  length  = 20
+}
+
+locals {
+  db_name = "testdb"
+}
+
+resource docker_container mysql {
+  name  = random_pet.mysql.id
+  image = docker_image.mysql.latest
+
+  env = [
+    "MYSQL_ROOT_PASSWORD=${random_password.db_password.result}",
+    "MYSQL_DATABASE=${local.db_name}",
+  ]
+  ports {
+    internal = 3306
+    external = var.port
+  }
+}
+
+resource docker_image mysql {
+  name = "mysql"
+}
+
+output endpoint {
+  value       = "localhost:${var.port}"
+  description = "The MySQL instance's host/port."
+}
+
+output username {
+  value       = "root"
+  description = "The MySQL username to connect with."
+}
+
+output password {
+  value       = random_password.db_password.result
+  sensitive   = true
+  description = "The MySQL instance password for the user."
+}
+
+output database {
+  value       = local.db_name
+  description = "The name of the database inside the MySQL instance."
+}
+

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -16,6 +16,7 @@ package mysql
 
 import (
 	"context"
+	"net/url"
 	"testing"
 )
 
@@ -32,5 +33,23 @@ func TestOpen(t *testing.T) {
 	}
 	if err := dbByURL.Close(); err != nil {
 		t.Error("Close:", err)
+	}
+}
+
+func TestConfigFromURL(t *testing.T) {
+	const urlstr = "mysql://localhost/db?parseTime=true&interpolateParams=true"
+	u, err := url.Parse(urlstr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ConfigFromURL(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.ParseTime {
+		t.Error("ParseTime is false, want true")
+	}
+	if !cfg.InterpolateParams {
+		t.Error("InterpolateParams is false, want true")
 	}
 }

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -16,22 +16,43 @@ package mysql
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"testing"
+
+	"gocloud.dev/internal/testing/terraform"
 )
 
 func TestOpen(t *testing.T) {
-	t.Skip("Test not hermetic yet")
+	// This test will be skipped unless the project is set up with Terraform.
+	// Before running go test, run in this directory:
+	//
+	// terraform init
+	// terraform apply
+
+	tfOut, err := terraform.ReadOutput(".")
+	if err != nil || len(tfOut) == 0 {
+		t.Skipf("Could not obtain harness info: %v", err)
+	}
+	endpoint, _ := tfOut["endpoint"].Value.(string)
+	username, _ := tfOut["username"].Value.(string)
+	password, _ := tfOut["password"].Value.(string)
+	databaseName, _ := tfOut["database"].Value.(string)
+	if endpoint == "" || username == "" || databaseName == "" {
+		t.Fatalf("Missing one or more required Terraform outputs; got endpoint=%q username=%q database=%q", endpoint, username, databaseName)
+	}
 
 	ctx := context.Background()
-	dbByURL, err := Open(ctx, "mysql://root@localhost/mysql")
+	urlstr := fmt.Sprintf("%s://%s:%s@%s/%s", Scheme, username, password, endpoint, databaseName)
+	t.Log("Connecting to:", urlstr)
+	db, err := Open(ctx, urlstr)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := dbByURL.Ping(); err != nil {
+	if err := db.Ping(); err != nil {
 		t.Error("Ping:", err)
 	}
-	if err := dbByURL.Close(); err != nil {
+	if err := db.Close(); err != nil {
 		t.Error("Close:", err)
 	}
 }


### PR DESCRIPTION
Currently it's not possible to open a mysql instance via URL and when attempted the following error is shows:
URL: mysql://root:root@localhost/testdb
Error: default addr for network 'localhost' unknown

This occurs since mysql.OpenMySQLURL treats a mysql DSN as a URL prefixed with a schema which is incorrect.
In order to fix this I moved the `configFromURL` function I added in https://github.com/google/go-cloud/pull/2831 to mysql package and made it public. In addition I've added a terraform harnest for mysql driver using docker provider.

Fixed https://github.com/google/go-cloud/issues/2856.