### PR TITLE
blob/azblob: Pass nil instead of an empty map for tags on Copy operation

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -561,7 +561,7 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 		}
 	}
 	resp, err := dstBlobURL.StartCopyFromURL(ctx, srcURL, md, mac, bac, at, nil /* BlobTagsMap */)
-	 if err != nil {
+	if err != nil {
 		return err
 	}
 	copyStatus := resp.CopyStatus()

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -541,7 +541,6 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 	mac := azblob.ModifiedAccessConditions{}
 	bac := azblob.BlobAccessConditions{}
 	at := azblob.AccessTierNone
-	btm := azblob.BlobTagsMap{}
 	if opts.BeforeCopy != nil {
 		asFunc := func(i interface{}) bool {
 			switch v := i.(type) {
@@ -561,7 +560,7 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 			return err
 		}
 	}
-	resp, err := dstBlobURL.StartCopyFromURL(ctx, srcURL, md, mac, bac, at, btm)
+	resp, err := dstBlobURL.StartCopyFromURL(ctx, srcURL, md, mac, bac, at, nil /* BlobTagsMap */)
 	if err != nil {
 		return err
 	}

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -561,7 +561,7 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 		}
 	}
 	resp, err := dstBlobURL.StartCopyFromURL(ctx, srcURL, md, mac, bac, at, nil /* BlobTagsMap */)
-	if err != nil {
+	 if err != nil {
 		return err
 	}
 	copyStatus := resp.CopyStatus()

--- a/blob/azureblob/testdata/TestConformance/TestAs/verify_As_returns_false_when_passed_nil.replay
+++ b/blob/azureblob/testdata/TestConformance/TestAs/verify_As_returns_false_when_passed_nil.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7XW2bbEn9QMv4g",
+  "Initial": "AQAAAA7YC9l4MhnTlP5c",
   "Version": "0.2",
   "Converter": {
     "ScrubBody": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "f44f8531b8c861a7",
+      "ID": "37e511c57401063e",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test?blockid=CLEARED\u0026comp=block",
@@ -76,7 +76,7 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:08 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -85,7 +85,7 @@
             "vo7q9sPVKY0="
           ],
           "X-Ms-Request-Id": [
-            "3659834b-601e-000e-5dc9-c9b8df000000"
+            "44b65f54-d01e-0131-01f4-324956000000"
           ],
           "X-Ms-Request-Server-Encrypted": [
             "true"
@@ -98,7 +98,7 @@
       }
     },
     {
-      "ID": "d000e05a269ee02a",
+      "ID": "6c31d809364141e7",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test?comp=blocklist",
@@ -152,22 +152,22 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:08 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04E379FC3\""
+            "\"0x8D9010C1745C182\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:09 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
           ],
           "X-Ms-Content-Crc64": [
-            "vWva8W86/CY="
+            "oYPmYXRoOaI="
           ],
           "X-Ms-Request-Id": [
-            "3659835e-601e-000e-6ec9-c9b8df000000"
+            "44b65f5d-d01e-0131-07f4-324956000000"
           ],
           "X-Ms-Request-Server-Encrypted": [
             "true"
@@ -180,7 +180,7 @@
       }
     },
     {
-      "ID": "010fd349fb7ad442",
+      "ID": "188d860e205cf722",
       "Request": {
         "Method": "HEAD",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test",
@@ -222,13 +222,13 @@
             "text/plain; charset=utf-8"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:08 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04E379FC3\""
+            "\"0x8D9010C1745C182\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:09 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -243,7 +243,7 @@
             "BlockBlob"
           ],
           "X-Ms-Creation-Time": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:09 GMT"
           ],
           "X-Ms-Lease-State": [
             "available"
@@ -252,7 +252,7 @@
             "unlocked"
           ],
           "X-Ms-Request-Id": [
-            "36598366-601e-000e-76c9-c9b8df000000"
+            "44b65f64-d01e-0131-0cf4-324956000000"
           ],
           "X-Ms-Server-Encrypted": [
             "true"
@@ -265,7 +265,7 @@
       }
     },
     {
-      "ID": "56945d7fa9d475b6",
+      "ID": "b276cfd1d5b76fed",
       "Request": {
         "Method": "GET",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test",
@@ -310,13 +310,13 @@
             "text/plain; charset=utf-8"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:08 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04E379FC3\""
+            "\"0x8D9010C1745C182\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:09 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -325,7 +325,7 @@
             "BlockBlob"
           ],
           "X-Ms-Creation-Time": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:09 GMT"
           ],
           "X-Ms-Lease-State": [
             "available"
@@ -334,7 +334,7 @@
             "unlocked"
           ],
           "X-Ms-Request-Id": [
-            "3659836e-601e-000e-7ec9-c9b8df000000"
+            "44b65f65-d01e-0131-0df4-324956000000"
           ],
           "X-Ms-Server-Encrypted": [
             "true"
@@ -347,7 +347,7 @@
       }
     },
     {
-      "ID": "900fd773a6b6a0db",
+      "ID": "1f1b30c84d22a55a",
       "Request": {
         "Method": "GET",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket?comp=list\u0026delimiter=%2F\u0026maxresults=1000\u0026prefix=mydir\u0026restype=container",
@@ -380,13 +380,13 @@
             "application/xml"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:08 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
           ],
           "X-Ms-Request-Id": [
-            "36598386-601e-000e-15c9-c9b8df000000"
+            "44b65f6a-d01e-0131-11f4-324956000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -396,7 +396,7 @@
       }
     },
     {
-      "ID": "92319501ab94db8f",
+      "ID": "f183e75086f38aa5",
       "Request": {
         "Method": "GET",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket?comp=list\u0026delimiter=\u0026maxresults=1000\u0026prefix=mydir%2Fas-test\u0026restype=container",
@@ -429,23 +429,23 @@
             "application/xml"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:08 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
           ],
           "X-Ms-Request-Id": [
-            "36598392-601e-000e-1fc9-c9b8df000000"
+            "44b65f6d-d01e-0131-13f4-324956000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
           ]
         },
