### PR TITLE
pubsub: fix data race accessing topic error on shutdown

### DIFF
--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -258,7 +258,7 @@ func (t *Topic) Shutdown(ctx context.Context) (err error) {
 
 	t.mu.Lock()
 	if t.err == errTopicShutdown {
-		t.mu.Unlock()
+		defer t.mu.Unlock()
 		return t.err
 	}
 	t.err = errTopicShutdown


### PR DESCRIPTION
Similar to https://github.com/google/go-cloud/pull/2901 but for topic shutdown.