### PR TITLE
`blob/azblob`: Pass nil instead of an empty map for tags on Copy operation

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -541,7 +541,6 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 	mac := azblob.ModifiedAccessConditions{}
 	bac := azblob.BlobAccessConditions{}
 	at := azblob.AccessTierNone
-	btm := azblob.BlobTagsMap{}
 	if opts.BeforeCopy != nil {
 		asFunc := func(i interface{}) bool {
 			switch v := i.(type) {
@@ -561,7 +560,7 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 			return err
 		}
 	}
-	resp, err := dstBlobURL.StartCopyFromURL(ctx, srcURL, md, mac, bac, at, btm)
+	resp, err := dstBlobURL.StartCopyFromURL(ctx, srcURL, md, mac, bac, at, nil /* blogsTagMap */)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://github.com/google/go-cloud/issues/2982

Providing an empty map ends up causing the underlying SDK to want to have permissions to write tags against the destination blob. However, we don't actually need this permission since we're not really writing any tags. Instead, we should just pass in `nil`.