### PR TITLE
secrets/localsecrets: update docs to note that that base64 keys must be URL-safe

### DIFF
--- a/internal/website/data/examples.json
+++ b/internal/website/data/examples.json
@@ -425,7 +425,7 @@
 	},
 	"gocloud.dev/secrets/localsecrets.Example_openFromURL": {
 		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/secrets\"\n\t_ \"gocloud.dev/secrets/localsecrets\"\n)",
-		"code": "// Using \"base64key://\", a new random key will be generated.\nrandomKeyKeeper, err := secrets.OpenKeeper(ctx, \"base64key://\")\nif err != nil {\n\treturn err\n}\ndefer randomKeyKeeper.Close()\n\n// Otherwise, the URL hostname must be a base64-encoded key, of length 32 bytes when decoded.\nsavedKeyKeeper, err := secrets.OpenKeeper(ctx, \"base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=\")\nif err != nil {\n\treturn err\n}\ndefer savedKeyKeeper.Close()"
+		"code": "// Using \"base64key://\", a new random key will be generated.\nrandomKeyKeeper, err := secrets.OpenKeeper(ctx, \"base64key://\")\nif err != nil {\n\treturn err\n}\ndefer randomKeyKeeper.Close()\n\n// Otherwise, the URL hostname must be a base64-encoded key, of length 32 bytes when decoded.\n// Note that base64.URLEncode should be used, to avoid URL-unsafe characters.\nsavedKeyKeeper, err := secrets.OpenKeeper(ctx, \"base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=\")\nif err != nil {\n\treturn err\n}\ndefer savedKeyKeeper.Close()"
 	},
 	"gocloud.dev/server.ExampleServer_HealthChecks": {
 		"imports": "import (\n\t\"fmt\"\n\t\"net/http\"\n\t\"time\"\n\n\t\"gocloud.dev/server\"\n\t\"gocloud.dev/server/health\"\n)",

--- a/secrets/localsecrets/example_test.go
+++ b/secrets/localsecrets/example_test.go
@@ -49,6 +49,7 @@ func Example_openFromURL() {
 	defer randomKeyKeeper.Close()
 
 	// Otherwise, the URL hostname must be a base64-encoded key, of length 32 bytes when decoded.
+	// Note that base64.URLEncode should be used, to avoid URL-unsafe characters.
 	savedKeyKeeper, err := secrets.OpenKeeper(ctx, "base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=")
 	if err != nil {
 		log.Fatal(err)

--- a/secrets/localsecrets/localsecrets.go
+++ b/secrets/localsecrets/localsecrets.go
@@ -56,6 +56,7 @@ const (
 // URLOpener opens localsecrets URLs like "base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=".
 //
 // The URL host must be base64 encoded, and must decode to exactly 32 bytes.
+// Note that base64.URLEncoding should be used to avoid URL-unsafe character in the hostname.
 // If the URL host is empty (e.g., "base64key://"), a new random key is generated.
 //
 // No query parameters are supported.


### PR DESCRIPTION
Fixes #3123.
