### PR TITLE
gcp/cloudsql: GCP postgres IAM login support

### DIFF
--- a/gcp/cloudsql/cloudsql.go
+++ b/gcp/cloudsql/cloudsql.go
@@ -36,8 +36,8 @@ func NewCertSource(c *gcp.HTTPClient) *certs.RemoteCertSource {
 	return certs.NewCertSourceOpts(&c.Client, certs.RemoteOpts{})
 }
 
-// NewCertSourceIam creates a local certificate source, including Token source for token information used in
-//cert creation, that uses the given HTTP client. The client is assumed to make authenticated requests.
+// NewCertSourceWithIAM creates a local certificate source, including Token source for token information used in
+// cert creation, that uses the given HTTP client. The client is assumed to make authenticated requests.
 func NewCertSourceWithIAM(c *gcp.HTTPClient, t oauth2.TokenSource) *certs.RemoteCertSource {
 	return certs.NewCertSourceOpts(&c.Client, certs.RemoteOpts{EnableIAMLogin: true, TokenSource: t})
 }

--- a/gcp/cloudsql/cloudsql.go
+++ b/gcp/cloudsql/cloudsql.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/proxy"
 	"github.com/google/wire"
 	"gocloud.dev/gcp"
+	"golang.org/x/oauth2"
 )
 
 // CertSourceSet is a Wire provider set that binds a Cloud SQL proxy
