### PR TITLE
pubsub/gcppubsub: Consider publish request body size limitation when batching

### DIFF
--- a/pubsub/batcher/batcher.go
+++ b/pubsub/batcher/batcher.go
@@ -74,6 +74,9 @@ type Batcher struct {
 	shutdown  bool
 }
 
+// Message is larger than the maximum batch byte size
+var ErrMessageTooLarge = errors.New("batcher: message too large")
+
 type sizableItem interface {
 	ByteSize() int
 }
@@ -158,7 +161,7 @@ func (b *Batcher) AddNoWait(item interface{}) <-chan error {
 
 	if sizable, ok := item.(sizableItem); b.opts.MaxBatchByteSize > 0 && ok {
 		if sizable.ByteSize() > b.opts.MaxBatchByteSize {
-			c <- errors.New("batcher: message too large")
+			c <- ErrMessageTooLarge
 			return c
 		}
 	}

--- a/pubsub/driver/driver.go
+++ b/pubsub/driver/driver.go
@@ -78,6 +78,11 @@ type Message struct {
 	AfterSend func(asFunc func(interface{}) bool) error
 }
 
+// Implement batcher item for byte sized based batching
+func (m *Message) ByteSize() int {
+	return len(m.Body)
+}
+
 // Topic publishes messages.
 // Drivers may optionally also implement io.Closer; Close will be called
 // when the pubsub.Topic is Shutdown.

--- a/pubsub/driver/driver.go
+++ b/pubsub/driver/driver.go
@@ -78,7 +78,7 @@ type Message struct {
 	AfterSend func(asFunc func(interface{}) bool) error
 }
 
-// Implement batcher item for byte sized based batching
+// ByteSize estimates the size in bytes of the message for the purpose of restricting batch sizes.
 func (m *Message) ByteSize() int {
 	return len(m.Body)
 }

--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -81,8 +81,9 @@ import (
 var endPoint = "pubsub.googleapis.com:443"
 
 var sendBatcherOpts = &batcher.Options{
-	MaxBatchSize: 1000, // The PubSub service limits the number of messages in a single Publish RPC
-	MaxHandlers:  2,
+	MaxBatchSize:     1000, // The PubSub service limits the number of messages in a single Publish RPC
+	MaxHandlers:      2,
+	MaxBatchByteSize: 10 * 1000 * 1000, // The PubSub service limits the size of request body in a single Publish RPC
 }
 
 var defaultRecvBatcherOpts = &batcher.Options{

--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -81,9 +81,13 @@ import (
 var endPoint = "pubsub.googleapis.com:443"
 
 var sendBatcherOpts = &batcher.Options{
-	MaxBatchSize:     1000, // The PubSub service limits the number of messages in a single Publish RPC
-	MaxHandlers:      2,
-	MaxBatchByteSize: 10 * 1000 * 1000, // The PubSub service limits the size of request body in a single Publish RPC
+	MaxBatchSize: 1000, // The PubSub service limits the number of messages in a single Publish RPC
+	MaxHandlers:  2,
+	// The PubSub service limits the size of the request body in a single Publish RPC.
+	// The limit is currently documented as "10MB (total size)" and "10MB (data field)" per message.
+	// We are enforcing 9MiB to give ourselves some headroom for message attributes since those
+	// are currently not considered when computing the byte size of a message.
+	MaxBatchByteSize: 9 * 1024 * 1024,
 }
 
 var defaultRecvBatcherOpts = &batcher.Options{


### PR DESCRIPTION
This allows configuring a maximum batch size in bytes on the batcher in an attempt to respect the GCP 10MB limitation per publish request_size as documented in https://cloud.google.com/pubsub/quotas.
Happy to add tests if this limitation should be enforced at the batcher level like proposed in this PR.