### PR TITLE
blob/azblob: Fix SAS token not being used to open a container

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -161,7 +161,7 @@ func (o *lazyCredsOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.
 
 		isMSIEnvironment := adal.MSIAvailable(ctx, adal.CreateSender())
 
-		if accountKey != "" {
+		if accountKey != "" || sasToken != "" {
 			o.opener, o.err = openerFromEnv(accountName, accountKey, sasToken, storageDomain, protocol)
 		} else if isMSIEnvironment {
 			o.opener, o.err = openerFromMSI(accountName, storageDomain, protocol)


### PR DESCRIPTION
Prior to https://github.com/google/go-cloud/pull/2873, setting the
environment variable `AZURE_STORAGE_SAS_TOKEN` would work because the
default behavior was to open the bucket via the environment. However,
that pull request changed the behavior to only use the environment if an
account key were provided, but the SAS token can be thought of as a
temporary key.

To fix this, we check whether an account key or a SAS token is
provided. If one of them is available, open the container with the
environment.

Closes #2933
