### PR TITLE
internal/website: try using a different syntax for GITHUB_TOKEN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
         fqdn: gocloud.dev
         skip-cleanup: true
         local-dir: internal/website/public
-        github-token: $GITHUB_TOKEN  # set in the Settings page of the repo
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         keep-history: true
         verbose: true  # temporarily, while verifying
         on:


### PR DESCRIPTION
The push started failing, no idea why:
https://travis-ci.com/github/google/go-cloud/jobs/468898520

The current documentation says `${{ secrets.GITHUB_TOKEN }}` instead of just `$GITHUB_TOKEN`, so let's try that and see if it works (https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow).