### PR TITLE
blob/fileblob: utilize syscall openat2 on Linux as another guard

### DIFF
--- a/blob/fileblob/fileblob_generic.go
+++ b/blob/fileblob/fileblob_generic.go
@@ -1,0 +1,38 @@
+// Copyright 2021 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package fileblob
+
+import "os"
+
+var (
+	// Disable support for openat2 syscalls on this OS
+	// to skip opening the directory in OpenBucket.
+	openat2Supported int32 = 0
+)
+
+func (*bucket) osOpen(name string) (*os.File, error) {
+	return os.Open(name)
+}
+
+// initFeatures examines OS support to toggle feature flags.
+func (b *bucket) initFeatures() error {
+	return nil
+}
+
+func (b *bucket) Close() error {
+	return nil
+}

--- a/blob/fileblob/fileblob_linux.go
+++ b/blob/fileblob/fileblob_linux.go
@@ -1,0 +1,79 @@
+// Copyright 2021 The Go Cloud Development Kit Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileblob
+
+import (
+	"os"
+	"sync/atomic"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+var (
+	// Accessed atomically, guards the use of the unix.Openat2 syscall.
+	openat2Supported int32 = 1
+
+	howOpenReadonly = &unix.OpenHow{
+		Flags:   unix.O_RDONLY,
+		Resolve: unix.RESOLVE_BENEATH,
+	}
+)
+
+func (b *bucket) osOpen(name string) (*os.File, error) {
+	if atomic.LoadInt32(&openat2Supported) == 0 {
+		return os.Open(name)
+	}
+
+	relativeName := name[len(b.dir)+1:]
+	fd, err := unix.Openat2(int(b.rootDirFd), relativeName, howOpenReadonly)
+	if err != nil {
+		return nil, &os.PathError{Op: "openat2", Path: relativeName, Err: err}
+	}
+	return os.NewFile(uintptr(fd), name), nil
+}
+
+// initFeatures examines OS support to toggle feature flags.
+func (b *bucket) initFeatures() error {
+	if atomic.LoadInt32(&openat2Supported) == 0 {
+		return nil
+	}
+
+	// Deliberately use openat2 to tell whether it is supported at all.
+	// With b.dir an absolute path, and absent any special flags, dirfd=0 gets ignored.
+	dirfd, err := unix.Openat2(0, b.dir, &unix.OpenHow{
+		// O_CLOEXEC follows precedent in Go's stdlib,
+		// O_PATH is opportune and predates openat2.
+		Flags: unix.O_PATH | unix.O_CLOEXEC,
+	})
+	switch err {
+	case nil:
+		b.rootDirFd = uintptr(dirfd)
+	case syscall.ENOSYS, syscall.EPERM:
+		// EPERM – as openBucket already interacted with the directory –
+		// will be the result of shambolic syscall whitelists.
+		atomic.StoreInt32(&openat2Supported, 0)
+		err = nil
+	}
+	return err
+}
+
+func (b *bucket) Close() error {
+	if dirfd := int(b.rootDirFd); dirfd != 0 {
+		b.rootDirFd = 0
+		unix.Close(dirfd)
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
 	golang.org/x/oauth2 v0.0.0-20201203001011-0b49973bad19
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20201202213521-69691e467435 // indirect
+	golang.org/x/sys v0.0.0-20201202213521-69691e467435
 	golang.org/x/tools v0.0.0-20201203202102-a1a1cbeaa516 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/api v0.36.0


### PR DESCRIPTION
Extending syscall 'openat', by using flag RESOLVE_BENEATH we can involve the kernel in pathname resolution as additional (and final) guard against descending below the Bucket's configured root directory.