### PR TITLE
internal: Correct Docs of ADC for GCP

### DIFF
--- a/internal/admin/README.md
+++ b/internal/admin/README.md
@@ -3,7 +3,7 @@
 This is a [Terraform][] configuration for the Go CDK open source project. It
 manages GitHub ACLs, issue labels, and the module proxy buckets on GCS. To apply
 the configuration to the project's resources, [sign into the gcloud
-CLI][gcloud auth login], grab a [GitHub access token][], and then do the
+CLI][gcloud auth application-default login], grab a [GitHub access token][], and then do the
 following:
 
 ```bash
@@ -12,6 +12,6 @@ internal/admin$ terraform init
 internal/admin$ terraform apply
 ```
 
-[gcloud auth login]: https://cloud.google.com/sdk/docs/authorizing#running_gcloud_auth_login
+[`gcloud auth application-default login`]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
 [GitHub access token]: https://github.com/settings/tokens/new?scopes=repo
 [Terraform]: https://www.terraform.io/

--- a/internal/website/content/howto/blob/_index.md
+++ b/internal/website/content/howto/blob/_index.md
@@ -158,12 +158,12 @@ you would see in the [`gsutil`][] CLI.
 [`gsutil`]: https://cloud.google.com/storage/docs/gsutil
 
 `blob.OpenBucket` will use Application Default Credentials; if you have
-authenticated via [`gcloud auth login`][], it will use those credentials. See
+authenticated via [`gcloud auth application-default login`][], it will use those credentials. See
 [Application Default Credentials][GCP creds] to learn about authentication
 alternatives, including using environment variables.
 
 [GCP creds]: https://cloud.google.com/docs/authentication/production
-[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
+[`gcloud auth application-default login`]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
 
 {{< goexample "gocloud.dev/blob/gcsblob.Example_openBucketFromURL" >}}
 

--- a/internal/website/content/howto/docstore/_index.md
+++ b/internal/website/content/howto/docstore/_index.md
@@ -258,12 +258,12 @@ Firestore URLs provide the project and collection, as well as the field that
 holds the document name.
 
 `docstore.OpenCollection` will use Application Default Credentials; if you have
-authenticated via [`gcloud auth login`][], it will use those credentials. See
+authenticated via [`gcloud auth application-default login`][], it will use those credentials. See
 [Application Default Credentials][GCP creds] to learn about authentication
 alternatives, including using environment variables.
 
 [GCP creds]: https://cloud.google.com/docs/authentication/production
-[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
+[`gcloud auth application-default login`]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
 
 {{< goexample
 "gocloud.dev/docstore/gcpfirestore.Example_openCollectionFromURL" >}}

--- a/internal/website/content/howto/pubsub/publish.md
+++ b/internal/website/content/howto/pubsub/publish.md
@@ -97,12 +97,12 @@ project ID and the topic ID.
 [Cloud Pub/Sub]: https://cloud.google.com/pubsub/docs/
 
 `pubsub.OpenTopic` will use Application Default Credentials; if you have
-authenticated via [`gcloud auth login`][], it will use those credentials. See
+authenticated via [`gcloud auth application-default login`][], it will use those credentials. See
 [Application Default Credentials][GCP creds] to learn about authentication
 alternatives, including using environment variables.
 
 [GCP creds]: https://cloud.google.com/docs/authentication/production
-[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
+[`gcloud auth application-default login`]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
 
 {{< goexample "gocloud.dev/pubsub/gcppubsub.Example_openTopicFromURL" >}}
 

--- a/internal/website/content/howto/pubsub/subscribe.md
+++ b/internal/website/content/howto/pubsub/subscribe.md
@@ -106,12 +106,12 @@ The URLs use the project ID and the subscription ID.
 [Cloud Pub/Sub]: https://cloud.google.com/pubsub/docs/
 
 `pubsub.OpenSubscription` will use Application Default Credentials; if you have
-authenticated via [`gcloud auth login`][], it will use those credentials. See
+authenticated via [`gcloud auth application-default login`][], it will use those credentials. See
 [Application Default Credentials][GCP creds] to learn about authentication
 alternatives, including using environment variables.
 
 [GCP creds]: https://cloud.google.com/docs/authentication/production
-[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
+[`gcloud auth application-default login`]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
 
 {{< goexample "gocloud.dev/pubsub/gcppubsub.Example_openSubscriptionFromURL" >}}
 

--- a/internal/website/content/howto/runtimevar/_index.md
+++ b/internal/website/content/howto/runtimevar/_index.md
@@ -126,12 +126,12 @@ the `runtimevar.OpenVariable` function as shown in the example below.
 [GCP Runtime Configurator]: https://cloud.google.com/deployment-manager/runtime-configurator/
 
 `runtimevar.OpenVariable` will use Application Default Credentials; if you have
-authenticated via [`gcloud auth login`][], it will use those credentials. See
+authenticated via [`gcloud auth application-default login`][], it will use those credentials. See
 [Application Default Credentials][GCP creds] to learn about authentication
 alternatives, including using environment variables.
 
 [GCP creds]: https://cloud.google.com/docs/authentication/production
-[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
+[`gcloud auth application-default login`]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
 
 {{< goexample
 "gocloud.dev/runtimevar/gcpruntimeconfig.Example_openVariableFromURL" >}}
@@ -153,12 +153,12 @@ the `runtimevar.OpenVariable` function as shown in the example below.
 [GCP Secret Manager]: https://cloud.google.com/secret-manager
 
 `runtimevar.OpenVariable` will use Application Default Credentials; if you have
-authenticated via [`gcloud auth login`][], it will use those credentials. See
+authenticated via [`gcloud auth application-default login`][], it will use those credentials. See
 [Application Default Credentials][GCP creds] to learn about authentication
 alternatives, including using environment variables.
 
 [GCP creds]: https://cloud.google.com/docs/authentication/production
-[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
+[`gcloud auth application-default login`]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
 
 {{< goexample
 "gocloud.dev/runtimevar/gcpsecretmanager.Example_openVariableFromURL" >}}

--- a/internal/website/content/howto/secrets/_index.md
+++ b/internal/website/content/howto/secrets/_index.md
@@ -167,12 +167,12 @@ similar to [key resource IDs][].
 [key resource IDs]: https://cloud.google.com/kms/docs/object-hierarchy#key
 
 `secrets.OpenKeeper` will use Application Default Credentials; if you have
-authenticated via [`gcloud auth login`][], it will use those credentials. See
+authenticated via [`gcloud auth application-default login`][], it will use those credentials. See
 [Application Default Credentials][GCP creds] to learn about authentication
 alternatives, including using environment variables.
 
 [GCP creds]: https://cloud.google.com/docs/authentication/production
-[`gcloud auth login`]: https://cloud.google.com/sdk/gcloud/reference/auth/login
+[`gcloud auth application-default login`]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
 
 {{< goexample "gocloud.dev/secrets/gcpkms.Example_openFromURL" >}}
 


### PR DESCRIPTION
Fixes #2973 

Update Documentation regarding `gcloud auth login` as it no longer (after gcloud version 128) sets Application Default Credentials.