### PR TITLE
blob/azureblob: Ensure container exist on write

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -907,6 +907,8 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType str
 		opts.BufferSize = defaultUploadBlockSize
 	}
 
+	b.containerURL.Create(ctx, nil, azblob.PublicAccessNone)
+
 	md := make(map[string]string, len(opts.Metadata))
 	for k, v := range opts.Metadata {
 		// See the package comments for more details on escaping of metadata


### PR DESCRIPTION
I've found that go-cloud doesn't create the container if it doesn't exist nor gives an option to create it. 

Adding this line will create it if it doesn't exist and do nothing if it already exists.

May is better to add this functionality at the driver level, but for now, this solves my issue.
