### PR TITLE
blob/all: adding BeforeSign support to SignedURL operation

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -62,6 +62,7 @@
 //  - Attributes: azblob.BlobGetPropertiesResponse
 //  - CopyOptions.BeforeCopy: azblob.Metadata, *azblob.ModifiedAccessConditions, *azblob.BlobAccessConditions
 //  - WriterOptions.BeforeWrite: *azblob.UploadStreamToBlockBlobOptions
+//  - SignedURLOptions.BeforeSign: *azblob.BlobSASSignatureValues
 package azureblob
 
 import (
@@ -749,15 +750,27 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 	default:
 		return "", fmt.Errorf("unsupported Method %s", opts.Method)
 	}
-	var err error
-	srcBlobParts.SAS, err = azblob.BlobSASSignatureValues{
+	signVals := &azblob.BlobSASSignatureValues{
 		Protocol:      azblob.SASProtocolHTTPS,
 		ExpiryTime:    time.Now().UTC().Add(opts.Expiry),
 		ContainerName: b.name,
 		BlobName:      srcBlobParts.BlobName,
 		Permissions:   perms.String(),
-	}.NewSASQueryParameters(b.opts.Credential)
-	if err != nil {
+	}
+	if opts.BeforeSign != nil {
+		asFunc := func(i interface{}) bool {
+			v, ok := i.(**azblob.BlobSASSignatureValues)
+			if ok {
+				*v = signVals
+			}
+			return ok
+		}
+		if err := opts.BeforeSign(asFunc); err != nil {
+			return "", err
+		}
+	}
+	var err error
+	if srcBlobParts.SAS, err = signVals.NewSASQueryParameters(b.opts.Credential); err != nil {
 		return "", err
 	}
 	srcBlobURLWithSAS := srcBlobParts.URL()

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -221,6 +221,14 @@ func (verifyContentLanguage) BeforeList(as func(interface{}) bool) error {
 	return nil
 }
 
+func (verifyContentLanguage) BeforeSign(as func(interface{}) bool) error {
+	var azOpts *azblob.BlobSASSignatureValues
+	if !as(&azOpts) {
+		return errors.New("BeforeSign.As failed")
+	}
+	return nil
+}
+
 func (verifyContentLanguage) AttributesCheck(attrs *blob.Attributes) error {
 	var resp azblob.BlobGetPropertiesResponse
 	if !attrs.As(&resp) {

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -945,6 +945,7 @@ func (b *Bucket) SignedURL(ctx context.Context, key string, opts *SignedURLOptio
 	}
 	dopts.ContentType = opts.ContentType
 	dopts.EnforceAbsentContentType = opts.EnforceAbsentContentType
+	dopts.BeforeSign = opts.BeforeSign
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	if b.closed {
@@ -999,6 +1000,12 @@ type SignedURLOptions struct {
 	//
 	// Must be false for non-PUT requests.
 	EnforceAbsentContentType bool
+
+	// BeforeSign is a callback that will be called before each call to the
+	// the underlying service's sign functionality.
+	// asFunc converts its argument to driver-specific types.
+	// See https://gocloud.dev/concepts/as/ for background information.
+	BeforeSign func(asFunc func(interface{}) bool) error
 }
 
 // ReaderOptions sets options for NewReader and NewRangeReader.

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -330,6 +330,12 @@ type SignedURLOptions struct {
 	//
 	// This field will always be false for non-PUT requests.
 	EnforceAbsentContentType bool
+
+	// BeforeSign is a callback that will be called before each call to the
+	// the underlying service's sign functionality.
+	// asFunc converts its argument to driver-specific types.
+	// See https://gocloud.dev/concepts/as/ for background information.
+	BeforeSign func(asFunc func(interface{}) bool) error
 }
 
 // prefixedBucket implements Bucket by prepending prefix to all keys.

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -651,6 +651,11 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 	if b.opts.URLSigner == nil {
 		return "", errors.New("sign fileblob url: bucket does not have an Options.URLSigner")
 	}
+	if opts.BeforeSign != nil {
+		if err := opts.BeforeSign(func(interface{}) bool { return false }); err != nil {
+			return "", err
+		}
+	}
 	surl, err := b.opts.URLSigner.URLFromKey(ctx, key, opts)
 	if err != nil {
 		return "", err

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -214,6 +214,7 @@ func (verifyPathError) BeforeRead(as func(interface{}) bool) error   { return ni
 func (verifyPathError) BeforeWrite(as func(interface{}) bool) error  { return nil }
 func (verifyPathError) BeforeCopy(as func(interface{}) bool) error   { return nil }
 func (verifyPathError) BeforeList(as func(interface{}) bool) error   { return nil }
+func (verifyPathError) BeforeSign(as func(interface{}) bool) error   { return nil }
 func (verifyPathError) AttributesCheck(attrs *blob.Attributes) error { return nil }
 func (verifyPathError) ReaderCheck(r *blob.Reader) error             { return nil }
 func (verifyPathError) ListObjectCheck(o *blob.ListObject) error     { return nil }

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -52,6 +52,7 @@
 //  - Attributes: storage.ObjectAttrs
 //  - CopyOptions.BeforeCopy: *CopyObjectHandles, *storage.Copier (if accessing both, must be in that order)
 //  - WriterOptions.BeforeWrite: **storage.ObjectHandle, *storage.Writer (if accessing both, must be in that order)
+//  - SignedURLOptions.BeforeSign: *storage.SignedURLOptions
 package gcsblob // import "gocloud.dev/blob/gcsblob"
 
 import (
@@ -711,6 +712,18 @@ func (b *bucket) SignedURL(ctx context.Context, key string, dopts *driver.Signed
 	}
 	if b.opts.MakeSignBytes != nil {
 		opts.SignBytes = b.opts.MakeSignBytes(ctx)
+	}
+	if dopts.BeforeSign != nil {
+		asFunc := func(i interface{}) bool {
+			v, ok := i.(**storage.SignedURLOptions)
+			if ok {
+				*v = opts
+			}
+			return ok
+		}
+		if err := dopts.BeforeSign(asFunc); err != nil {
+			return "", err
+		}
 	}
 	return storage.SignedURL(b.name, key, opts)
 }

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -196,6 +196,15 @@ func (verifyContentLanguage) BeforeList(as func(interface{}) bool) error {
 	return nil
 }
 
+func (verifyContentLanguage) BeforeSign(as func(interface{}) bool) error {
+	var opts *storage.SignedURLOptions
+	if !as(&opts) {
+		return errors.New("BeforeSign.As failed")
+	}
+	// Nothing to do.
+	return nil
+}
+
 func (verifyContentLanguage) AttributesCheck(attrs *blob.Attributes) error {
 	var oa storage.ObjectAttrs
 	if !attrs.As(&oa) {

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -51,6 +51,10 @@
 //  - Attributes: s3.HeadObjectOutput
 //  - CopyOptions.BeforeCopy: *s3.CopyObjectInput
 //  - WriterOptions.BeforeWrite: *s3manager.UploadInput, *s3manager.Uploader
+//  - SignedURLOptions.BeforeSign:
+//      *s3.GetObjectInput when Options.Method == http.MethodGet, or
+//      *s3.PutObjectInput when Options.Method == http.MethodPut, or
+//      *s3.DeleteObjectInput when Options.Method == http.MethodDelete
 package s3blob // import "gocloud.dev/blob/s3blob"
 
 import (
@@ -70,6 +74,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/google/wire"
@@ -727,30 +732,66 @@ func (b *bucket) Delete(ctx context.Context, key string) error {
 
 func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedURLOptions) (string, error) {
 	key = escapeKey(key)
+	var req *request.Request
 	switch opts.Method {
 	case http.MethodGet:
 		in := &s3.GetObjectInput{
 			Bucket: aws.String(b.name),
 			Key:    aws.String(key),
 		}
-		req, _ := b.client.GetObjectRequest(in)
-		return req.Presign(opts.Expiry)
+		if opts.BeforeSign != nil {
+			asFunc := func(i interface{}) bool {
+				v, ok := i.(**s3.GetObjectInput)
+				if ok {
+					*v = in
+				}
+				return ok
+			}
+			if err := opts.BeforeSign(asFunc); err != nil {
+				return "", err
+			}
+		}
+		req, _ = b.client.GetObjectRequest(in)
 	case http.MethodPut:
 		in := &s3.PutObjectInput{
 			Bucket:      aws.String(b.name),
 			Key:         aws.String(key),
 			ContentType: aws.String(opts.ContentType),
 		}
-		req, _ := b.client.PutObjectRequest(in)
-		return req.Presign(opts.Expiry)
+		if opts.BeforeSign != nil {
+			asFunc := func(i interface{}) bool {
+				v, ok := i.(**s3.PutObjectInput)
+				if ok {
+					*v = in
+				}
+				return ok
+			}
+			if err := opts.BeforeSign(asFunc); err != nil {
+				return "", err
+			}
+		}
+		req, _ = b.client.PutObjectRequest(in)
 	case http.MethodDelete:
 		in := &s3.DeleteObjectInput{
 			Bucket: aws.String(b.name),
 			Key:    aws.String(key),
 		}
-		req, _ := b.client.DeleteObjectRequest(in)
-		return req.Presign(opts.Expiry)
+		if opts.BeforeSign != nil {
+			asFunc := func(i interface{}) bool {
+				v, ok := i.(**s3.DeleteObjectInput)
+				if ok {
+					*v = in
+				}
+				return ok
+			}
+			if err := opts.BeforeSign(asFunc); err != nil {
+				return "", err
+			}
+		}
+		req, _ = b.client.DeleteObjectRequest(in)
 	default:
 		return "", fmt.Errorf("unsupported Method %q", opts.Method)
 	}
+	req.SetContext(ctx)
+	return req.Presign(opts.Expiry)
 }

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -730,7 +730,7 @@ func (b *bucket) Delete(ctx context.Context, key string) error {
 	return err
 }
 
-func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedURLOptions) (string, error) {
+func (b *bucket) SignedURL(_ context.Context, key string, opts *driver.SignedURLOptions) (string, error) {
 	key = escapeKey(key)
 	var req *request.Request
 	switch opts.Method {
@@ -792,6 +792,5 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 	default:
 		return "", fmt.Errorf("unsupported Method %q", opts.Method)
 	}
-	req.SetContext(ctx)
 	return req.Presign(opts.Expiry)
 }

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -169,6 +169,18 @@ func (v verifyContentLanguage) BeforeList(as func(interface{}) bool) error {
 	return nil
 }
 
+func (v verifyContentLanguage) BeforeSign(as func(interface{}) bool) error {
+	var (
+		get *s3.GetObjectInput
+		put *s3.PutObjectInput
+		del *s3.DeleteObjectInput
+	)
+	if as(&get) || as(&put) || as(&del) {
+		return nil
+	}
+	return errors.New("BeforeSign.As failed")
+}
+
 func (verifyContentLanguage) AttributesCheck(attrs *blob.Attributes) error {
 	var hoo s3.HeadObjectOutput
 	if !attrs.As(&hoo) {


### PR DESCRIPTION
`BeforeSign` is similar to `BeforeRead` and friends allowing users to hook into SignedURL operation. In my case it's needed to set `ContentDisposition` before signing s3blob get request.
