### PR TITLE
blob/fileblob: fix directory from opts.CreateDir not being writable

### DIFF
--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -197,7 +197,7 @@ func openBucket(dir string, opts *Options) (driver.Bucket, error) {
 
 	// Optionally, create the directory if it does not already exist.
 	if err != nil && opts.CreateDir && os.IsNotExist(err) {
-		err = os.MkdirAll(absdir, os.ModeDir)
+		err = os.MkdirAll(absdir, os.FileMode(0777))
 		if err != nil {
 			return nil, fmt.Errorf("tried to create directory but failed: %v", err)
 		}
@@ -577,7 +577,7 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType str
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), os.FileMode(0777)); err != nil {
 		return nil, err
 	}
 	f, err := ioutil.TempFile(filepath.Dir(path), "fileblob")

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -203,9 +203,16 @@ func TestNewBucket(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer os.RemoveAll(dir)
-		_, gotErr := OpenBucket(filepath.Join(dir, "notfound"), &Options{CreateDir: true})
+		b, gotErr := OpenBucket(filepath.Join(dir, "notfound"), &Options{CreateDir: true})
 		if gotErr != nil {
 			t.Errorf("got error %v", gotErr)
+		}
+		defer b.Close()
+
+		// Make sure the subdir has gotten permissions to be used.
+		gotErr = b.WriteAll(context.Background(), "key", []byte("delme"), nil)
+		if gotErr != nil {
+			t.Errorf("got error writing to bucket from CreateDir %v", gotErr)
 		}
 	})
 	t.Run("BucketIsFile", func(t *testing.T) {


### PR DESCRIPTION
Not conferred by os.ModeDir, read-write permissions need to be set explicitly.