### PR TITLE
internal/website: remove duplicates from howto list

### DIFF
--- a/internal/website/layouts/_default/baseof.html
+++ b/internal/website/layouts/_default/baseof.html
@@ -52,17 +52,6 @@
               </li>
               {{- end }}
               {{- end }}
-              {{with .Sections}}
-              {{- range .GroupBy "Weight" }}
-              {{- range .ByTitle }}
-              {{- if .Params.showInSidenav }}
-              <li class="Sidenav-page">
-                <a href="{{.RelPermalink}}" class="Sidenav-pageLink">{{.LinkTitle}}</a>
-              </li>
-              {{- end }}
-              {{- end }}
-              {{- end }}
-              {{- end }}
             </ul>
           {{- end}}
         </li>

--- a/internal/website/layouts/howto/list.html
+++ b/internal/website/layouts/howto/list.html
@@ -2,13 +2,8 @@
 <h1>{{ .Title }}</h1>
 {{ partial "page-toc.html" . }}
 {{ partial "header-link.html" .Content }}
-{{ if or .Data.Pages .Sections }}
+{{ if or .Data.Pages }}
 <ul class="HowtoList">
-{{- range .Sections.GroupBy "Weight" }}
-{{- range .ByTitle }}
-  {{.Render "li"}}
-{{- end }}
-{{- end }}
 {{- range .Data.Pages.GroupBy "Weight" }}
 {{- range .ByTitle }}
   {{.Render "li"}}


### PR DESCRIPTION

There is a duplication of content in [How-To Guides](https://gocloud.dev/howto/) page and the side navigation.

![image](https://user-images.githubusercontent.com/26559890/148929479-772dddf3-5dac-44d1-942a-64497d4943ff.png)


I have removed the duplication as shown in the following image.
![image](https://user-images.githubusercontent.com/26559890/148929545-d97b3b0b-8003-4c52-9274-8b405d2e0dbb.png)