-        "Body": "77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9nb2Nsb3VkYmxvYnRlc3RzLmJsb2IuY29yZS53aW5kb3dzLm5ldC8iIENvbnRhaW5lck5hbWU9ImdvLWNsb3VkLWJ1Y2tldCI+PFByZWZpeD5teWRpci9hcy10ZXN0PC9QcmVmaXg+PE1heFJlc3VsdHM+MTAwMDwvTWF4UmVzdWx0cz48QmxvYnM+PEJsb2I+PE5hbWU+bXlkaXIvYXMtdGVzdDwvTmFtZT48UHJvcGVydGllcz48Q3JlYXRpb24tVGltZT5UaHUsIDAzIERlYyAyMDIwIDIzOjA4OjExIEdNVDwvQ3JlYXRpb24tVGltZT48TGFzdC1Nb2RpZmllZD5UaHUsIDAzIERlYyAyMDIwIDIzOjA4OjExIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEODk3RTA0RTM3OUZDMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTE8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+dGV4dC9wbGFpbjsgY2hhcnNldD11dGYtODwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1DUkM2NCAvPjxDb250ZW50LU1ENT5Yclk3dStBZTd0Q1R5eUs3ajFyTnd3PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48QWNjZXNzVGllcj5Ib3Q8L0FjY2Vzc1RpZXI+PEFjY2Vzc1RpZXJJbmZlcnJlZD50cnVlPC9BY2Nlc3NUaWVySW5mZXJyZWQ+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD50cnVlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjxPck1ldGFkYXRhIC8+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4="
+        "Body": "77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9nb2Nsb3VkYmxvYnRlc3RzLmJsb2IuY29yZS53aW5kb3dzLm5ldC8iIENvbnRhaW5lck5hbWU9ImdvLWNsb3VkLWJ1Y2tldCI+PFByZWZpeD5teWRpci9hcy10ZXN0PC9QcmVmaXg+PE1heFJlc3VsdHM+MTAwMDwvTWF4UmVzdWx0cz48QmxvYnM+PEJsb2I+PE5hbWU+bXlkaXIvYXMtdGVzdDwvTmFtZT48UHJvcGVydGllcz48Q3JlYXRpb24tVGltZT5GcmksIDE2IEFwciAyMDIxIDE5OjE2OjA5IEdNVDwvQ3JlYXRpb24tVGltZT48TGFzdC1Nb2RpZmllZD5GcmksIDE2IEFwciAyMDIxIDE5OjE2OjA5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEOTAxMEMxNzQ1QzE4MjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTE8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+dGV4dC9wbGFpbjsgY2hhcnNldD11dGYtODwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1DUkM2NCAvPjxDb250ZW50LU1ENT5Yclk3dStBZTd0Q1R5eUs3ajFyTnd3PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48QWNjZXNzVGllcj5Ib3Q8L0FjY2Vzc1RpZXI+PEFjY2Vzc1RpZXJJbmZlcnJlZD50cnVlPC9BY2Nlc3NUaWVySW5mZXJyZWQ+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD50cnVlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjxPck1ldGFkYXRhIC8+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4="
       }
     },
     {
-      "ID": "e5791a5d92f939cb",
+      "ID": "ac36ee278f247e69",
       "Request": {
         "Method": "GET",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/key-does-not-exist",
@@ -481,7 +481,7 @@
             "application/xml"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:08 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -490,17 +490,17 @@
             "BlobNotFound"
           ],
           "X-Ms-Request-Id": [
-            "365983a5-601e-000e-2dc9-c9b8df000000"
+            "44b65f72-d01e-0131-16f4-324956000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
           ]
         },
