### PR TITLE
samples: update go-cmdtest to latest

### DIFF
--- a/samples/go.mod
+++ b/samples/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/Azure/azure-storage-blob-go v0.12.0
 	github.com/aws/aws-sdk-go v1.36.1
 	github.com/go-sql-driver/mysql v1.5.0
-	github.com/google/go-cmdtest v0.1.0
+	github.com/google/go-cmdtest v0.3.0
 	github.com/google/go-cmp v0.5.4
 	github.com/google/subcommands v1.2.0
 	github.com/google/uuid v1.1.2

--- a/samples/go.sum
+++ b/samples/go.sum
@@ -256,8 +256,8 @@ github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/go-cmdtest v0.1.0 h1:C8Q59LybwJuSEpl3YK55ko5DOfLT5Ykae4rNnyytQhY=
-github.com/google/go-cmdtest v0.1.0/go.mod h1:f6OWISNhOFSB5dtuBlUJfSZzjtCwopip5fWSXDyLRRg=
+github.com/google/go-cmdtest v0.3.0 h1:382oNMtKBpvJjOm5c5ONU3pzwh2ZK/eNA4/h2v9PnXM=
+github.com/google/go-cmdtest v0.3.0/go.mod h1:apVn/GCasLZUVpAJ6oWAuyP7Ne7CEsQbTnc0plM3m+o=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=


### PR DESCRIPTION
Couldn't update this before because `v0.2.0` was broken for Windows. Now fixed by @jba.