### PR TITLE
blob/azureblob: add azure cli authorizer and URL params

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -187,8 +187,15 @@ func (o *lazyCredsOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.
 	if err != nil {
 		return nil, fmt.Errorf("can't parse global options")
 	}
+
+	// copy the URL as we are not allowed to change the original one
+	// see https://github.com/golang/go/issues/38351#issuecomment-619567154
+	if u == nil {
+		return nil, fmt.Errorf("the URL is nil")
+	}
+	copiedURL := &*u
 	// pass the rest of the options
-	u.RawQuery = rest.Encode()
+	copiedURL.RawQuery = rest.Encode()
 
 	if globalOptions.AccountName != "" {
 		accountName = globalOptions.AccountName
@@ -216,7 +223,7 @@ func (o *lazyCredsOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.
 	if o.err != nil {
 		return nil, fmt.Errorf("open bucket %v: %v", u, o.err)
 	}
-	return o.opener.OpenBucketURL(ctx, u)
+	return o.opener.OpenBucketURL(ctx, copiedURL)
 }
 
 type GlobalOptions struct {

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -234,7 +234,7 @@ func setGlobalOptionsFromURLParams(q url.Values, o *GlobalOptions) (url.Values, 
 
 		value := values[0]
 		switch param {
-		case "account_name":
+		case "storage_account":
 			o.AccountName = AccountName(value)
 		case "subscription_id":
 			o.SubscriptionId = SubscriptionId(value)

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -591,7 +591,7 @@ func TestOpenBucketFromURL(t *testing.T) {
 		// Invalid parameter.
 		{"azblob://mybucket?param=value", true},
 		// With account_name.
-		{"azblob://mybucket?account_name=value", false},
+		{"azblob://mybucket?storage_account=value", false},
 		// With subscription_id (but expect error as it requires a valid subscription id).
 		{"azblob://mybucket?subscription_id=value", true},
 	}

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -590,6 +590,10 @@ func TestOpenBucketFromURL(t *testing.T) {
 		{"azblob://mybucket?cdn=42", true},
 		// Invalid parameter.
 		{"azblob://mybucket?param=value", true},
+		// With account_name.
+		{"azblob://mybucket?account_name=value", false},
+		// With subscription_id (but expect error as it requires a valid subscription id).
+		{"azblob://mybucket?subscription_id=value", true},
 	}
 
 	ctx := context.Background()

--- a/blob/azureblob/example_test.go
+++ b/blob/azureblob/example_test.go
@@ -115,11 +115,11 @@ func Example_openBucketFromURLWithCLI() {
 	ctx := context.Background()
 
 	// blob.OpenBucket creates a *blob.Bucket from a URL.
-	// This URL will open the container "my-container" using default
-	// credentials found in the environment variables
-	// AZURE_STORAGE_ACCOUNT plus at least one of AZURE_STORAGE_KEY
+	// This URL will open the container "my-container" using
+	// credentials created by az cli, and storage account "xxx" and
+	// subscription "xxx-yyy"
 	// and AZURE_STORAGE_SAS_TOKEN.
-	bucket, err := blob.OpenBucket(ctx, "azblob://my-container?subscription_id=xxx&account_name=xxx")
+	bucket, err := blob.OpenBucket(ctx, "azblob://my-container?subscription_id=xxx-yyy&account_name=xxx")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/blob/azureblob/example_test.go
+++ b/blob/azureblob/example_test.go
@@ -108,6 +108,24 @@ func Example_openBucketFromURL() {
 	defer bucket.Close()
 }
 
+func Example_openBucketFromURLWithCLI() {
+	// PRAGMA: This example is used on gocloud.dev; PRAGMA comments adjust how it is shown and can be ignored.
+	// PRAGMA: On gocloud.dev, add a blank import: _ "gocloud.dev/blob/azureblob"
+	// PRAGMA: On gocloud.dev, hide lines until the next blank line.
+	ctx := context.Background()
+
+	// blob.OpenBucket creates a *blob.Bucket from a URL.
+	// This URL will open the container "my-container" using default
+	// credentials found in the environment variables
+	// AZURE_STORAGE_ACCOUNT plus at least one of AZURE_STORAGE_KEY
+	// and AZURE_STORAGE_SAS_TOKEN.
+	bucket, err := blob.OpenBucket(ctx, "azblob://my-container?subscription_id=xxx&account_name=xxx")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer bucket.Close()
+}
+
 func ExampleOpenBucket_usingAADCredentials() {
 	const (
 		// Your Azure Storage Account.

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.21
 	github.com/Azure/go-autorest/autorest/adal v0.9.16
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.8
-	github.com/Azure/go-autorest/autorest/azure/cli v0.4.3 // indirect
+	github.com/Azure/go-autorest/autorest/azure/cli v0.4.3
 	github.com/GoogleCloudPlatform/cloudsql-proxy v1.26.0
 	github.com/aws/aws-sdk-go v1.41.5
 	github.com/aws/aws-sdk-go-v2 v1.9.2

--- a/internal/website/data/examples.json
+++ b/internal/website/data/examples.json
@@ -35,6 +35,10 @@
 		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/blob\"\n\t_ \"gocloud.dev/blob/azureblob\"\n)",
 		"code": "// blob.OpenBucket creates a *blob.Bucket from a URL.\n// This URL will open the container \"my-container\" using default\n// credentials found in the environment variables\n// AZURE_STORAGE_ACCOUNT plus at least one of AZURE_STORAGE_KEY\n// and AZURE_STORAGE_SAS_TOKEN.\nbucket, err := blob.OpenBucket(ctx, \"azblob://my-container\")\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()"
 	},
+	"gocloud.dev/blob/azureblob.Example_openBucketFromURLWithCLI": {
+		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/blob\"\n\t_ \"gocloud.dev/blob/azureblob\"\n)",
+		"code": "// blob.OpenBucket creates a *blob.Bucket from a URL.\n// This URL will open the container \"my-container\" using\n// credentials created by az cli, and storage account \"xxx\" and\n// subscription \"xxx-yyy\"\n// and AZURE_STORAGE_SAS_TOKEN.\nbucket, err := blob.OpenBucket(ctx, \"azblob://my-container?subscription_id=xxx-yyy\u0026account_name=xxx\")\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()"
+	},
 	"gocloud.dev/blob/fileblob.ExampleOpenBucket": {
 		"imports": "import (\n\t\"os\"\n\n\t\"gocloud.dev/blob/fileblob\"\n)",
 		"code": "// The directory you pass to fileblob.OpenBucket must exist first.\nconst myDir = \"path/to/local/directory\"\nif err := os.MkdirAll(myDir, 0777); err != nil {\n\treturn err\n}\n\n// Create a file-based bucket.\nbucket, err := fileblob.OpenBucket(myDir, nil)\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()"


### PR DESCRIPTION
Fixes #3012

First of all this PR adds a new variable `AZURE_BLOB_AUTH_VIA_CLI` to enable authorisation using CLI.
Secondly, to make it useful, it adds 2 URL parameters, similar to https://github.com/google/go-cloud/pull/3008, to specify storage account name and subscription id.

A reminder needs to be put somewhere that Blob authorisation via CLI requires "Storage Blob Data Contributor" role (it seems like it requires this specific role even if you've got "Contributor" already).

I've chosen `AZURE_BLOB_AUTH_VIA_CLI` as the name of the env var to so it doesn't look like one of the standard Azure env vars.