### PR TITLE
blob/azureblob: Obtain Credentials from MSI for URL Signing

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -836,16 +836,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 // SignedURL implements driver.SignedURL.
 func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedURLOptions) (string, error) {
 	if b.opts.Credential == nil {
-		if opts.Credential == nil {
-			return "", gcerr.New(gcerr.Unimplemented, nil, 1, "azureblob: to use SignedURL, you must call OpenBucket with a non-nil Options.Credential")
-		} else {
-			switch t := opts.Credential.(type) {
-			case azblob.StorageAccountCredential:
-				b.opts.Credential = opts.Credential.(azblob.StorageAccountCredential)
-			default:
-				return "", gcerr.New(gcerr.Unimplemented, nil, 1, fmt.Sprintf("azureblob: to use SignedURL, you must call OpenBucket with a non-nil Options.Credential got %+v", t))
-			}
-		}
+		return "", gcerr.New(gcerr.Unimplemented, nil, 1, "azureblob: to use SignedURL, you must call OpenBucket with a non-nil Options.Credential")
 	}
 	if opts.ContentType != "" || opts.EnforceAbsentContentType {
 		return "", gcerr.New(gcerr.Unimplemented, nil, 1, "azureblob: does not enforce Content-Type on PUT")

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -862,6 +862,8 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 		return "", gcerr.New(gcerr.Unimplemented, nil, 1, "azureblob: does not enforce Content-Type on PUT")
 	}
 
+	fmt.Printf("\n\n\n\ntoken: %+v\n", b.opts.Credential)
+
 	key = escapeKey(key, false)
 	blockBlobURL := b.containerURL.NewBlockBlobURL(key)
 	srcBlobParts := azblob.NewBlobURLParts(blockBlobURL.URL())

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -420,14 +420,11 @@ func NewPipeline(credential azblob.Credential, opts azblob.PipelineOptions) pipe
 // write and delete operations on objects within it.
 // See https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction.
 type bucket struct {
-	name         string
-	pageMarkers  map[string]azblob.Marker
-	serviceURL   *azblob.ServiceURL
-	containerURL azblob.ContainerURL
-	opts         *Options
-
-	// CredentialExpiration is when the current MSI-obtained signing credential
-	// expires so that we can refresh it on demand.
+	name                 string
+	pageMarkers          map[string]azblob.Marker
+	serviceURL           *azblob.ServiceURL
+	containerURL         azblob.ContainerURL
+	opts                 *Options
 	credentialExpiration time.Time
 }
 

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -852,7 +852,7 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 		}
 	}
 
-	if time.Now().UTC().Before(b.opts.CredentialExpiration) {
+	if time.Now().UTC().After(b.opts.CredentialExpiration) {
 		var err error
 		if b.opts.Credential, err = b.getDelegationCredentials(ctx); err != nil {
 			return "", err

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -851,7 +851,7 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 	if time.Now().UTC().After(b.credentialExpiration) {
 		var err error
 		if b.opts.Credential, err = b.getDelegationCredentials(ctx); err != nil {
-			return "", err
+			return "", gcerr.New(gcerr.Internal, err, 1, "azureblob: unable to generate User Delegation Credential")
 		}
 	}
 

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -101,7 +101,8 @@ const (
 // Options sets options for constructing a *blob.Bucket backed by Azure Block Blob.
 type Options struct {
 	// Credential represents the authorizer for SignedURL.
-	// Required to use SignedURL.
+	// Required to use SignedURL. If you're using MSI for authentication, this will
+	// attempt to be loaded lazily the first time you call SignedURL
 	Credential azblob.StorageAccountCredential
 
 	// SASToken can be provided along with anonymous credentials to use

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -490,7 +490,7 @@ func openBucket(ctx context.Context, pipeline pipeline.Pipeline, accountName Acc
 			keyInfo := azblob.NewKeyInfo(currentTime, currentTime.Add(48*time.Hour))
 			delegationCredentials, err := serviceURL.GetUserDelegationCredential(ctx, keyInfo, nil, nil)
 
-			if err == nil {
+			if err != nil {
 				return nil, fmt.Errorf("azureblob.OpenBucket: error while retrieving user delegation credential: %s", err)
 			}
 

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -309,8 +309,6 @@ type Bucket interface {
 
 // SignedURLOptions sets options for SignedURL.
 type SignedURLOptions struct {
-	Credential interface{}
-
 	// Expiry sets how long the returned URL is valid for. It is guaranteed to be > 0.
 	Expiry time.Duration
 

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -309,6 +309,8 @@ type Bucket interface {
 
 // SignedURLOptions sets options for SignedURL.
 type SignedURLOptions struct {
+	Credential interface{}
+
 	// Expiry sets how long the returned URL is valid for. It is guaranteed to be > 0.
 	Expiry time.Duration
 


### PR DESCRIPTION
In order to sign URLs we require credentials to be generated.  The previous pull #2873 added support for authentication via MSI in Azure, this makes it so MSI-enabled environments are able to obtain credentials correctly for URL signing.

We tried to add this to the openerFromMSI, but we ran into a chicken-and-egg issue where in order to create the Credentials we needed a service URL, which wasn't being created until the openBucket function.

Happy to make any changes necessary to get this approved!  
