### PR TITLE
pubsub/kafka: fix fallback to random partitioner

### DIFF
--- a/pubsub/kafkapubsub/kafka.go
+++ b/pubsub/kafkapubsub/kafka.go
@@ -229,20 +229,20 @@ func (t *topic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 	// Convert the messages to a slice of sarama.ProducerMessage.
 	ms := make([]*sarama.ProducerMessage, 0, len(dms))
 	for _, dm := range dms {
-		var kafkaKey []byte
+		var kafkaKey sarama.Encoder
 		var headers []sarama.RecordHeader
 		for k, v := range dm.Metadata {
 			if k == t.opts.KeyName {
 				// Use this key's value as the Kafka message key instead of adding it
 				// to the headers.
-				kafkaKey = []byte(v)
+				kafkaKey = sarama.ByteEncoder(v)
 			} else {
 				headers = append(headers, sarama.RecordHeader{Key: []byte(k), Value: []byte(v)})
 			}
 		}
 		pm := &sarama.ProducerMessage{
 			Topic:   t.topicName,
-			Key:     sarama.ByteEncoder(kafkaKey),
+			Key:     kafkaKey,
 			Value:   sarama.ByteEncoder(dm.Body),
 			Headers: headers,
 		}


### PR DESCRIPTION
When using the default `kafka://` scheme, [no topic options with key are set](https://github.com/google/go-cloud/blob/e00dad626e8a600ae8028f56fbac281db67122f8/pubsub/kafkapubsub/kafka.go#L107-L110). This means that `Key` is always `sarama.ByteEncoder(nil)`: https://github.com/google/go-cloud/blob/e00dad626e8a600ae8028f56fbac281db67122f8/pubsub/kafkapubsub/kafka.go#L232-L245

Since `sarama.ByteEncoder(nil) != nil`, the underlying default hash partitioner does not fallback to the default partitioner: https://github.com/Shopify/sarama/blob/2a5254c26ef606cd9a5871a5dc4d2db86d5e35b7/partitioner.go#L183-L185

This means effectively that Kafka partitioning doesn't work with the default URL opener, because the partition is always the hash of an empty byte slice. Seems pretty serious. Unless I'm totally overlooking something, @vangent?

Here's a quickfix that only sets `Key` when there is one defined in the metadata. If the metadata contains the key but it is an empty string, the original behavior persists in case applications depend on that. This is my first PR here so bear with me.