-        "Body": "77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RXJyb3I+PENvZGU+QmxvYk5vdEZvdW5kPC9Db2RlPjxNZXNzYWdlPlRoZSBzcGVjaWZpZWQgYmxvYiBkb2VzIG5vdCBleGlzdC4KUmVxdWVzdElkOjM2NTk4M2E1LTYwMWUtMDAwZS0yZGM5LWM5YjhkZjAwMDAwMApUaW1lOjIwMjAtMTItMDNUMjM6MDg6MTEuNDI2NDYwNVo8L01lc3NhZ2U+PC9FcnJvcj4="
+        "Body": "77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RXJyb3I+PENvZGU+QmxvYk5vdEZvdW5kPC9Db2RlPjxNZXNzYWdlPlRoZSBzcGVjaWZpZWQgYmxvYiBkb2VzIG5vdCBleGlzdC4KUmVxdWVzdElkOjQ0YjY1ZjcyLWQwMWUtMDEzMS0xNmY0LTMyNDk1NjAwMDAwMApUaW1lOjIwMjEtMDQtMTZUMTk6MTY6MDkuMTc4NTcwNlo8L01lc3NhZ2U+PC9FcnJvcj4="
       }
     },
     {
-      "ID": "1c0ce10d9b8b8cab",
+      "ID": "72a1bea8049fa8a5",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test-copy",
@@ -519,9 +519,6 @@
           ],
           "X-Ms-Date": [
             "CLEARED"
-          ],
-          "X-Ms-Tags": [
-            ""
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -542,25 +539,25 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:09 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04E444C3E\""
+            "\"0x8D9010C174EEAE8\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:09 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
           ],
           "X-Ms-Copy-Id": [
-            "0aa2770a-ad59-4339-8503-e19cb812fac4"
+            "206f7747-bb32-4d9b-a073-0c0347e99cb8"
           ],
           "X-Ms-Copy-Status": [
             "success"
           ],
           "X-Ms-Request-Id": [
-            "365983ae-601e-000e-35c9-c9b8df000000"
+            "44b65f76-d01e-0131-1af4-324956000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -570,7 +567,7 @@
       }
     },
     {
-      "ID": "a7ca1add6bf6697d",
+      "ID": "d81d82420f2f65fd",
       "Request": {
         "Method": "DELETE",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test-copy",
@@ -606,7 +603,7 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:09 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -615,7 +612,7 @@
             "true"
           ],
           "X-Ms-Request-Id": [
-            "365983ca-601e-000e-4dc9-c9b8df000000"
+            "44b65f82-d01e-0131-24f4-324956000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -625,7 +622,7 @@
       }
     },
     {
-      "ID": "6535e891988a6473",
+      "ID": "0aa7868f6cb27aee",
       "Request": {
         "Method": "DELETE",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test",
@@ -661,7 +658,7 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:09 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -670,7 +667,7 @@
             "true"
           ],
           "X-Ms-Request-Id": [
-            "365983dd-601e-000e-5fc9-c9b8df000000"
+            "44b65f85-d01e-0131-27f4-324956000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"

--- a/blob/azureblob/testdata/TestConformance/TestAs/verify_ContentLanguage_can_be_written_and_read_through_As.replay
+++ b/blob/azureblob/testdata/TestConformance/TestAs/verify_ContentLanguage_can_be_written_and_read_through_As.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7XW2bbB/aHcv4g",
+  "Initial": "AQAAAA7YC9mJDu5o7/5c",
   "Version": "0.2",
   "Converter": {
     "ScrubBody": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "2a601bc1213be605",
+      "ID": "8a853e331d604cbf",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test?blockid=CLEARED\u0026comp=block",
@@ -76,7 +76,7 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:24 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -85,7 +85,7 @@
             "vo7q9sPVKY0="
           ],
           "X-Ms-Request-Id": [
-            "dac1ec8c-e01e-0139-76c9-c95225000000"
+            "169bf957-301e-0130-11f4-3248ab000000"
           ],
           "X-Ms-Request-Server-Encrypted": [
             "true"
@@ -98,7 +98,7 @@
       }
     },
     {
-      "ID": "c199158be73683f0",
+      "ID": "ada772f61d936f1c",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test?comp=blocklist",
@@ -152,22 +152,22 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:24 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04E1C4AA5\""
+            "\"0x8D9010C21182CA7\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:25 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
           ],
           "X-Ms-Content-Crc64": [
-            "qMAguVMum9A="
+            "pOeVRLH3+Dk="
           ],
           "X-Ms-Request-Id": [
-            "dac1ec9f-e01e-0139-06c9-c95225000000"
+            "169bf96d-301e-0130-23f4-3248ab000000"
           ],
           "X-Ms-Request-Server-Encrypted": [
             "true"
@@ -180,7 +180,7 @@
       }
     },
     {
-      "ID": "0726b0bf32e0de19",
+      "ID": "d6b89bb752612ce3",
       "Request": {
         "Method": "HEAD",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test",
@@ -225,13 +225,13 @@
             "text/plain; charset=utf-8"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:24 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04E1C4AA5\""
+            "\"0x8D9010C21182CA7\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:25 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -246,7 +246,7 @@
             "BlockBlob"
           ],
           "X-Ms-Creation-Time": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:25 GMT"
           ],
           "X-Ms-Lease-State": [
             "available"
@@ -255,7 +255,7 @@
             "unlocked"
           ],
           "X-Ms-Request-Id": [
-            "dac1ecaa-e01e-0139-10c9-c95225000000"
+            "169bf97a-301e-0130-30f4-3248ab000000"
           ],
           "X-Ms-Server-Encrypted": [
             "true"
@@ -268,7 +268,7 @@
       }
     },
     {
-      "ID": "e0a6e9ea6369bf33",
+      "ID": "c9bb1c970cf4e364",
       "Request": {
         "Method": "GET",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test",
@@ -316,13 +316,13 @@
             "text/plain; charset=utf-8"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:24 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04E1C4AA5\""
+            "\"0x8D9010C21182CA7\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:25 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -331,7 +331,7 @@
             "BlockBlob"
           ],
           "X-Ms-Creation-Time": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:25 GMT"
           ],
           "X-Ms-Lease-State": [
             "available"
@@ -340,7 +340,7 @@
             "unlocked"
           ],
           "X-Ms-Request-Id": [
-            "dac1ecb6-e01e-0139-18c9-c95225000000"
+            "169bf981-301e-0130-36f4-3248ab000000"
           ],
           "X-Ms-Server-Encrypted": [
             "true"
@@ -353,7 +353,7 @@
       }
     },
     {
-      "ID": "dd8334a5577cb192",
+      "ID": "2490af437aa2c751",
       "Request": {
         "Method": "GET",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket?comp=list\u0026delimiter=%2F\u0026maxresults=1000\u0026prefix=mydir\u0026restype=container",
@@ -386,13 +386,13 @@
             "application/xml"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:24 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
           ],
           "X-Ms-Request-Id": [
-            "dac1ecc8-e01e-0139-29c9-c95225000000"
+            "169bf98a-301e-0130-3ef4-3248ab000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -402,7 +402,7 @@
       }
     },
     {
-      "ID": "a22eb52fdc236f4b",
+      "ID": "aab5bfdff431a4de",
       "Request": {
         "Method": "GET",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket?comp=list\u0026delimiter=\u0026maxresults=1000\u0026prefix=mydir%2Fas-test\u0026restype=container",
@@ -435,23 +435,23 @@
             "application/xml"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:24 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
           ],
           "X-Ms-Request-Id": [
-            "dac1ecd3-e01e-0139-30c9-c95225000000"
+            "169bf991-301e-0130-45f4-3248ab000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
           ]
         },
