### PR TITLE
pubsub/gcppubsub: Allow configuration of batch sizes

### DIFF
--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -424,6 +424,10 @@ type SubscriptionOptions struct {
 func OpenSubscription(client *raw.SubscriberClient, projectID gcp.ProjectID, subscriptionName string, opts *SubscriptionOptions) *pubsub.Subscription {
 	path := fmt.Sprintf("projects/%s/subscriptions/%s", projectID, subscriptionName)
 
+	if opts == nil {
+		opts = &SubscriptionOptions{MaxBatchSize: defaultRecvBatcherOpts.MaxBatchSize}
+	}
+
 	recvOpts := &batcher.Options{
 		MaxHandlers:  defaultRecvBatcherOpts.MaxHandlers,
 		MinBatchSize: defaultRecvBatcherOpts.MinBatchSize,
@@ -444,6 +448,10 @@ func OpenSubscriptionByPath(client *raw.SubscriberClient, subscriptionPath strin
 		return nil, fmt.Errorf("invalid subscriptionPath %q; must match %v", subscriptionPath, subscriptionPathRE)
 	}
 
+	if opts == nil {
+		opts = &SubscriptionOptions{MaxBatchSize: defaultRecvBatcherOpts.MaxBatchSize}
+	}
+
 	recvOpts := &batcher.Options{
 		MaxHandlers:  defaultRecvBatcherOpts.MaxHandlers,
 		MinBatchSize: defaultRecvBatcherOpts.MinBatchSize,
@@ -455,6 +463,10 @@ func OpenSubscriptionByPath(client *raw.SubscriberClient, subscriptionPath strin
 
 // openSubscription returns a driver.Subscription.
 func openSubscription(client *raw.SubscriberClient, subscriptionPath string, opts *SubscriptionOptions) driver.Subscription {
+	if opts == nil {
+		opts = &SubscriptionOptions{MaxBatchSize: defaultRecvBatcherOpts.MaxBatchSize}
+	}
+
 	return &subscription{client, subscriptionPath, opts}
 }
 

--- a/pubsub/gcppubsub/gcppubsub_test.go
+++ b/pubsub/gcppubsub/gcppubsub_test.go
@@ -409,7 +409,11 @@ func TestOpenSubscriptionFromURL(t *testing.T) {
 		// Invalid parameter.
 		{"gcppubsub://myproject/mysub?param=value", true},
 		// Valid parameters
-		{"gcppubsub://projects/myproject/subscriptions/mysub?max-batch-size=1", false},
+		{"gcppubsub://projects/myproject/subscriptions/mysub?max_recv_batch_size=1", false},
+		// Invalid parameters
+		{"gcppubsub://projects/myproject/subscriptions/mysub?max_recv_batch_size=0", true},
+		// Invalid parameters
+		{"gcppubsub://projects/myproject/subscriptions/mysub?max_recv_batch_size=1001", true},
 	}
 
 	ctx := context.Background()

--- a/pubsub/gcppubsub/gcppubsub_test.go
+++ b/pubsub/gcppubsub/gcppubsub_test.go
@@ -119,7 +119,7 @@ func createSubscription(ctx context.Context, subClient *raw.SubscriberClient, dt
 	if err != nil {
 		return nil, nil, err
 	}
-	ds = openSubscription(subClient, path.Join("projects", projectID, "subscriptions", subName))
+	ds = openSubscription(subClient, path.Join("projects", projectID, "subscriptions", subName), nil)
 	cleanup = func() {
 		subClient.DeleteSubscription(ctx, &pubsubpb.DeleteSubscriptionRequest{Subscription: subPath})
 	}
@@ -127,7 +127,7 @@ func createSubscription(ctx context.Context, subClient *raw.SubscriberClient, dt
 }
 
 func (h *harness) MakeNonexistentSubscription(ctx context.Context) (driver.Subscription, func(), error) {
-	return openSubscription(h.subClient, path.Join("projects", projectID, "subscriptions", "nonexistent-subscription")), func() {}, nil
+	return openSubscription(h.subClient, path.Join("projects", projectID, "subscriptions", "nonexistent-subscription"), nil), func() {}, nil
 }
 
 func (h *harness) Close() {
@@ -188,7 +188,7 @@ func BenchmarkGcpPubSub(b *testing.B) {
 		b.Fatal(err)
 	}
 	defer cleanup2()
-	sub := pubsub.NewSubscription(ds, recvBatcherOpts, ackBatcherOpts)
+	sub := pubsub.NewSubscription(ds, defaultRecvBatcherOpts, ackBatcherOpts)
 	defer sub.Shutdown(ctx)
 
 	drivertest.RunBenchmarks(b, topic, sub)
@@ -409,7 +409,7 @@ func TestOpenSubscriptionFromURL(t *testing.T) {
 		// Invalid parameter.
 		{"gcppubsub://myproject/mysub?param=value", true},
 		// Valid parameters
-		{"gcppubsub://projects/myproject/subscriptions/mysub?receive-max-handlers=1&receive-min-batch-size=1&receive-max-batch-size=1&ack-max-handlers=1&ack-min-batch-size=1&ack-max-batch-size=1", false},
+		{"gcppubsub://projects/myproject/subscriptions/mysub?max-batch-size=1", false},
 	}
 
 	ctx := context.Background()

--- a/pubsub/gcppubsub/gcppubsub_test.go
+++ b/pubsub/gcppubsub/gcppubsub_test.go
@@ -408,6 +408,8 @@ func TestOpenSubscriptionFromURL(t *testing.T) {
 		{"gcppubsub://projects/myproject/subscriptions/mysub", false},
 		// Invalid parameter.
 		{"gcppubsub://myproject/mysub?param=value", true},
+		// Valid parameters
+		{"gcppubsub://projects/myproject/subscriptions/mysub?receive-max-handlers=1&receive-min-batch-size=1&receive-max-batch-size=1&ack-max-handlers=1&ack-min-batch-size=1&ack-max-batch-size=1", false},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #3003 

This PR allows users of the `pubsub/gcppubsub` package to configure the receive batch size via a query parameter. 

Signed-off-by: David Bond <davidsbond93@gmail.com>