### PR TITLE
`internal/website`: fix wrong document link

### DIFF
--- a/internal/website/content/howto/docstore/_index.md
+++ b/internal/website/content/howto/docstore/_index.md
@@ -404,7 +404,7 @@ whose name is the combination of two or more fields.
 
 ### In-Memory Document Store {#mem}
 
-The [`memdocstore`](https://godoc.org/gocloud.dev/docstore/mongodocstore)
+The [`memdocstore`](https://godoc.org/gocloud.dev/docstore/memdocstore)
 package implements an in-memory document store suitable for testing and
 development.
 


### PR DESCRIPTION
Docstore's how to guide points to wrong web url (the label is memdocstore, but link destination is mongodocstore). This PR just fix this link issue.