-        "Body": "77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9nb2Nsb3VkYmxvYnRlc3RzLmJsb2IuY29yZS53aW5kb3dzLm5ldC8iIENvbnRhaW5lck5hbWU9ImdvLWNsb3VkLWJ1Y2tldCI+PFByZWZpeD5teWRpci9hcy10ZXN0PC9QcmVmaXg+PE1heFJlc3VsdHM+MTAwMDwvTWF4UmVzdWx0cz48QmxvYnM+PEJsb2I+PE5hbWU+bXlkaXIvYXMtdGVzdDwvTmFtZT48UHJvcGVydGllcz48Q3JlYXRpb24tVGltZT5UaHUsIDAzIERlYyAyMDIwIDIzOjA4OjExIEdNVDwvQ3JlYXRpb24tVGltZT48TGFzdC1Nb2RpZmllZD5UaHUsIDAzIERlYyAyMDIwIDIzOjA4OjExIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEODk3RTA0RTFDNEFBNTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTE8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+dGV4dC9wbGFpbjsgY2hhcnNldD11dGYtODwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2U+bmw8L0NvbnRlbnQtTGFuZ3VhZ2U+PENvbnRlbnQtQ1JDNjQgLz48Q29udGVudC1NRDU+WHJZN3UrQWU3dENUeXlLN2oxck53dz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PEFjY2Vzc1RpZXI+SG90PC9BY2Nlc3NUaWVyPjxBY2Nlc3NUaWVySW5mZXJyZWQ+dHJ1ZTwvQWNjZXNzVGllckluZmVycmVkPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+dHJ1ZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48T3JNZXRhZGF0YSAvPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+"
+        "Body": "77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9nb2Nsb3VkYmxvYnRlc3RzLmJsb2IuY29yZS53aW5kb3dzLm5ldC8iIENvbnRhaW5lck5hbWU9ImdvLWNsb3VkLWJ1Y2tldCI+PFByZWZpeD5teWRpci9hcy10ZXN0PC9QcmVmaXg+PE1heFJlc3VsdHM+MTAwMDwvTWF4UmVzdWx0cz48QmxvYnM+PEJsb2I+PE5hbWU+bXlkaXIvYXMtdGVzdDwvTmFtZT48UHJvcGVydGllcz48Q3JlYXRpb24tVGltZT5GcmksIDE2IEFwciAyMDIxIDE5OjE2OjI1IEdNVDwvQ3JlYXRpb24tVGltZT48TGFzdC1Nb2RpZmllZD5GcmksIDE2IEFwciAyMDIxIDE5OjE2OjI1IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEOTAxMEMyMTE4MkNBNzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTE8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+dGV4dC9wbGFpbjsgY2hhcnNldD11dGYtODwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2U+bmw8L0NvbnRlbnQtTGFuZ3VhZ2U+PENvbnRlbnQtQ1JDNjQgLz48Q29udGVudC1NRDU+WHJZN3UrQWU3dENUeXlLN2oxck53dz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PEFjY2Vzc1RpZXI+SG90PC9BY2Nlc3NUaWVyPjxBY2Nlc3NUaWVySW5mZXJyZWQ+dHJ1ZTwvQWNjZXNzVGllckluZmVycmVkPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+dHJ1ZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48T3JNZXRhZGF0YSAvPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+"
       }
     },
     {
-      "ID": "05fa6ed10d89834a",
+      "ID": "7b13da04f93f787b",
       "Request": {
         "Method": "GET",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/key-does-not-exist",
@@ -487,7 +487,7 @@
             "application/xml"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:24 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -496,17 +496,17 @@
             "BlobNotFound"
           ],
           "X-Ms-Request-Id": [
-            "dac1ecde-e01e-0139-38c9-c95225000000"
+            "169bf996-301e-0130-4af4-3248ab000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
           ]
         },
