### PR TITLE
blob/s3blob: Don't set ContentType in the S3 input for signing if it is an empty string

### DIFF
--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -748,9 +748,11 @@ func (b *bucket) SignedURL(_ context.Context, key string, opts *driver.SignedURL
 		req, _ = b.client.GetObjectRequest(in)
 	case http.MethodPut:
 		in := &s3.PutObjectInput{
-			Bucket:      aws.String(b.name),
-			Key:         aws.String(key),
-			ContentType: aws.String(opts.ContentType),
+			Bucket: aws.String(b.name),
+			Key:    aws.String(key),
+		}
+		if opts.ContentType != "" {
+			in.ContentType = aws.String(opts.ContentType)
 		}
 		if opts.BeforeSign != nil {
 			asFunc := func(i interface{}) bool {


### PR DESCRIPTION
Including an empty ContentType during signing causes the signed URL to also include `content-type` as one of the signed headers. This doesn't appear to be a problem with AWS S3 itself. However, when used with Minio, it seems that Minio is strict about including the content-type when a client tries to use a signed URL to upload objects. That is, it seems to expect the client upload the object to also including an empty `content-type` header. Otherwise, a signature mismatch error is encountered. I have worked around this issue by using the `BeforeSign` callback to override the `ContentType` of `s3.PutObjectInput` to `nil` and then things work as expected.