### PR TITLE
pubsub: fix data race accessing subscription error

### DIFF
--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -676,7 +676,7 @@ func (s *Subscription) Shutdown(ctx context.Context) (err error) {
 	s.mu.Lock()
 	if s.err == errSubscriptionShutdown {
 		// Already Shutdown.
-		s.mu.Unlock()
+		defer s.mu.Unlock()
 		return s.err
 	}
 	s.err = errSubscriptionShutdown


### PR DESCRIPTION
When running go test with -race I hit the following splat:
```
WARNING: DATA RACE
Write at 0x00c00048d1e8 by goroutine 68:
  gocloud.dev/pubsub.(*Subscription).Receive.func2()
      /home/runner/go/pkg/mod/gocloud.dev@v0.20.1-0.20200914152856-6be5a462804a/pubsub/pubsub.go:560 +0x4a4

Previous read at 0x00c00048d1e8 by goroutine 119:
  gocloud.dev/pubsub.(*Subscription).Shutdown()
      /home/runner/go/pkg/mod/gocloud.dev@v0.20.1-0.20200914152856-6be5a462804a/pubsub/pubsub.go:680 +0x61d
  github.com/facebookincubator/symphony/pkg/ev.(*TopicReceiver).Shutdown()
```
The issue occurs as .Shutdown reads `s.err` _after_ releasing the lock.