### PR TITLE
blob/fileblob: try copy by reflink first

### DIFF
--- a/blob/fileblob/fileblob_generic.go
+++ b/blob/fileblob/fileblob_generic.go
@@ -1,0 +1,23 @@
+// Copyright 2021 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package fileblob
+
+import "io"
+
+func (b *bucket) ioCopy(dst io.Writer, src io.Reader) (written int64, err error) {
+	return io.Copy(dst, src)
+}

--- a/blob/fileblob/fileblob_linux.go
+++ b/blob/fileblob/fileblob_linux.go
@@ -1,0 +1,102 @@
+// Copyright 2021 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileblob
+
+import (
+	"io"
+	"os"
+	"sync/atomic"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+type fileLike interface {
+	Fd() uintptr
+	Seek(offset int64, whence int) (ret int64, err error)
+	Stat() (os.FileInfo, error)
+}
+
+// ioCopy tries optimized copy operations, else falls back to io.Copy.
+func (b *bucket) ioCopy(dst io.Writer, src io.Reader) (written int64, err error) {
+	if atomic.LoadInt32(&b.fsSupportsReflink) == 0 {
+		return io.Copy(dst, src)
+	}
+
+	srcFile, okSrc := src.(fileLike)
+	dstFile, okDst := dst.(fileLike)
+	if !(okSrc && okDst) {
+		return io.Copy(dst, src)
+	}
+	written, err = ioCopyReflink(dstFile, srcFile)
+	switch err {
+	case nil:
+		return written, nil
+	case syscall.ENOSYS:
+		atomic.StoreInt32(&copyReflinkSupported, 0)
+		fallthrough
+	case syscall.EOPNOTSUPP, syscall.EIO, syscall.EINVAL, syscall.EBADF, syscall.EPERM:
+		// syscall.EIO is thrown on netshares.
+		atomic.StoreInt32(&b.fsSupportsReflink, 0)
+	}
+	return io.Copy(dst, src)
+}
+
+// ioCopyReflink copies from srcFile to dstFile using clone/copy-on-write
+// system calls.
+//
+// On errors syscall.{EINVAL, EBADF} don't try again with the given files,
+// on syscall.EOPNOTSUPP skip for the filesystem.
+func ioCopyReflink(dstFile, srcFile fileLike) (written int64, err error) {
+	srcPos, err := srcFile.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return
+	}
+	dstPos, err := dstFile.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return
+	}
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return
+	}
+	srcLength := srcInfo.Size() - srcPos // Remaining size.
+
+	if srcPos == 0 && dstPos == 0 {
+		for {
+			err = unix.IoctlFileClone(int(dstFile.Fd()), int(srcFile.Fd()))
+			if err != syscall.EINTR {
+				break
+			}
+		}
+	} else {
+		srcRange := &unix.FileCloneRange{
+			Src_fd:      int64(srcFile.Fd()), // int64/int mismatch in API
+			Src_offset:  uint64(srcPos),
+			Src_length:  uint64(srcLength),
+			Dest_offset: uint64(dstPos),
+		}
+		for {
+			err = unix.IoctlFileCloneRange(int(dstFile.Fd()), srcRange)
+			if err != syscall.EINTR {
+				break
+			}
+		}
+	}
+	if err == nil {
+		written = srcLength
+	}
+	return
+}

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
 	golang.org/x/oauth2 v0.0.0-20201203001011-0b49973bad19
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20201202213521-69691e467435 // indirect
+	golang.org/x/sys v0.0.0-20201202213521-69691e467435
 	golang.org/x/tools v0.0.0-20201203202102-a1a1cbeaa516 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/api v0.36.0


### PR DESCRIPTION
Following #2954 enables a faster file duplication on filesystems that
support clone/copy-on-write.

The speed advantage is particularly beneficial if the operator merely
intends to rename a key, in which case going through Copy is currently needed.