### PR TITLE
pubsub: Add attributes to the message object request

### DIFF
--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -671,6 +671,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 		QueueUrl:              aws.String(s.qURL),
 		MaxNumberOfMessages:   aws.Int64(int64(maxMessages)),
 		MessageAttributeNames: []*string{aws.String("All")},
+		AttributeNames:        []*string{aws.String("All")},
 	}
 	if s.opts.WaitTime != 0 {
 		req.WaitTimeSeconds = aws.Int64(int64(s.opts.WaitTime.Seconds()))


### PR DESCRIPTION
As we read through the messages on our consumers, we would like access to the ApproximateReceiveCount in order to make business logic decisions. We also leverage FIFO queues and as such, it would be helpful to have access to the MessageDeduplicationId and MessageGroupId (hence the option is set to All in this PR).

If preferred, I can cherry-pick the attributes we want access to but that would inconvenience those that want to use other fields.