### PR TITLE
blob/azblob: allow for client id in MSI authentication

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -30,8 +30,9 @@
 // blob storage domain to use. If no AZURE_STORAGE_DOMAIN is provided, the
 // default Azure public domain "blob.core.windows.net" will be used. Check
 // the Azure Developer Guide for your particular cloud environment to see
-// the proper blob storage domain name to provide. We ignore errors on blob.OpenBucket
-// because we'll get them from OpenBucket later
+// the proper blob storage domain name to provide.
+// If there are multiple identities assigned to your account, you can also provide
+// AZURE_CLIENT_ID to designate which identity should be used for authentication.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
 // See https://gocloud.dev/concepts/urls/ for background information.

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -30,7 +30,8 @@
 // blob storage domain to use. If no AZURE_STORAGE_DOMAIN is provided, the
 // default Azure public domain "blob.core.windows.net" will be used. Check
 // the Azure Developer Guide for your particular cloud environment to see
-// the proper blob storage domain name to provide.
+// the proper blob storage domain name to provide. We ignore errors on blob.OpenBucket
+// because we'll get them from OpenBucket later
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
 // See https://gocloud.dev/concepts/urls/ for background information.

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -165,6 +165,7 @@ func (o *lazyCredsOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.
 		// Ignore errors, as we'll get errors from OpenBucket later.
 		accountName, _ := DefaultAccountName()
 		accountKey, _ := DefaultAccountKey()
+		clientId, _ := DefaultClientId()
 		sasToken, _ := DefaultSASToken()
 		storageDomain, _ := DefaultStorageDomain()
 		isCDN, _ := DefaultIsCDN()
@@ -180,7 +181,7 @@ func (o *lazyCredsOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.
 		if accountKey != "" || sasToken != "" {
 			o.opener, o.err = openerFromEnv(accountName, accountKey, sasToken, opts)
 		} else if isMSIEnvironment {
-			o.opener, o.err = openerFromMSI(accountName, opts)
+			o.opener, o.err = openerFromMSI(accountName, clientId, opts)
 		} else {
 			o.opener, o.err = openerFromAnon(accountName, opts)
 		}
@@ -266,9 +267,9 @@ var defaultTokenRefreshFunction = func(spToken *adal.ServicePrincipalToken) func
 }
 
 // openerFromMSI acquires an MSI token and returns TokenCredential backed URLOpener
-func openerFromMSI(accountName AccountName, opts Options) (*URLOpener, error) {
+func openerFromMSI(accountName AccountName, clientId ClientId, opts Options) (*URLOpener, error) {
 
-	spToken, err := getMSIServicePrincipalToken(azure.PublicCloud.ResourceIdentifiers.Storage)
+	spToken, err := getMSIServicePrincipalToken(azure.PublicCloud.ResourceIdentifiers.Storage, clientId)
 	if err != nil {
 		return nil, fmt.Errorf("failure acquiring token from MSI endpoint %w", err)
 	}
@@ -287,14 +288,23 @@ func openerFromMSI(accountName AccountName, opts Options) (*URLOpener, error) {
 }
 
 // getMSIServicePrincipalToken retrieves Azure API Service Principal token.
-func getMSIServicePrincipalToken(resource string) (*adal.ServicePrincipalToken, error) {
+func getMSIServicePrincipalToken(resource string, clientId ClientId) (*adal.ServicePrincipalToken, error) {
 
 	msiEndpoint, err := adal.GetMSIEndpoint()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the managed service identity endpoint: %v", err)
 	}
 
-	token, err := adal.NewServicePrincipalTokenFromMSI(msiEndpoint, resource)
+	var token *adal.ServicePrincipalToken
+	if clientId == "" {
+		token, err = adal.NewServicePrincipalTokenFromMSI(msiEndpoint, resource)
+	} else {
+		opts := &adal.ManagedIdentityOptions{
+			ClientID: string(clientId),
+		}
+		token, err = adal.NewServicePrincipalTokenFromManagedIdentity(resource, opts)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the managed service identity token: %v", err)
 	}
@@ -366,6 +376,9 @@ type AccountName string
 // AccountKey is an Azure storage account key (primary or secondary).
 type AccountKey string
 
+// ClientID is an Azure client id
+type ClientId string
+
 // SASToken is an Azure shared access signature.
 // https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1
 type SASToken string
@@ -398,6 +411,13 @@ func DefaultAccountKey() (AccountKey, error) {
 		return "", errors.New("azureblob: environment variable AZURE_STORAGE_KEY not set")
 	}
 	return AccountKey(s), nil
+}
+
+// DefaultClientId loads the Azure client Id from the
+// AZURE_CLIENT_ID environment variable. Use of the client Id is optional
+func DefaultClientId() (ClientId, error) {
+	s := os.Getenv("AZURE_CLIENT_ID")
+	return ClientId(s), nil
 }
 
 // DefaultSASToken loads a Azure SAS token from the AZURE_STORAGE_SAS_TOKEN


### PR DESCRIPTION
Due to Azure security requirements, there might be multiple service
identities attached to a particular account. In that case, the Client ID
must be provided in order to secure an authorization token.

This allows the `AZURE_CLIENT_ID` environment variable to be read in as
an optional extra bit of data and if provided will invoke the
appropriate underlying method in Azure autorest to authenticate with the
client Id instead

Please use a title starting with the name of the affected package, or \"all\",
followed by a colon, followed by a short summary of the issue. Example:
`blob/gcsblob: fix typo in documentation`.

Please reference any Issue related to this Pull Request. Example: `Fixes #1`.

See
[here](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
for tips on good Pull Request description.
