### PR TITLE
doc: remove go report card link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ _Write once, run on any cloud ☁️_
 [![Build Status](https://travis-ci.com/google/go-cloud.svg?branch=master)][travis]
 [![PkgGoDev](https://pkg.go.dev/badge/mod/gocloud.dev)][PkgGoDev]
 [![Coverage](https://codecov.io/gh/google/go-cloud/branch/master/graph/badge.svg)](https://codecov.io/gh/google/go-cloud)
-[![Go Report Card](https://goreportcard.com/badge/github.com/google/go-cloud)](https://goreportcard.com/report/github.com/google/go-cloud)
 
 <p align="center">
   <img width="509" height="276" src="internal/website/static/go-cdk-logo-gopherblue.png" alt="">


### PR DESCRIPTION
It seems to be broken due to "too many open files". Seems safer to just remove it for now
