### PR TITLE
mysql: parse url host in the form of 'protocol(addr)' (#2923)

### DIFF
--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 // URLOpener opens URLs like "mysql://" by using the underlying MySQL driver.
-// See https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters for details.
+// like "mysql://user:password@localhost:3306/mydb".
 type URLOpener struct {
 	TraceOpts []ocsql.TraceOption
 }

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -58,19 +58,36 @@ func TestOpen(t *testing.T) {
 }
 
 func TestConfigFromURL(t *testing.T) {
-	const urlstr = "mysql://localhost/db?parseTime=true&interpolateParams=true"
-	u, err := url.Parse(urlstr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cfg, err := ConfigFromURL(u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !cfg.ParseTime {
-		t.Error("ParseTime is false, want true")
-	}
-	if !cfg.InterpolateParams {
-		t.Error("InterpolateParams is false, want true")
+	for _, host := range []string{
+		"localhost",
+		"tcp(localhost)",
+	} {
+		urlstr := "mysql://user:password@" + host + "/db?parseTime=true&interpolateParams=true"
+		u, err := url.Parse(urlstr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := ConfigFromURL(u)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := cfg.User, "user"; got != want {
+			t.Errorf(`User = %q; want %q`, got, want)
+		}
+		if got, want := cfg.Passwd, "password"; got != want {
+			t.Errorf(`Passwd = %q; want %q`, got, want)
+		}
+		if got, want := cfg.Net, "tcp"; got != want {
+			t.Errorf(`Net = %q; want %q`, got, want)
+		}
+		if got, want := cfg.Addr, "localhost"; got != want {
+			t.Errorf(`Addr = %q; want %q`, got, want)
+		}
+		if !cfg.ParseTime {
+			t.Error("ParseTime = false; want true")
+		}
+		if !cfg.InterpolateParams {
+			t.Error("InterpolateParams = false; want true")
+		}
 	}
 }


### PR DESCRIPTION
Allow url host to take the form of `protocol(addr)` (similar to [mysql.ParseDSN](https://github.com/go-sql-driver/mysql/blob/master/dsn.go#L323-L338)).

Fixes #2923.