### PR TITLE
pubsub/rabbitpubsub: allow setting routing key for topic publishers

### DIFF
--- a/pubsub/rabbitpubsub/amqp.go
+++ b/pubsub/rabbitpubsub/amqp.go
@@ -27,10 +27,6 @@ const (
 	// response. We always want to wait.
 	wait = false
 
-	// Always use the empty routing key. This driver expects to be used with topic
-	// exchanges, which disregard the routing key.
-	routingKey = ""
-
 	// If the message can't be enqueued, return it to the sender rather than silently
 	// dropping it.
 	mandatory = true
@@ -47,7 +43,7 @@ type amqpConnection interface {
 
 // See https://godoc.org/github.com/streadway/amqp#Channel for the documentation of these methods.
 type amqpChannel interface {
-	Publish(exchange string, msg amqp.Publishing) error
+	Publish(exchangeName, routingKey string, msg amqp.Publishing) error
 	Consume(queue, consumer string) (<-chan amqp.Delivery, error)
 	Ack(tag uint64) error
 	Nack(tag uint64) error
@@ -89,8 +85,8 @@ type channel struct {
 	ch *amqp.Channel
 }
 
-func (ch *channel) Publish(exchange string, msg amqp.Publishing) error {
-	return ch.ch.Publish(exchange, routingKey, mandatory, immediate, msg)
+func (ch *channel) Publish(exchangeName, routingKey string, msg amqp.Publishing) error {
+	return ch.ch.Publish(exchangeName, routingKey, mandatory, immediate, msg)
 }
 
 func (ch *channel) Consume(queue, consumer string) (<-chan amqp.Delivery, error) {

--- a/pubsub/rabbitpubsub/fake_test.go
+++ b/pubsub/rabbitpubsub/fake_test.go
@@ -152,7 +152,7 @@ func (ch *fakeChannel) QueueDeclareAndBind(queueName, exchangeName string) error
 	return nil
 }
 
-func (ch *fakeChannel) Publish(exchangeName string, pub amqp.Publishing) error {
+func (ch *fakeChannel) Publish(exchangeName, routingKey string, pub amqp.Publishing) error {
 	if ch.isClosed() {
 		return amqp.ErrClosed
 	}

--- a/pubsub/rabbitpubsub/rabbit_test.go
+++ b/pubsub/rabbitpubsub/rabbit_test.go
@@ -119,11 +119,11 @@ func (h *harness) CreateTopic(_ context.Context, testName string) (dt driver.Top
 		}
 		ch.ExchangeDelete(exchange)
 	}
-	return newTopic(h.conn, exchange), cleanup, nil
+	return newTopic(h.conn, exchange, ""), cleanup, nil
 }
 
 func (h *harness) MakeNonexistentTopic(context.Context) (driver.Topic, error) {
-	return newTopic(h.conn, "nonexistent-topic"), nil
+	return newTopic(h.conn, "nonexistent-topic", ""), nil
 }
 
 func (h *harness) CreateSubscription(_ context.Context, dt driver.Topic, testName string) (ds driver.Subscription, cleanup func(), err error) {
@@ -164,7 +164,7 @@ func TestUnroutable(t *testing.T) {
 	if err := declareExchange(conn, "u"); err != nil {
 		t.Fatal(err)
 	}
-	topic := newTopic(conn, "u")
+	topic := newTopic(conn, "u", "")
 	msgs := []*driver.Message{
 		{Body: []byte("")},
 		{Body: []byte("")},


### PR DESCRIPTION
This PR adds `routing_key` URL query parameter and option for RabbitMQ PubSub topics.