### PR TITLE
blob/azureblob: add storage_account query parameter

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -28,7 +28,9 @@
 // credentials and a service URL; see
 // https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
 // for a more complete descriptions of each approach.
-//   - AZURE_STORAGE_ACCOUNT: The service account name. Required.
+//   - AZURE_STORAGE_ACCOUNT: The service account name. Required if used along with AZURE_STORAGE KEY, because it defines
+//     authentication mechanism to be azblob.NewSharedKeyCredential, which creates immutable shared key credentials.
+//     Otherwise, "storage_account" in the URL query string parameter can be used.
 //   - AZURE_STORAGE_KEY: To use a shared key credential. The service account
 //     name and key are passed to NewSharedKeyCredential and then the
 //     resulting credential is passed to NewServiceClientWithSharedKey.
@@ -216,6 +218,8 @@ func (o *ServiceURLOptions) withOverrides(urlValues url.Values) (*ServiceURLOpti
 				return nil, err
 			}
 			retval.IsLocalEmulator = isLocalEmulator
+		case "storage_account":
+			retval.AccountName = value
 		default:
 			return nil, fmt.Errorf("unknown query parameter %q", param)
 		}

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -624,6 +624,8 @@ func TestOpenBucketFromURL(t *testing.T) {
 		{"azblob://mybucket?protocol=http", false},
 		// With invalid protocol.
 		{"azblob://mybucket?protocol=ftp", true},
+		// With Account.
+		{"azblob://mybucket?storage_account=test", false},
 		// With CDN.
 		{"azblob://mybucket?cdn=true", false},
 		// With invalid CDN.

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -470,6 +470,14 @@ func TestNewServiceURL(t *testing.T) {
 			wantErrURL: true,
 		},
 		{
+			// Account name set in the query
+			opts: ServiceURLOptions{},
+			query: url.Values{
+				"storage_account": {"testaccount"},
+			},
+			want: "https://testaccount.blob.core.windows.net",
+		},
+		{
 			// Basic working case.
 			opts: ServiceURLOptions{
 				AccountName: "myaccount",


### PR DESCRIPTION
This PR adds "storage_account" as possible query string parameter to the URL.

It'll allow opening multiple storage accounts using the same credentials.