-        "Body": "77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RXJyb3I+PENvZGU+QmxvYk5vdEZvdW5kPC9Db2RlPjxNZXNzYWdlPlRoZSBzcGVjaWZpZWQgYmxvYiBkb2VzIG5vdCBleGlzdC4KUmVxdWVzdElkOmRhYzFlY2RlLWUwMWUtMDEzOS0zOGM5LWM5NTIyNTAwMDAwMApUaW1lOjIwMjAtMTItMDNUMjM6MDg6MTEuMjQ5NDcwNlo8L01lc3NhZ2U+PC9FcnJvcj4="
+        "Body": "77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RXJyb3I+PENvZGU+QmxvYk5vdEZvdW5kPC9Db2RlPjxNZXNzYWdlPlRoZSBzcGVjaWZpZWQgYmxvYiBkb2VzIG5vdCBleGlzdC4KUmVxdWVzdElkOjE2OWJmOTk2LTMwMWUtMDEzMC00YWY0LTMyNDhhYjAwMDAwMApUaW1lOjIwMjEtMDQtMTZUMTk6MTY6MjUuNjU3ODc5MVo8L01lc3NhZ2U+PC9FcnJvcj4="
       }
     },
     {
-      "ID": "043c2303c6ec7687",
+      "ID": "70d1906a16f0abfd",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test-copy",
@@ -525,9 +525,6 @@
           ],
           "X-Ms-Date": [
             "CLEARED"
-          ],
-          "X-Ms-Tags": [
-            ""
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -548,25 +545,25 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:24 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04E28D005\""
+            "\"0x8D9010C21212EFB\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:11 GMT"
+            "Fri, 16 Apr 2021 19:16:25 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
           ],
           "X-Ms-Copy-Id": [
-            "0be80200-a70f-4aaa-94bf-bddb382baade"
+            "8ea5a58e-30df-42fd-a39d-1de924ac233a"
           ],
           "X-Ms-Copy-Status": [
             "success"
           ],
           "X-Ms-Request-Id": [
-            "dac1ece4-e01e-0139-3ec9-c95225000000"
+            "169bf999-301e-0130-4df4-3248ab000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -576,7 +573,7 @@
       }
     },
     {
-      "ID": "9b53e55ce4d0f256",
+      "ID": "21ec9d82cd699b0a",
       "Request": {
         "Method": "DELETE",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test-copy",
@@ -612,7 +609,7 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:24 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -621,7 +618,7 @@
             "true"
           ],
           "X-Ms-Request-Id": [
-            "dac1ecfa-e01e-0139-4ec9-c95225000000"
+            "169bf9a4-301e-0130-58f4-3248ab000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -631,7 +628,7 @@
       }
     },
     {
-      "ID": "73ad1eb74a23bdcc",
+      "ID": "fa963dabeeb451ef",
       "Request": {
         "Method": "DELETE",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/mydir/as-test",
@@ -667,7 +664,7 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:10 GMT"
+            "Fri, 16 Apr 2021 19:16:24 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -676,7 +673,7 @@
             "true"
           ],
           "X-Ms-Request-Id": [
-            "dac1ed02-e01e-0139-55c9-c95225000000"
+            "169bf9a8-301e-0130-5cf4-3248ab000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"

--- a/blob/azureblob/testdata/TestConformance/TestCopy/NonExistentSourceFails.replay
+++ b/blob/azureblob/testdata/TestConformance/TestCopy/NonExistentSourceFails.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7XW2bYChP0UP4g",
+  "Initial": "AQAAAA7YC9ljL6pcAv5c",
   "Version": "0.2",
   "Converter": {
     "ScrubBody": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "decce1862040fe58",
+      "ID": "b8962af4e8e9c0a7",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-dest",
@@ -59,9 +59,6 @@
           ],
           "X-Ms-Date": [
             "CLEARED"
-          ],
-          "X-Ms-Tags": [
-            ""
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -85,7 +82,7 @@
             "application/xml"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:07 GMT"
+            "Fri, 16 Apr 2021 19:15:47 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -94,13 +91,13 @@
             "BlobNotFound"
           ],
           "X-Ms-Request-Id": [
-            "a92398d5-801e-0087-6ac9-c901fb000000"
+            "492055de-101e-00ef-0df4-325faa000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
           ]
         },
-        "Body": "77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RXJyb3I+PENvZGU+QmxvYk5vdEZvdW5kPC9Db2RlPjxNZXNzYWdlPlRoZSBzcGVjaWZpZWQgYmxvYiBkb2VzIG5vdCBleGlzdC4KUmVxdWVzdElkOmE5MjM5OGQ1LTgwMWUtMDA4Ny02YWM5LWM5MDFmYjAwMDAwMApUaW1lOjIwMjAtMTItMDNUMjM6MDg6MDguMjE5MTY1MFo8L01lc3NhZ2U+PC9FcnJvcj4="
+        "Body": "77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RXJyb3I+PENvZGU+QmxvYk5vdEZvdW5kPC9Db2RlPjxNZXNzYWdlPlRoZSBzcGVjaWZpZWQgYmxvYiBkb2VzIG5vdCBleGlzdC4KUmVxdWVzdElkOjQ5MjA1NWRlLTEwMWUtMDBlZi0wZGY0LTMyNWZhYTAwMDAwMApUaW1lOjIwMjEtMDQtMTZUMTk6MTU6NDguMTM2OTE0OFo8L01lc3NhZ2U+PC9FcnJvcj4="
       }
     }
   ]

