### PR TITLE
runtimevar/aws*: fix flaky tests by mapping AWS errors to more standard context ones

### DIFF
--- a/runtimevar/awssecretsmanager/awssecretsmanager.go
+++ b/runtimevar/awssecretsmanager/awssecretsmanager.go
@@ -38,12 +38,14 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/google/wire"
 	gcaws "gocloud.dev/aws"
@@ -191,6 +193,15 @@ func (s *state) As(i interface{}) bool {
 // errorState returns a new State with err, unless prevS also represents
 // the same error, in which case it returns nil.
 func errorState(err error, prevS driver.State) driver.State {
+	// Map aws.RequestCanceled to the more standard context package errors.
+	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == request.CanceledErrorCode {
+		msg := err.Error()
+		if strings.Contains(msg, "context deadline exceeded") {
+			err = context.DeadlineExceeded
+		} else {
+			err = context.Canceled
+		}
+	}
 	s := &state{err: err}
 	if prevS == nil {
 		return s


### PR DESCRIPTION
Fixed #2969 