@@ -31,6 +32,6 @@ var CertSourceSet = wire.NewSet(
 
 // NewCertSource creates a local certificate source that uses the given
 // HTTP client. The client is assumed to make authenticated requests.
-func NewCertSource(c *gcp.HTTPClient) *certs.RemoteCertSource {
-	return certs.NewCertSourceOpts(&c.Client, certs.RemoteOpts{})
+func NewCertSource(c *gcp.HTTPClient, t oauth2.TokenSource) *certs.RemoteCertSource {
+	return certs.NewCertSourceOpts(&c.Client, certs.RemoteOpts{EnableIAMLogin: true, TokenSource: t})
 }

--- a/gcp/cloudsql/cloudsql.go
+++ b/gcp/cloudsql/cloudsql.go
@@ -32,6 +32,12 @@ var CertSourceSet = wire.NewSet(
 
 // NewCertSource creates a local certificate source that uses the given
 // HTTP client. The client is assumed to make authenticated requests.
-func NewCertSource(c *gcp.HTTPClient, t oauth2.TokenSource) *certs.RemoteCertSource {
+func NewCertSource(c *gcp.HTTPClient) *certs.RemoteCertSource {
+	return certs.NewCertSourceOpts(&c.Client, certs.RemoteOpts{})
+}
+
+// NewCertSourceIam creates a local certificate source, including Token source for token information used in
+//cert creation, that uses the given HTTP client. The client is assumed to make authenticated requests.
+func NewCertSourceWithIAM(c *gcp.HTTPClient, t oauth2.TokenSource) *certs.RemoteCertSource {
 	return certs.NewCertSourceOpts(&c.Client, certs.RemoteOpts{EnableIAMLogin: true, TokenSource: t})
 }

--- a/postgres/gcppostgres/gcppostgres.go
+++ b/postgres/gcppostgres/gcppostgres.go
@@ -75,7 +75,7 @@ func (o *lazyCredsOpener) OpenPostgresURL(ctx context.Context, u *url.URL) (*sql
 			o.err = err
 			return
 		}
-		certSource := cloudsql.NewCertSource(client)
+		certSource := cloudsql.NewCertSource(client, creds.TokenSource)
 		o.opener = &URLOpener{CertSource: certSource}
 	})
 	if o.err != nil {

--- a/postgres/gcppostgres/gcppostgres.go
+++ b/postgres/gcppostgres/gcppostgres.go
@@ -75,7 +75,7 @@ func (o *lazyCredsOpener) OpenPostgresURL(ctx context.Context, u *url.URL) (*sql
 			o.err = err
 			return
 		}
-		certSource := cloudsql.NewCertSource(client, creds.TokenSource)
+		certSource := cloudsql.NewCertSourceWithIAM(client, creds.TokenSource)
 		o.opener = &URLOpener{CertSource: certSource}
 	})
 	if o.err != nil {

--- a/postgres/gcppostgres/gcppostgres_test.go
+++ b/postgres/gcppostgres/gcppostgres_test.go
@@ -41,8 +41,9 @@ func TestURLOpener(t *testing.T) {
 	username, _ := tfOut["username"].Value.(string)
 	password, _ := tfOut["password"].Value.(string)
 	databaseName, _ := tfOut["database"].Value.(string)
-	if project == "" || region == "" || instance == "" || username == "" || databaseName == "" {
-		t.Fatalf("Missing one or more required Terraform outputs; got project=%q region=%q instance=%q username=%q database=%q", project, region, instance, username, databaseName)
+	userEmail, _ := tfOut["user_email"].Value.(string)
+	if project == "" || region == "" || instance == "" || username == "" || databaseName == "" || userEmail == "" {
+		t.Fatalf("Missing one or more required Terraform outputs; got project=%q region=%q instance=%q username=%q database=%q userEmail=%q", project, region, instance, username, databaseName, userEmail)
 	}
 	tests := []struct {
 		name    string
@@ -50,7 +51,11 @@ func TestURLOpener(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:   "Success",
+			name:   "SuccessIam",
+			urlstr: fmt.Sprintf("gcppostgres://%s@%s/%s/%s/%s", userEmail, project, region, instance, databaseName),
+		},
+		{
+			name:   "SuccessBuiltin",
 			urlstr: fmt.Sprintf("gcppostgres://%s:%s@%s/%s/%s/%s", username, password, project, region, instance, databaseName),
 		},
 		{

--- a/postgres/gcppostgres/main.tf
+++ b/postgres/gcppostgres/main.tf
@@ -42,8 +42,8 @@ variable "user_email" {
 }
 
 variable "region" {
-  default     = "europe-west1"
-  description = "GCP region to create database and storage in, for example 'europe-west1'. See https://cloud.google.com/compute/docs/regions-zones/ for valid values."
+  default     = "us-central1"
+  description = "GCP region to create database and storage in, for example 'us-central1'. See https://cloud.google.com/compute/docs/regions-zones/ for valid values."
 }
 
 locals {

--- a/postgres/gcppostgres/main.tf
+++ b/postgres/gcppostgres/main.tf
@@ -15,26 +15,35 @@
 # Harness for Cloud SQL Postgres tests.
 
 terraform {
-  required_version = "~>0.12"
+  required_version = ">= 1.1.0"
+  required_providers {
+    google = {
+      version = "4.40.0"
+    }
+    random = {
+      version = "3.4.3"
+    }
+  }
 }
 
 provider "google" {
-  version = "~> 2.5"
   project = var.project
-}
-
-provider "random" {
-  version = "~> 2.1"
+  region  = var.region
 }
 
 variable "project" {
   type        = string
-  description = "Project to set up."
+  description = "Project ID - Google Cloud project ID in which to create resources."
+}
+
+variable "user_email" {
+  type        = string
+  description = "User email address - Google identity to be used for testing IAM authentication."
 }
 
 variable "region" {
-  default     = "us-central1"
-  description = "GCP region to create database and storage in, for example 'us-central1'. See https://cloud.google.com/compute/docs/regions-zones/ for valid values."
+  default     = "europe-west1"
+  description = "GCP region to create database and storage in, for example 'europe-west1'. See https://cloud.google.com/compute/docs/regions-zones/ for valid values."
 }
 
 locals {
@@ -60,6 +69,18 @@ resource "random_id" "sql_instance" {
   byte_length = 12
 }
 
+resource "google_project_iam_member" "cloudsql_client" {
+  project = var.project
+  role    = "roles/cloudsql.client"
+  member  = "user:${var.user_email}"
+}
+
+resource "google_project_iam_member" "cloudsql_instanceUser" {
+  project = var.project
+  role    = "roles/cloudsql.instanceUser"
+  member  = "user:${var.user_email}"
+}
+
 resource "google_sql_database_instance" "main" {
   name             = local.sql_instance
   database_version = "POSTGRES_9_6"
@@ -69,6 +90,10 @@ resource "google_sql_database_instance" "main" {
   settings {
     tier      = "db-f1-micro"
     disk_size = 10 # GiB
+    database_flags {
+      name  = "cloudsql.iam_authentication"
+      value = "on"
+    }
   }
 
   depends_on = [
@@ -78,6 +103,7 @@ resource "google_sql_database_instance" "main" {
 }
 
 resource "google_sql_database" "main" {
+  project  = var.project
   name     = "testdb"
   instance = google_sql_database_instance.main.name
 }
@@ -94,9 +120,16 @@ resource "random_string" "db_password" {
 }
 
 resource "google_sql_user" "root" {
+  type     = "BUILT_IN"
   name     = "root"
   instance = google_sql_database_instance.main.name
   password = random_string.db_password.result
+}
+
+resource "google_sql_user" "user_account" {
+  type     = "CLOUD_IAM_USER"
+  name     = var.user_email
+  instance = google_sql_database_instance.main.name
 }
 
 output "project" {
@@ -130,3 +163,7 @@ output "database" {
   description = "The name of the database inside the Cloud SQL instance."
 }
 
+output "user_email" {
+  value       = var.user_email
+  description = "The email of a GCP service account used for testing connections."
+}


### PR DESCRIPTION
gcp/cloudsql: enable IAM login

Fixes #3121
Fixes #3122
Fixes #3164

The code in this pull request allows Google Cloud [IAM PostgreSQL authentication](https://cloud.google.com/sql/docs/postgres/authentication). As agreed in #3122, the option for IAM authentication is always on. The only difference is oauth2 tokenSource being added as a parameter in certs.RemoteOpts.

I've also updated terraform testing infrastructure, added variable (user_email) to be added as a SQL IAM user

Test passing for both built in and IAM authentication:
```
$ go test
2022/10/14 18:11:07 refreshing ephemeral certificate for instance project-id:europe-west1:go-cloud-test-e271c23e4c3e86e2331697d5
2022/10/14 18:11:07 Generated RSA key in 58.542136ms
2022/10/14 18:11:08 Scheduling refresh of ephemeral certificate in 54m59s
2022/10/14 18:11:09 refreshing ephemeral certificate for instance project-id:europe-west1:go-cloud-test-e271c23e4c3e86e2331697d5
2022/10/14 18:11:09 Scheduling refresh of ephemeral certificate in 54m58s
PASS
ok  	gocloud.dev/postgres/gcppostgres	2.357s
```