### PR TITLE
internal/website: add a notice about dropping etcd support to the HOWTO

### DIFF
--- a/internal/website/content/howto/runtimevar/_index.md
+++ b/internal/website/content/howto/runtimevar/_index.md
@@ -175,6 +175,14 @@ https://godoc.org/gocloud.dev/runtimevar/awsparamstore#OpenVariable
 
 ### etcd {#etcd}
 
+*NOTE*: Support for `etcd` has been temporarily dropped until they sort out
+their Go module dependency problems. See
+https://github.com/google/go-cloud/issues/2914.
+
+You can use `runtimevar.etcd` in Go CDK version `v0.20.0` or earlier.
+
+<!--
+
 To open a variable stored in [etcd][] via URL, you can use the
 `runtimevar.OpenVariable` function as follows.
 
@@ -190,6 +198,8 @@ The [`etcdvar.OpenVariable`][] constructor opens an `etcd` variable.
 https://godoc.org/gocloud.dev/runtimevar/etcdvar#OpenVariable
 
 {{< goexample "gocloud.dev/runtimevar/etcdvar.ExampleOpenVariable" >}}
+
+-->
 
 ### HTTP {#http}
 

--- a/internal/website/content/howto/runtimevar/_index.md
+++ b/internal/website/content/howto/runtimevar/_index.md
@@ -175,31 +175,10 @@ https://godoc.org/gocloud.dev/runtimevar/awsparamstore#OpenVariable
 
 ### etcd {#etcd}
 
-*NOTE*: Support for `etcd` has been temporarily dropped until they sort out
-their Go module dependency problems. See
-https://github.com/google/go-cloud/issues/2914.
+*NOTE*: Support for `etcd` has been temporarily dropped due to dependency
+issues. See https://github.com/google/go-cloud/issues/2914.
 
 You can use `runtimevar.etcd` in Go CDK version `v0.20.0` or earlier.
-
-<!--
-
-To open a variable stored in [etcd][] via URL, you can use the
-`runtimevar.OpenVariable` function as follows.
-
-{{< goexample "gocloud.dev/runtimevar/etcdvar.Example_openVariableFromURL" >}}
-
-[etcd]: https://etcd.io/
-
-#### etcd Constructor {#etcd-ctor}
-
-The [`etcdvar.OpenVariable`][] constructor opens an `etcd` variable.
-
-[`etcdvar.OpenVariable`]:
-https://godoc.org/gocloud.dev/runtimevar/etcdvar#OpenVariable
-
-{{< goexample "gocloud.dev/runtimevar/etcdvar.ExampleOpenVariable" >}}
-
--->
 
 ### HTTP {#http}
 


### PR DESCRIPTION
Updates #2914.

Also fixes the build, the web page references the etcd examples which are no longer included since it was commented out in `allmodules`.