### PR TITLE
blob/azblob: generic storage domain support for local storage emulator (proposal)

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -134,9 +134,8 @@ type Options struct {
 	// "<account name>." part is dropped if IsCDN is set to true.
 	IsCDN bool
 
-	// IsLocalEmulator should be set to true when targetting Local Storage Emulator (Azurite)
-	// https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite
-	// This allows to build an URL structure that works with it (which is a bit different from the real one.)
+	// IsLocalEmulator should be set to true when targetting Local Storage Emulator (Azurite).
+	// The URL format is "<Protocol>://<StorageDomain>/<account name>" (ex: http://127.0.0.1:10000/devstoreaccount1).
 	IsLocalEmulator bool
 }
 
@@ -211,6 +210,7 @@ const Scheme = "azblob"
 //  - domain: The domain name used to access the Azure Blob storage (e.g. blob.core.windows.net)
 //  - protocol: The protocol to use (e.g., http or https; default to https)
 //  - cdn: Set to true when domain represents a CDN
+//  - local: Set to true when domain points to the Local Storage Emulator (Azurite)
 //
 // See Options for more details.
 type URLOpener struct {
@@ -350,6 +350,12 @@ func setOptionsFromURLParams(q url.Values, o *Options) error {
 				return err
 			}
 			o.IsCDN = isCDN
+		case "localemu":
+			isLocalEmulator, err := strconv.ParseBool(value)
+			if err != nil {
+				return err
+			}
+			o.IsLocalEmulator = isLocalEmulator
 		default:
 			return fmt.Errorf("unknown query parameter %q", param)
 		}

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -210,7 +210,7 @@ const Scheme = "azblob"
 //  - domain: The domain name used to access the Azure Blob storage (e.g. blob.core.windows.net)
 //  - protocol: The protocol to use (e.g., http or https; default to https)
 //  - cdn: Set to true when domain represents a CDN
-//  - local: Set to true when domain points to the Local Storage Emulator (Azurite)
+//  - localemu: Set to true when domain points to the Local Storage Emulator (Azurite)
 //
 // See Options for more details.
 type URLOpener struct {

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -133,6 +133,11 @@ type Options struct {
 	// The full URL used is "<Protocol>://<account name>.<StorageDomain>", where the
 	// "<account name>." part is dropped if IsCDN is set to true.
 	IsCDN bool
+
+	// IsLocalEmulator should be set to true when targetting Local Storage Emulator (Azurite)
+	// https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+	// This allows to build an URL structure that works with it (which is a bit different from the real one.)
+	IsLocalEmulator bool
 }
 
 const (
@@ -522,7 +527,7 @@ func openBucket(ctx context.Context, pipeline pipeline.Pipeline, accountName Acc
 	d := string(opts.StorageDomain)
 	var u string
 	// The URL structure of the local emulator is a bit different from the real one.
-	if strings.HasPrefix(d, "127.0.0.1") || strings.HasPrefix(d, "localhost") {
+	if strings.HasPrefix(d, "127.0.0.1") || strings.HasPrefix(d, "localhost") || opts.IsLocalEmulator {
 		u = fmt.Sprintf("%s://%s/%s", opts.Protocol, opts.StorageDomain, accountName) // http://127.0.0.1:10000/devstoreaccount1
 	} else if opts.IsCDN {
 		u = fmt.Sprintf("%s://%s", opts.Protocol, opts.StorageDomain) // https://mycdnname.azureedge.net

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -442,7 +442,6 @@ func Test_openBucket(t *testing.T) {
 			name:             "local emulator 127.0.0.1:10000",
 			protocol:         "http",
 			storageDomain:    "127.0.0.1:10000",
-			isLocalEmulator:  false, // to test backward compatibility before introduction of Options.IsLocalEmulator
 			wantContainerURL: "http://127.0.0.1:10000/gocloudblobtests/mycontainer",
 			wantErr:          false,
 		},
@@ -450,7 +449,6 @@ func Test_openBucket(t *testing.T) {
 			name:             "local emulator localhost:10000",
 			protocol:         "http",
 			storageDomain:    "localhost:10000",
-			isLocalEmulator:  false, // to test backward compatibility before introduction of Options.IsLocalEmulator
 			wantContainerURL: "http://localhost:10000/gocloudblobtests/mycontainer",
 			wantErr:          false,
 		},
@@ -599,6 +597,10 @@ func TestOpenBucketFromURL(t *testing.T) {
 		{"azblob://mybucket?cdn=true", false},
 		// With invalid CDN.
 		{"azblob://mybucket?cdn=42", true},
+		// With local emulator.
+		{"azblob://mybucket?localemu=true", false},
+		// With invalid local emulator.
+		{"azblob://mybucket?localemu=42", true},
 		// Invalid parameter.
 		{"azblob://mybucket?param=value", true},
 	}

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -422,6 +422,7 @@ func Test_openBucket(t *testing.T) {
 		protocol         Protocol
 		storageDomain    StorageDomain
 		isCDN            bool
+		isLocalEmulator  bool
 		wantContainerURL string
 		wantErr          bool
 	}{
@@ -441,6 +442,7 @@ func Test_openBucket(t *testing.T) {
 			name:             "local emulator 127.0.0.1:10000",
 			protocol:         "http",
 			storageDomain:    "127.0.0.1:10000",
+			isLocalEmulator:  false, // to test backward compatibility before introduction of Options.IsLocalEmulator
 			wantContainerURL: "http://127.0.0.1:10000/gocloudblobtests/mycontainer",
 			wantErr:          false,
 		},
@@ -448,7 +450,16 @@ func Test_openBucket(t *testing.T) {
 			name:             "local emulator localhost:10000",
 			protocol:         "http",
 			storageDomain:    "localhost:10000",
+			isLocalEmulator:  false, // to test backward compatibility before introduction of Options.IsLocalEmulator
 			wantContainerURL: "http://localhost:10000/gocloudblobtests/mycontainer",
+			wantErr:          false,
+		},
+		{
+			name:             "local emulator azurite-http.svc.local:10000",
+			protocol:         "http",
+			storageDomain:    "azurite-http.svc.local:10000",
+			isLocalEmulator:  true,
+			wantContainerURL: "http://azurite-http.svc.local:10000/gocloudblobtests/mycontainer",
 			wantErr:          false,
 		},
 		{
@@ -488,7 +499,7 @@ func Test_openBucket(t *testing.T) {
 			}
 			pipeline := azblob.NewPipeline(cred, azblob.PipelineOptions{})
 			containerName := "mycontainer"
-			o := &Options{Protocol: test.protocol, StorageDomain: test.storageDomain, IsCDN: test.isCDN}
+			o := &Options{Protocol: test.protocol, StorageDomain: test.storageDomain, IsCDN: test.isCDN, IsLocalEmulator: test.isLocalEmulator}
 			b, err := openBucket(ctx, pipeline, accountName, containerName, o)
 			if (err != nil) != test.wantErr {
 				t.Fatalf("wantErr=%v but got=%v", test.wantErr, err)


### PR DESCRIPTION
Disclaimer: this change is primarily meant as a proposal. Feel free to amend or suggest other more appropriate ways to support it if needed.

Allows support for local storage emulator running on any storage domain (not only localhost or loopback addresses).

This could be the case if Azurite is running on on another node, in a local kube cluster (kind, minikube, ...) or in Jenkins Pipeline (for which Azurite may have an ip from the docker network if running itself in docker)
