### PR TITLE
pubsub/all: Add support for As hook AfterSend

### DIFF
--- a/pubsub/awssnssqs/awssnssqs_test.go
+++ b/pubsub/awssnssqs/awssnssqs_test.go
@@ -352,6 +352,24 @@ func (t awsAsTest) BeforeSend(as func(interface{}) bool) error {
 	return nil
 }
 
+func (t awsAsTest) AfterSend(as func(interface{}) bool) error {
+	switch t.topicKind {
+	case topicKindSNS, topicKindSNSRaw:
+		var pub *sns.PublishOutput
+		if !as(&pub) {
+			return fmt.Errorf("cast failed for %T", &pub)
+		}
+	case topicKindSQS:
+		var entry *sqs.SendMessageBatchResultEntry
+		if !as(&entry) {
+			return fmt.Errorf("cast failed for %T", &entry)
+		}
+	default:
+		panic("unreachable")
+	}
+	return nil
+}
+
 func sanitize(s string) string {
 	// AWS doesn't like names that are too long; trim some not-so-useful stuff.
 	const maxNameLen = 80

--- a/pubsub/azuresb/azuresb_test.go
+++ b/pubsub/azuresb/azuresb_test.go
@@ -240,6 +240,10 @@ func (sbAsTest) BeforeSend(as func(interface{}) bool) error {
 	return nil
 }
 
+func (sbAsTest) AfterSend(as func(interface{}) bool) error {
+	return nil
+}
+
 func sanitize(s string) string {
 	// First trim some not-so-useful strings that are part of all test names.
 	s = strings.Replace(s, "TestConformance/Test", "", 1)

--- a/pubsub/driver/driver.go
+++ b/pubsub/driver/driver.go
@@ -62,6 +62,16 @@ type Message struct {
 	// asFunc converts its argument to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
 	BeforeSend func(asFunc func(interface{}) bool) error
+
+	// AfterSend is a callback used when sending a message. It should remain
+	// nil on messages returned from ReceiveBatch.
+	//
+	// The callback must be called at most once, after the message is sent.
+	// If Send returns an error, AfterSend will not be called.
+	//
+	// asFunc converts its argument to driver-specific types.
+	// See https://gocloud.dev/concepts/as/ for background information.
+	AfterSend func(asFunc func(interface{}) bool) error
 }
 
 // Topic publishes messages.

--- a/pubsub/gcppubsub/gcppubsub_test.go
+++ b/pubsub/gcppubsub/gcppubsub_test.go
@@ -266,6 +266,14 @@ func (gcpAsTest) BeforeSend(as func(interface{}) bool) error {
 	return nil
 }
 
+func (gcpAsTest) AfterSend(as func(interface{}) bool) error {
+	var msgId string
+	if !as(&msgId) {
+		return fmt.Errorf("cast failed for %T", &msgId)
+	}
+	return nil
+}
+
 func sanitize(testName string) string {
 	return strings.Replace(testName, "/", "_", -1)
 }

--- a/pubsub/kafkapubsub/kafka_test.go
+++ b/pubsub/kafkapubsub/kafka_test.go
@@ -181,6 +181,10 @@ func (asTest) BeforeSend(as func(interface{}) bool) error {
 	return nil
 }
 
+func (asTest) AfterSend(as func(interface{}) bool) error {
+	return nil
+}
+
 // TestKafkaKey tests sending/receiving a message with the Kafka message key set.
 func TestKafkaKey(t *testing.T) {
 	if !setup.HasDockerTestEnvironment() {

--- a/pubsub/mempubsub/mem.go
+++ b/pubsub/mempubsub/mem.go
@@ -158,6 +158,11 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 				return err
 			}
 		}
+		if m.AfterSend != nil {
+			if err := m.AfterSend(func(interface{}) bool { return false }); err != nil {
+				return err
+			}
+		}
 	}
 	t.nextAckID += len(ms)
 	for _, s := range t.subs {

--- a/pubsub/natspubsub/nats.go
+++ b/pubsub/natspubsub/nats.go
@@ -40,6 +40,7 @@
 //  - Topic: *nats.Conn
 //  - Subscription: *nats.Subscription
 //  - Message.BeforeSend: None.
+//  - Message.AfterSend: None.
 //  - Message: *nats.Msg
 package natspubsub // import "gocloud.dev/pubsub/natspubsub"
 
@@ -230,6 +231,12 @@ func (t *topic) SendBatch(ctx context.Context, msgs []*driver.Message) error {
 		}
 		if err := t.nc.Publish(t.subj, payload); err != nil {
 			return err
+		}
+		if m.AfterSend != nil {
+			asFunc := func(i interface{}) bool { return false }
+			if err := m.AfterSend(asFunc); err != nil {
+				return err
+			}
 		}
 	}
 	// Per specification this is supposed to only return after

--- a/pubsub/natspubsub/nats_test.go
+++ b/pubsub/natspubsub/nats_test.go
@@ -170,6 +170,10 @@ func (natsAsTest) BeforeSend(as func(interface{}) bool) error {
 	return nil
 }
 
+func (natsAsTest) AfterSend(as func(interface{}) bool) error {
+	return nil
+}
+
 func TestConformance(t *testing.T) {
 	asTests := []drivertest.AsTest{natsAsTest{}}
 	drivertest.RunConformanceTests(t, newHarness, asTests)

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -111,6 +111,16 @@ type Message struct {
 	// See https://gocloud.dev/concepts/as/ for background information.
 	BeforeSend func(asFunc func(interface{}) bool) error
 
+	// AfterSend is a callback used when sending a message. It will always be
+	// set to nil for received messages.
+	//
+	// The callback will be called at most once, after the message is sent.
+	// If Send returns an error, AfterSend will not be called.
+	//
+	// asFunc converts its argument to driver-specific types.
+	// See https://gocloud.dev/concepts/as/ for background information.
+	AfterSend func(asFunc func(interface{}) bool) error
+
 	// asFunc invokes driver.Message.AsFunc.
 	asFunc func(interface{}) bool
 
@@ -244,6 +254,7 @@ func (t *Topic) Send(ctx context.Context, m *Message) (err error) {
 		Body:       m.Body,
 		Metadata:   m.Metadata,
 		BeforeSend: m.BeforeSend,
+		AfterSend:  m.AfterSend,
 	}
 	return t.batcher.Add(ctx, dm)
 }

--- a/pubsub/rabbitpubsub/doc.go
+++ b/pubsub/rabbitpubsub/doc.go
@@ -48,6 +48,7 @@
 //  - Topic: *amqp.Connection
 //  - Subscription: *amqp.Connection
 //  - Message.BeforeSend: *amqp.Publishing
+//  - Message.AfterSend: None
 //  - Message: amqp.Delivery
 //  - Error: *amqp.Error and MultiError
 package rabbitpubsub // import "gocloud.dev/pubsub/rabbitpubsub"

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -266,6 +266,12 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 			cancel()
 			break
 		}
+		if m.AfterSend != nil {
+			asFunc := func(i interface{}) bool { return false }
+			if err := m.AfterSend(asFunc); err != nil {
+				return err
+			}
+		}
 	}
 	// Wait for the goroutine to finish.
 	err := <-errc

--- a/pubsub/rabbitpubsub/rabbit_test.go
+++ b/pubsub/rabbitpubsub/rabbit_test.go
@@ -375,6 +375,10 @@ func (rabbitAsTest) BeforeSend(as func(interface{}) bool) error {
 	return nil
 }
 
+func (rabbitAsTest) AfterSend(as func(interface{}) bool) error {
+	return nil
+}
+
 func fakeConnectionStringInEnv() func() {
 	oldEnvVal := os.Getenv("RABBIT_SERVER_URL")
 	os.Setenv("RABBIT_SERVER_URL", "amqp://localhost:10000/vhost")


### PR DESCRIPTION
Only a couple of drivers support a real type here (AWS and GCP), but it's reasonable to expose it if so (instead of just dropping it in the floor as we did previously).

Fixes #2986.