### PR TITLE
pubsub/awssqssns: Make the SQS Message.As work with concurrent workers

### DIFF
--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -684,6 +684,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 	}
 	var ms []*driver.Message
 	for _, m := range output.Messages {
+		m := m
 		bodyStr, rawAttrs := extractBody(m, s.opts.Raw)
 
 		decodeIt := false


### PR DESCRIPTION
When using multiple workers as per the example code in the docs, if it is combined with using `message.As(&sqsMessage)` the underlying SQS message will be wrong.

This fix creates a local variable for `m` which will keep scope for the asFunc. The downside I suspect is that memory usage will go up as more references are held rather than the current value which is overwritten as part of the loop.