### PR TITLE
pubsub/azuresb: Simplify ReceiveBatch to only return 1 message; fixes error handling

### DIFF
--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -647,6 +647,8 @@ type SubscriptionOptions struct {
 
 	// WaitTime passed to ReceiveMessage to enable long polling.
 	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling.
+	// Note that a non-zero WaitTime can delay delivery of messages
+	// by up to that duration.
 	WaitTime time.Duration
 }
 

--- a/pubsub/azuresb/azuresb.go
+++ b/pubsub/azuresb/azuresb.go
@@ -455,7 +455,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 	// ReceiveOne will block until ctx is Done; we want to return after
 	// a reasonably short delay even if there are no messages. So, create a
 	// sub context for the RPC.
-	rCtx, cancel := context.WithTimeout(ctx, listenerTimeout)
+	rctx, cancel := context.WithTimeout(ctx, listenerTimeout)
 	defer cancel()
 
 	// NOTE: there's also a Receive method, but it starts two goroutines
@@ -463,7 +463,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 	// data races if Receive is called again quickly. ReceiveOne is more
 	// straightforward.
 	var message *driver.Message
-	err := s.sbSub.ReceiveOne(rCtx, servicebus.HandlerFunc(func(_ context.Context, sbmsg *servicebus.Message) error {
+	err := s.sbSub.ReceiveOne(rctx, servicebus.HandlerFunc(func(_ context.Context, sbmsg *servicebus.Message) error {
 		metadata := map[string]string{}
 		for key, value := range sbmsg.GetKeyValues() {
 			if strVal, ok := value.(string); ok {
@@ -484,8 +484,8 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 		}
 		return nil
 	}))
-	// Mask rCtx timeouts, they are expected if no messages are available.
-	if err == rCtx.Err() {
+	// Mask rctx timeouts, they are expected if no messages are available.
+	if err == rctx.Err() {
 		err = nil
 	}
 	return []*driver.Message{message}, err

--- a/pubsub/driver/driver.go
+++ b/pubsub/driver/driver.go
@@ -125,7 +125,8 @@ type Subscription interface {
 	// should return a nil slice and an error. The concrete API will take
 	// care of retry logic.
 	//
-	// If no messages are currently available, this method can return an empty
+	// If no messages are currently available, this method should block for
+	// no more than about 1 second. It can return an empty
 	// slice of messages and no error. ReceiveBatch will be called again
 	// immediately, so implementations should try to wait for messages for some
 	// non-zero amount of time before returning zero messages. If the underlying


### PR DESCRIPTION
Fixes #2897 
Fixes #2899
Fixes #2900

This code is simpler than before; it relies on the concrete type behavior of retrying driver.ReceiveBatch calls as needed, instead of trying to batch up some messages artificially inside ReceiveBatch.

It also fixes a bug introduced in #2891, where a timeout in the call to `ReceiveOne` would cause failures.

I benchmarked this, and it's not noticeably slower than before; the overhead from letting the concrete type retry vs looping inside the driver is minimal. This also lets the concrete type react faster/better with more concurrency (by calling ReceiveBatch concurrently).