### PR TITLE
blob/fileblob: remove erroneous stray sidecar

### DIFF
--- a/blob/fileblob/attrs.go
+++ b/blob/fileblob/attrs.go
@@ -46,6 +46,7 @@ func setAttrs(path string, xa xattrs) error {
 	}
 	if err := json.NewEncoder(f).Encode(xa); err != nil {
 		f.Close()
+		os.Remove(f.Name())
 		return err
 	}
 	return f.Close()


### PR DESCRIPTION
If `json.Encode` fails, the then-stray sidecar file should be removed—to not run afoul the contract, only correct and fully formed files are being left.