### PR TITLE
pubsub/all: add message ID to pubssub messages

### DIFF
--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -710,6 +710,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 		}
 
 		m2 := &driver.Message{
+			ID:       *m.MessageId,
 			Body:     b,
 			Metadata: attrs,
 			AckID:    m.ReceiptHandle,

--- a/pubsub/azuresb/azuresb.go
+++ b/pubsub/azuresb/azuresb.go
@@ -469,6 +469,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 				partitionID = *sbmsg.SystemProperties.PartitionID
 			}
 			messages = append(messages, &driver.Message{
+				ID:       sbmsg.ID,
 				Body:     sbmsg.Data,
 				Metadata: metadata,
 				AckID:    &partitionAckID{partitionID, sbmsg.LockToken},

--- a/pubsub/driver/driver.go
+++ b/pubsub/driver/driver.go
@@ -37,6 +37,10 @@ type AckInfo struct {
 // Message is data to be published (sent) to a topic and later received from
 // subscriptions on that topic.
 type Message struct {
+	// ID uniquely identify a message.
+	// ID must be populated on messages returned from ReceiveBatch.
+	ID string
+
 	// Body contains the content of the message.
 	Body []byte
 

--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -427,6 +427,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 	for _, rm := range resp.ReceivedMessages {
 		rmm := rm.Message
 		m := &driver.Message{
+			ID:       rmm.MessageId,
 			Body:     rmm.Data,
 			Metadata: rmm.Attributes,
 			AckID:    rm.AckId,

--- a/pubsub/kafkapubsub/kafka.go
+++ b/pubsub/kafkapubsub/kafka.go
@@ -520,6 +520,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 		}
 		ack := &ackInfo{msg: msg}
 		dm := &driver.Message{
+			ID:       "", // Kafka messages don't have an ID.
 			Body:     msg.Value,
 			Metadata: md,
 			AckID:    ack,

--- a/pubsub/mempubsub/mem.go
+++ b/pubsub/mempubsub/mem.go
@@ -151,6 +151,7 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 	// but that would require copying all the messages.
 	for i, m := range ms {
 		m.AckID = t.nextAckID + i
+		m.ID = fmt.Sprintf("%d", m.AckID)
 		m.AsFunc = func(interface{}) bool { return false }
 
 		if m.BeforeSend != nil {

--- a/pubsub/natspubsub/nats.go
+++ b/pubsub/natspubsub/nats.go
@@ -341,6 +341,8 @@ func decode(msg *nats.Msg) (*driver.Message, error) {
 	if err := decodeMessage(msg.Data, &dm); err != nil {
 		return nil, err
 	}
+
+	dm.ID = ""
 	dm.AckID = -1 // Not applicable to NATS
 	dm.AsFunc = messageAsFunc(msg)
 	return &dm, nil

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -89,6 +89,10 @@ import (
 
 // Message contains data to be published.
 type Message struct {
+	// ID uniquely identify a message.
+	// ID must be populated on messages returned from ReceiveBatch.
+	ID string
+
 	// Body contains the content of the message.
 	Body []byte
 
@@ -584,6 +588,7 @@ func (s *Subscription) Receive(ctx context.Context) (_ *Message, err error) {
 				md = nil
 			}
 			m2 := &Message{
+				ID:       m.ID,
 				Body:     m.Body,
 				Metadata: md,
 				asFunc:   m.AsFunc,

--- a/pubsub/rabbitpubsub/amqp.go
+++ b/pubsub/rabbitpubsub/amqp.go
@@ -62,7 +62,7 @@ type amqpChannel interface {
 	QueueDelete(qname string) error
 }
 
-// connection adapts an *amqp.Connection to the amqpConnection interface.
+// connection adapts an *amqp.Connection to the amqpConnection in terface.
 type connection struct {
 	conn *amqp.Connection
 }

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -627,6 +627,7 @@ func toMessage(d amqp.Delivery) *driver.Message {
 		md[k] = fmt.Sprint(v)
 	}
 	return &driver.Message{
+		ID:       d.MessageId,
 		Body:     d.Body,
 		AckID:    d.DeliveryTag,
 		Metadata: md,


### PR DESCRIPTION
Add read only `ID` property to pubsub messages. 

Only Kafka and Nats don't have this property -- I could be wrong, please confirm

This property is needed if we want to guarantee at most once delivery. It's also useful for logging/tracing and tracking messages.
