### PR TITLE
blob/s3: Adds NewSessionFromURLParams for AWS to set profile in the URL

### DIFF
--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -69,7 +69,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -88,7 +87,7 @@ import (
 const defaultPageSize = 1000
 
 func init() {
-	blob.DefaultURLMux().RegisterBucket(Scheme, new(lazySessionOpener))
+	blob.DefaultURLMux().RegisterBucket(Scheme, new(urlSessionOpener))
 }
 
 // Set holds Wire providers for this package.
@@ -96,28 +95,21 @@ var Set = wire.NewSet(
 	wire.Struct(new(URLOpener), "ConfigProvider"),
 )
 
-// lazySessionOpener obtains the AWS session from the environment on the first
-// call to OpenBucketURL.
-type lazySessionOpener struct {
-	init   sync.Once
+type urlSessionOpener struct {
 	opener *URLOpener
-	err    error
 }
 
-func (o *lazySessionOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.Bucket, error) {
-	o.init.Do(func() {
-		sess, err := gcaws.NewDefaultSession()
-		if err != nil {
-			o.err = err
-			return
-		}
-		o.opener = &URLOpener{
-			ConfigProvider: sess,
-		}
-	})
-	if o.err != nil {
-		return nil, fmt.Errorf("open bucket %v: %v", u, o.err)
+func (o *urlSessionOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.Bucket, error) {
+	sess, rest, err := gcaws.NewSessionFromURLParams(u.Query())
+	if err != nil {
+		return nil, fmt.Errorf("open bucket %v: %v", u, err)
 	}
+
+	o.opener = &URLOpener{
+		ConfigProvider: sess,
+	}
+
+	u.RawQuery = rest.Encode()
 	return o.opener.OpenBucketURL(ctx, u)
 }
 


### PR DESCRIPTION
It is used for s3 blob to enable setting profile from S3 URLs like: s3://bucket_name?profile=main

Fixes #2865

The first cut. I had to replace `lazySessionOpener` private class because after this change it is possible to open several s3 buckets using different AWS profiles, so creating a session with `init.Do` doesn't make much sense anymore.

Basically, the idea is to get profile from the url and pass the rest of the parameters to `ConfigFromURLParams` afterwards.

Maybe it would be a good idea to refactor those functions that parse the URL somehow, so they are not repeated in several places in this repository (i.e. https://github.com/google/go-cloud/blob/master/blob/azureblob/azureblob.go#L318 does pretty much the same thing, but it's private, and also doesn't allow multiple values for the same parameter).