### PR TITLE
pubsub/kafkapub: fix nil pointer dereference

### DIFF
--- a/pubsub/kafkapubsub/kafka.go
+++ b/pubsub/kafkapubsub/kafka.go
@@ -234,7 +234,11 @@ func OpenTopic(brokers []string, config *sarama.Config, topicName string, opts *
 	if err != nil {
 		return nil, err
 	}
-	bo := sendBatcherOpts.NewMergedOptions(&opts.BatcherOptions)
+	bo := &batcher.Options{}
+	if opts != nil {
+		bo = &opts.BatcherOptions
+	}
+	bo = sendBatcherOpts.NewMergedOptions(bo)
 	return pubsub.NewTopic(dt, bo), nil
 }
 


### PR DESCRIPTION
`ExampleOpenTopic` (pubsub/kafkapubsub/example_test.go) show a simple call to `OpenTopic` without `kafkapubsub.TopicOptions` as passing a `nil` argument.
This is done by replacing a `nil` pointer with the appropriate zero-value.  This behaviour exists in `OpenSubscription` too. However, PR #3163 introduced overriding batching options which inadvertently accesses a field of a nil pointer.

/cc @vangent I see you authored the relevant files, could you please take a look?

P.S> This is my first commit to this repository (read the contributing guidelines though) - so couple of questions: 
1. Would you like me to report a concomitant bug and reference it from the commit's message?
2. Markdown in commit body - yes/no?

### Local testing
```bash
$ go test ./...
?       gocloud.dev     [no test files]
ok      gocloud.dev/aws (cached)
ok      gocloud.dev/aws/awscloud        (cached) [no tests to run]
?       gocloud.dev/aws/rds     [no test files]
?       gocloud.dev/azure/azurecloud    [no test files]
?       gocloud.dev/azure/azuredb       [no test files]
ok      gocloud.dev/blob        (cached)
ok      gocloud.dev/blob/azureblob      (cached)
?       gocloud.dev/blob/driver [no test files]
?       gocloud.dev/blob/drivertest     [no test files]
ok      gocloud.dev/blob/fileblob       (cached)
ok      gocloud.dev/blob/gcsblob        (cached)
ok      gocloud.dev/blob/memblob        1.035s
ok      gocloud.dev/blob/s3blob (cached)
ok      gocloud.dev/docstore    (cached)
ok      gocloud.dev/docstore/awsdynamodb        (cached)
ok      gocloud.dev/docstore/driver     (cached)
?       gocloud.dev/docstore/drivertest [no test files]
ok      gocloud.dev/docstore/gcpfirestore       (cached)
ok      gocloud.dev/docstore/internal/fields    (cached)
ok      gocloud.dev/docstore/memdocstore        (cached)
ok      gocloud.dev/gcerrors    0.153s
ok      gocloud.dev/gcp (cached)
?       gocloud.dev/gcp/cloudsql        [no test files]
ok      gocloud.dev/gcp/gcpcloud        (cached) [no tests to run]
ok      gocloud.dev/internal/escape     (cached)
ok      gocloud.dev/internal/gcerr      (cached)
ok      gocloud.dev/internal/oc (cached)
ok      gocloud.dev/internal/openurl    (cached)
ok      gocloud.dev/internal/releasehelper      3.097s
ok      gocloud.dev/internal/retry      (cached)
?       gocloud.dev/internal/testing/octest     [no test files]
?       gocloud.dev/internal/testing/setup      [no test files]
?       gocloud.dev/internal/testing/terraform  [no test files]
ok      gocloud.dev/internal/testing/test-summary       (cached)
?       gocloud.dev/internal/useragent  [no test files]
ok      gocloud.dev/mysql       2.842s
ok      gocloud.dev/mysql/awsmysql      3.133s
ok      gocloud.dev/mysql/azuremysql    2.184s
ok      gocloud.dev/mysql/gcpmysql      0.158s
ok      gocloud.dev/postgres    (cached)
ok      gocloud.dev/postgres/awspostgres        2.520s
ok      gocloud.dev/postgres/gcppostgres        0.822s
ok      gocloud.dev/pubsub      (cached)
ok      gocloud.dev/pubsub/awssnssqs    (cached)
ok      gocloud.dev/pubsub/azuresb      (cached)
ok      gocloud.dev/pubsub/batcher      (cached)
?       gocloud.dev/pubsub/driver       [no test files]
?       gocloud.dev/pubsub/drivertest   [no test files]
ok      gocloud.dev/pubsub/gcppubsub    (cached)
ok      gocloud.dev/pubsub/mempubsub    (cached)
ok      gocloud.dev/runtimevar  (cached)
ok      gocloud.dev/runtimevar/awsparamstore    (cached)
ok      gocloud.dev/runtimevar/awssecretsmanager        (cached)
ok      gocloud.dev/runtimevar/blobvar  (cached)
ok      gocloud.dev/runtimevar/constantvar      (cached)
?       gocloud.dev/runtimevar/driver   [no test files]
?       gocloud.dev/runtimevar/drivertest       [no test files]
ok      gocloud.dev/runtimevar/filevar  (cached)
ok      gocloud.dev/runtimevar/gcpruntimeconfig (cached)
ok      gocloud.dev/runtimevar/gcpsecretmanager (cached)
ok      gocloud.dev/runtimevar/httpvar  (cached)
ok      gocloud.dev/secrets     (cached)
ok      gocloud.dev/secrets/awskms      (cached)
ok      gocloud.dev/secrets/azurekeyvault       (cached)
?       gocloud.dev/secrets/driver      [no test files]
?       gocloud.dev/secrets/drivertest  [no test files]
ok      gocloud.dev/secrets/gcpkms      (cached)
ok      gocloud.dev/secrets/localsecrets        (cached)
ok      gocloud.dev/server      (cached)
?       gocloud.dev/server/driver       [no test files]
ok      gocloud.dev/server/health       (cached)
ok      gocloud.dev/server/health/sqlhealth     (cached)
ok      gocloud.dev/server/requestlog   (cached)
?       gocloud.dev/server/sdserver     [no test files]
?       gocloud.dev/server/xrayserver   [no test files]
```