### PR TITLE
postgres: Support IAM auth for GCP.

### DIFF
--- a/gcp/cloudsql/cloudsql.go
+++ b/gcp/cloudsql/cloudsql.go
@@ -32,5 +32,5 @@ var CertSourceSet = wire.NewSet(
 // NewCertSource creates a local certificate source that uses the given
 // HTTP client. The client is assumed to make authenticated requests.
 func NewCertSource(c *gcp.HTTPClient) *certs.RemoteCertSource {
-	return certs.NewCertSourceOpts(&c.Client, certs.RemoteOpts{})
+	return certs.NewCertSourceOpts(&c.Client, certs.RemoteOpts{EnableIAMLogin: true})
 }


### PR DESCRIPTION
This fixes #3121.

This always enables the IAM login option for GCP.

We could also have this configurable through a URL parameter, but that seems like the wrong approach. If you truly for some reason didn't want IAM authentication for cloud sql, you would have already declined to enable the flag it in the GCP setup for that database instance. If you did want to use IAM authentication, it would be annoyingly hard to debug why it wasn't working as it may surprise you to learn that the proxy has it off by default. So, it makes the most sense to just always enable it in the proxy.
