### PR TITLE
pubsub/kafkapubsub: Configure initial offset in URL.

### DIFF
--- a/pubsub/kafkapubsub/kafka.go
+++ b/pubsub/kafkapubsub/kafka.go
@@ -139,7 +139,10 @@ const Scheme = "kafka"
 //
 // For subscriptions, the URL's host+path is used as the group name,
 // and the "topic" query parameter(s) are used as the set of topics to
-// subscribe to.
+// subscribe to. The "offset" parameter is available to subscribers to set
+// the Kafka consumer's initial offset. Where "oldest" starts consuming from
+// the oldest offset of the consumer group and "newest" starts consuming from
+// the most recent offset on the topic.
 type URLOpener struct {
 	// Brokers is the slice of brokers in the Kafka cluster.
 	Brokers []string
@@ -164,12 +167,30 @@ func (o *URLOpener) OpenTopicURL(ctx context.Context, u *url.URL) (*pubsub.Topic
 
 // OpenSubscriptionURL opens a pubsub.Subscription based on u.
 func (o *URLOpener) OpenSubscriptionURL(ctx context.Context, u *url.URL) (*pubsub.Subscription, error) {
-	q := u.Query()
-	topics := q["topic"]
-	q.Del("topic")
-	for param := range q {
-		return nil, fmt.Errorf("open subscription %v: invalid query parameter %q", u, param)
+	var topics []string
+	for param, value := range u.Query() {
+		switch param {
+		case "topic":
+			topics = value
+		case "offset":
+			if len(value) == 0 {
+				return nil, fmt.Errorf("open subscription %v: invalid query parameter %q", u, param)
+			}
+
+			offset := value[0]
+			switch offset {
+			case "oldest":
+				o.Config.Consumer.Offsets.Initial = sarama.OffsetOldest
+			case "newest":
+				o.Config.Consumer.Offsets.Initial = sarama.OffsetNewest
+			default:
+				return nil, fmt.Errorf("open subscription %v: invalid query parameter %q", u, offset)
+			}
+		default:
+			return nil, fmt.Errorf("open subscription %v: invalid query parameter %q", u, param)
+		}
 	}
+
 	group := path.Join(u.Host, u.Path)
 	return OpenSubscription(o.Brokers, o.Config, group, topics, &o.SubscriptionOptions)
 }


### PR DESCRIPTION
This commit adds the ability for users of the `kafkapubsub` package to specify the initial consumer offset
when using a URL.

When creating a kafka consumer, you sometimes want to specify at which point the consumer should begin reading from
a topic. This is specified as either `oldest` or `newest`, where `oldest` is the oldest committed offset by the
consumer group and `newest` is the most recent offset.

Currently, there is no way to configure this via the URL, you'd have to use the `kafkapubsub` package directly to
build your consumer. So when you use a URL, you get the default sarama behaviour and you start consuming from
the newest point in the stream. This doesn't allow you to read streams from the start, which is a very common
usecase for consumers.

Signed-off-by: David Bond <davidsbond93@gmail.com>