--- a/blob/azureblob/testdata/TestConformance/TestCopy/Works.replay
+++ b/blob/azureblob/testdata/TestConformance/TestCopy/Works.replay
@@ -1,5 +1,5 @@
 {
-  "Initial": "AQAAAA7XW2bYDY/o5P4g",
+  "Initial": "AQAAAA7YC9lkCGrIEf5c",
   "Version": "0.2",
   "Converter": {
     "ScrubBody": [
@@ -40,7 +40,7 @@
   },
   "Entries": [
     {
-      "ID": "a45ce7c38b2e9ce8",
+      "ID": "fe091201b03366f1",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-src?blockid=CLEARED\u0026comp=block",
@@ -76,7 +76,7 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:07 GMT"
+            "Fri, 16 Apr 2021 19:15:47 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -85,7 +85,7 @@
             "YeJLfssylmU="
           ],
           "X-Ms-Request-Id": [
-            "37506089-d01e-0017-60c9-c994b7000000"
+            "40e91abe-f01e-004f-79f4-3290cc000000"
           ],
           "X-Ms-Request-Server-Encrypted": [
             "true"
@@ -98,7 +98,7 @@
       }
     },
     {
-      "ID": "18688e4c3d0b832f",
+      "ID": "c07fa2aa396e3445",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-src?comp=blocklist",
@@ -155,22 +155,22 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:07 GMT"
+            "Fri, 16 Apr 2021 19:15:47 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04C62FFEF\""
+            "\"0x8D9010C0AC8E265\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
           ],
           "X-Ms-Content-Crc64": [
-            "wQTkC6h3sjE="
+            "Lt2M2pBQhso="
           ],
           "X-Ms-Request-Id": [
-            "37506095-d01e-0017-6ac9-c994b7000000"
+            "40e91acd-f01e-004f-02f4-3290cc000000"
           ],
           "X-Ms-Request-Server-Encrypted": [
             "true"
@@ -183,7 +183,7 @@
       }
     },
     {
-      "ID": "e96a7ad69f7762e6",
+      "ID": "5fdead771dd83e55",
       "Request": {
         "Method": "HEAD",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-src",
@@ -234,13 +234,13 @@
             "text/plain"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:07 GMT"
+            "Fri, 16 Apr 2021 19:15:47 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04C62FFEF\""
+            "\"0x8D9010C0AC8E265\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -267,7 +267,7 @@
             "bar"
           ],
           "X-Ms-Request-Id": [
-            "3750609d-d01e-0017-72c9-c994b7000000"
+            "40e91ad4-f01e-004f-09f4-3290cc000000"
           ],
           "X-Ms-Server-Encrypted": [
             "true"
@@ -280,7 +280,7 @@
       }
     },
     {
-      "ID": "bc7b380fe24d8c65",
+      "ID": "81645af121122e89",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-dest-exists?blockid=CLEARED\u0026comp=block",
@@ -316,7 +316,7 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:07 GMT"
+            "Fri, 16 Apr 2021 19:15:47 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -325,7 +325,7 @@
             "Y9mFmC2gxu4="
           ],
           "X-Ms-Request-Id": [
-            "375060a3-d01e-0017-78c9-c994b7000000"
+            "40e91add-f01e-004f-11f4-3290cc000000"
           ],
           "X-Ms-Request-Server-Encrypted": [
             "true"
@@ -338,7 +338,7 @@
       }
     },
     {
-      "ID": "e72b0622e79c4c9c",
+      "ID": "06319f3dfac4d0ee",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-dest-exists?comp=blocklist",
@@ -392,22 +392,22 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:07 GMT"
+            "Fri, 16 Apr 2021 19:15:47 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04C68F473\""
+            "\"0x8D9010C0ACDEC5B\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
           ],
           "X-Ms-Content-Crc64": [
-            "v1Dv8oGJt+Y="
+            "H5gOEpcUQ34="
           ],
           "X-Ms-Request-Id": [
-            "375060a7-d01e-0017-7cc9-c994b7000000"
+            "40e91adf-f01e-004f-13f4-3290cc000000"
           ],
           "X-Ms-Request-Server-Encrypted": [
             "true"
@@ -420,7 +420,7 @@
       }
     },
     {
-      "ID": "5be21f68c32c82b8",
+      "ID": "2cfcd2f775411e9b",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-dest",
@@ -439,9 +439,6 @@
           ],
           "X-Ms-Date": [
             "CLEARED"
-          ],
-          "X-Ms-Tags": [
-            ""
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -462,25 +459,25 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:07 GMT"
+            "Fri, 16 Apr 2021 19:15:47 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04C6CC5AF\""
+            "\"0x8D9010C0AD05DCB\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
           ],
           "X-Ms-Copy-Id": [
-            "41d28fc7-030b-4ff1-a1ce-5d23ad18c5da"
+            "7fac9d91-605c-403c-97b5-89f66d4509f7"
           ],
           "X-Ms-Copy-Status": [
             "success"
           ],
           "X-Ms-Request-Id": [
-            "375060b1-d01e-0017-05c9-c994b7000000"
+            "40e91ae8-f01e-004f-1cf4-3290cc000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -490,7 +487,7 @@
       }
     },
     {
-      "ID": "79d2eee92f64814c",
+      "ID": "8b30ddff229954a3",
       "Request": {
         "Method": "GET",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-dest",
@@ -544,13 +541,13 @@
             "text/plain"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:07 GMT"
+            "Fri, 16 Apr 2021 19:15:47 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04C6CC5AF\""
+            "\"0x8D9010C0AD05DCB\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -559,10 +556,10 @@
             "BlockBlob"
           ],
           "X-Ms-Copy-Completion-Time": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "X-Ms-Copy-Id": [
-            "41d28fc7-030b-4ff1-a1ce-5d23ad18c5da"
+            "7fac9d91-605c-403c-97b5-89f66d4509f7"
           ],
           "X-Ms-Copy-Progress": [
             "11/11"
@@ -586,7 +583,7 @@
             "bar"
           ],
           "X-Ms-Request-Id": [
-            "375060c3-d01e-0017-15c9-c994b7000000"
+            "40e91aed-f01e-004f-21f4-3290cc000000"
           ],
           "X-Ms-Server-Encrypted": [
             "true"
@@ -599,7 +596,7 @@
       }
     },
     {
-      "ID": "93d0404440e58bd5",
+      "ID": "ad40cdb76b729357",
       "Request": {
         "Method": "HEAD",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-dest",
@@ -650,13 +647,13 @@
             "text/plain"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:07 GMT"
+            "Fri, 16 Apr 2021 19:15:47 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04C6CC5AF\""
+            "\"0x8D9010C0AD05DCB\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -671,10 +668,10 @@
             "BlockBlob"
           ],
           "X-Ms-Copy-Completion-Time": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "X-Ms-Copy-Id": [
-            "41d28fc7-030b-4ff1-a1ce-5d23ad18c5da"
+            "7fac9d91-605c-403c-97b5-89f66d4509f7"
           ],
           "X-Ms-Copy-Progress": [
             "11/11"
@@ -698,7 +695,7 @@
             "bar"
           ],
           "X-Ms-Request-Id": [
-            "375060ca-d01e-0017-1bc9-c994b7000000"
+            "40e91af5-f01e-004f-27f4-3290cc000000"
           ],
           "X-Ms-Server-Encrypted": [
             "true"
@@ -711,7 +708,7 @@
       }
     },
     {
-      "ID": "720521f3f891ab96",
+      "ID": "5039fffb13559b25",
       "Request": {
         "Method": "PUT",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-dest-exists",
@@ -730,9 +727,6 @@
           ],
           "X-Ms-Date": [
             "CLEARED"
-          ],
-          "X-Ms-Tags": [
-            ""
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -753,25 +747,25 @@
             "0"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:07 GMT"
+            "Fri, 16 Apr 2021 19:15:47 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04C74412B\""
+            "\"0x8D9010C0AD4A44E\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
           ],
           "X-Ms-Copy-Id": [
-            "69fc0cf7-d768-4d96-9758-166f813825b9"
+            "e01acdef-8d73-4950-a47a-57400d404076"
           ],
           "X-Ms-Copy-Status": [
             "success"
           ],
           "X-Ms-Request-Id": [
-            "375060d5-d01e-0017-26c9-c994b7000000"
+            "40e91afd-f01e-004f-2df4-3290cc000000"
           ],
           "X-Ms-Version": [
             "2019-12-12"
@@ -781,7 +775,7 @@
       }
     },
     {
-      "ID": "316019fd456736cf",
+      "ID": "65b49e509e5fe910",
       "Request": {
         "Method": "GET",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-dest-exists",
@@ -835,13 +829,13 @@
             "text/plain"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:07 GMT"
+            "Fri, 16 Apr 2021 19:15:47 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04C74412B\""
+            "\"0x8D9010C0AD4A44E\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -850,10 +844,10 @@
             "BlockBlob"
           ],
           "X-Ms-Copy-Completion-Time": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "X-Ms-Copy-Id": [
-            "69fc0cf7-d768-4d96-9758-166f813825b9"
+            "e01acdef-8d73-4950-a47a-57400d404076"
           ],
           "X-Ms-Copy-Progress": [
             "11/11"
@@ -877,7 +871,7 @@
             "bar"
           ],
           "X-Ms-Request-Id": [
-            "375060ed-d01e-0017-3bc9-c994b7000000"
+            "40e91b06-f01e-004f-35f4-3290cc000000"
           ],
           "X-Ms-Server-Encrypted": [
             "true"
@@ -890,7 +884,7 @@
       }
     },
     {
-      "ID": "88f31a3dd5509134",
+      "ID": "2ed845639cdf1bd4",
       "Request": {
         "Method": "HEAD",
         "URL": "https://gocloudblobtests.blob.core.windows.net/go-cloud-bucket/blob-for-copying-dest-exists",
@@ -941,13 +935,13 @@
             "text/plain"
           ],
           "Date": [
-            "Thu, 03 Dec 2020 23:08:07 GMT"
+            "Fri, 16 Apr 2021 19:15:47 GMT"
           ],
           "Etag": [
-            "\"0x8D897E04C74412B\""
+            "\"0x8D9010C0AD4A44E\""
           ],
           "Last-Modified": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "Server": [
             "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0"
@@ -962,10 +956,10 @@
             "BlockBlob"
           ],
           "X-Ms-Copy-Completion-Time": [
-            "Thu, 03 Dec 2020 23:08:08 GMT"
+            "Fri, 16 Apr 2021 19:15:48 GMT"
           ],
           "X-Ms-Copy-Id": [
-            "69fc0cf7-d768-4d96-9758-166f813825b9"
+            "e01acdef-8d73-4950-a47a-57400d404076"
           ],
           "X-Ms-Copy-Progress": [
             "11/11"
@@ -989,7 +983,7 @@
             "bar"
           ],
           "X-Ms-Request-Id": [
-            "375060f5-d01e-0017-42c9-c994b7000000"
+            "40e91b0b-f01e-004f-3af4-3290cc000000"
           ],
           "X-Ms-Server-Encrypted": [
             "true"


### PR DESCRIPTION
Cloned from #2988 by @leezen, because it requires updating some golden files

Fixes #2982

Providing an empty map ends up causing the underlying SDK to want to have permissions to write tags against the destination blob. However, we don't actually need this permission since we're not really writing any tags. Instead, we should just pass in nil.