### PR TITLE
pubsub: Add Message.LoggableID

### DIFF
--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -745,9 +745,10 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 		}
 
 		m2 := &driver.Message{
-			Body:     b,
-			Metadata: attrs,
-			AckID:    m.ReceiptHandle,
+			LoggableID: aws.StringValue(m.MessageId),
+			Body:       b,
+			Metadata:   attrs,
+			AckID:      m.ReceiptHandle,
 			AsFunc: func(i interface{}) bool {
 				p, ok := i.(**sqs.Message)
 				if !ok {

--- a/pubsub/azuresb/azuresb.go
+++ b/pubsub/azuresb/azuresb.go
@@ -425,10 +425,11 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 			}
 		}
 		messages = append(messages, &driver.Message{
-			Body:     sbmsg.Data,
-			Metadata: metadata,
-			AckID:    sbmsg.LockToken,
-			AsFunc:   messageAsFunc(sbmsg),
+			LoggableID: sbmsg.ID,
+			Body:       sbmsg.Data,
+			Metadata:   metadata,
+			AckID:      sbmsg.LockToken,
+			AsFunc:     messageAsFunc(sbmsg),
 		})
 		return nil
 	}))

--- a/pubsub/driver/driver.go
+++ b/pubsub/driver/driver.go
@@ -37,6 +37,10 @@ type AckInfo struct {
 // Message is data to be published (sent) to a topic and later received from
 // subscriptions on that topic.
 type Message struct {
+	// LoggableID should be set to an opaque message identifer for
+	// received messages.
+	LoggableID string
+
 	// Body contains the content of the message.
 	Body []byte
 

--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -451,10 +451,11 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 	for _, rm := range resp.ReceivedMessages {
 		rmm := rm.Message
 		m := &driver.Message{
-			Body:     rmm.Data,
-			Metadata: rmm.Attributes,
-			AckID:    rm.AckId,
-			AsFunc:   messageAsFunc(rmm),
+			LoggableID: rmm.MessageId,
+			Body:       rmm.Data,
+			Metadata:   rmm.Attributes,
+			AckID:      rm.AckId,
+			AsFunc:     messageAsFunc(rmm),
 		}
 		ms = append(ms, m)
 	}

--- a/pubsub/kafkapubsub/kafka.go
+++ b/pubsub/kafkapubsub/kafka.go
@@ -532,10 +532,17 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 			md[s.opts.KeyName] = string(msg.Key)
 		}
 		ack := &ackInfo{msg: msg}
+		var loggableID string
+		if len(msg.Key) == 0 {
+			loggableID = fmt.Sprintf("partition %d offset %d", msg.Partition, msg.Offset)
+		} else {
+			loggableID = string(msg.Key)
+		}
 		dm := &driver.Message{
-			Body:     msg.Value,
-			Metadata: md,
-			AckID:    ack,
+			LoggableID: loggableID,
+			Body:       msg.Value,
+			Metadata:   md,
+			AckID:      ack,
 			AsFunc: func(i interface{}) bool {
 				if p, ok := i.(**sarama.ConsumerMessage); ok {
 					*p = msg

--- a/pubsub/kafkapubsub/kafka_test.go
+++ b/pubsub/kafkapubsub/kafka_test.go
@@ -264,6 +264,7 @@ func TestKafkaKey(t *testing.T) {
 	got.Ack()
 
 	m.BeforeSend = nil // don't expect this in the received message
+	m.LoggableID = keyValue
 	if diff := cmp.Diff(got, m, cmpopts.IgnoreUnexported(pubsub.Message{})); diff != "" {
 		t.Errorf("got\n%v\nwant\n%v\ndiff\n%v", got, m, diff)
 	}

--- a/pubsub/mempubsub/mem.go
+++ b/pubsub/mempubsub/mem.go
@@ -151,6 +151,7 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 	// but that would require copying all the messages.
 	for i, m := range ms {
 		m.AckID = t.nextAckID + i
+		m.LoggableID = fmt.Sprintf("msg #%d", m.AckID)
 		m.AsFunc = func(interface{}) bool { return false }
 
 		if m.BeforeSend != nil {

--- a/pubsub/natspubsub/nats.go
+++ b/pubsub/natspubsub/nats.go
@@ -317,7 +317,7 @@ func openSubscription(nc *nats.Conn, subject string, opts *SubscriptionOptions) 
 	if err != nil {
 		return nil, err
 	}
-	return &subscription{nc, sub}, nil
+	return &subscription{nc, sub, 1}, nil
 }
 
 // ReceiveBatch implements driver.ReceiveBatch.

--- a/pubsub/natspubsub/nats.go
+++ b/pubsub/natspubsub/nats.go
@@ -290,8 +290,9 @@ func (*topic) ErrorCode(err error) gcerrors.ErrorCode {
 func (*topic) Close() error { return nil }
 
 type subscription struct {
-	nc   *nats.Conn
-	nsub *nats.Subscription
+	nc     *nats.Conn
+	nsub   *nats.Subscription
+	nextID int
 }
 
 // OpenSubscription returns a *pubsub.Subscription representing a NATS subscription or NATS queue subscription.
@@ -336,6 +337,8 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 	if err != nil {
 		return nil, err
 	}
+	dm.LoggableID = fmt.Sprintf("msg #%d", s.nextID)
+	s.nextID++
 	return []*driver.Message{dm}, nil
 }
 

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -115,7 +115,11 @@ func TestSendReceive(t *testing.T) {
 	}
 	topic := NewTopic(dt, nil)
 	defer topic.Shutdown(ctx)
-	m := &Message{Body: []byte("user signed up")}
+	m := &Message{LoggableID: "foo", Body: []byte("user signed up")}
+	if err := topic.Send(ctx, m); err == nil {
+		t.Fatalf("expected a Send with a non-empty LoggableID to fail")
+	}
+	m.LoggableID = ""
 	if err := topic.Send(ctx, m); err != nil {
 		t.Fatal(err)
 	}

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -639,10 +639,18 @@ func toMessage(d amqp.Delivery) *driver.Message {
 	for k, v := range d.Headers {
 		md[k] = fmt.Sprint(v)
 	}
+	loggableID := d.MessageId
+	if loggableID == "" {
+		loggableID = d.CorrelationId
+	}
+	if loggableID == "" {
+		loggableID = fmt.Sprintf("DeliveryTag %d", d.DeliveryTag)
+	}
 	return &driver.Message{
-		Body:     d.Body,
-		AckID:    d.DeliveryTag,
-		Metadata: md,
+		LoggableID: loggableID,
+		Body:       d.Body,
+		AckID:      d.DeliveryTag,
+		Metadata:   md,
 		AsFunc: func(i interface{}) bool {
 			p, ok := i.(*amqp.Delivery)
 			if !ok {


### PR DESCRIPTION
An opaque field useful only for debugging and logging.

Fixes #2994.