### PR TITLE
blob/memblob: fix copy with options

### DIFF
--- a/blob/memblob/memblob.go
+++ b/blob/memblob/memblob.go
@@ -354,7 +354,9 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 	defer b.mu.Unlock()
 
 	if opts.BeforeCopy != nil {
-		return opts.BeforeCopy(func(interface{}) bool { return false })
+		if err := opts.BeforeCopy(func(interface{}) bool { return false }); err != nil {
+			return err
+		}
 	}
 	v := b.blobs[srcKey]
 	if v == nil {


### PR DESCRIPTION
Fix copy for memblob with options. Current behaviour always returns the option error value, nil with no copy done.