### PR TITLE
Set SigningRegion when using custom endpoint url

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -177,6 +177,7 @@ func NewDefaultV2Config(ctx context.Context) (awsv2.Config, error) {
 // The following query options are supported:
 //   - region: The AWS region for requests; sets WithRegion.
 //   - profile: The shared config profile to use; sets SharedConfigProfile.
+//   - endpoint: The AWS service endpoint to send HTTP request.
 func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, error) {
 	var opts []func(*awsv2cfg.LoadOptions) error
 	for param, values := range q {
@@ -188,8 +189,9 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 			customResolver := awsv2.EndpointResolverWithOptionsFunc(
 				func(service, region string, options ...interface{}) (awsv2.Endpoint, error) {
 					return awsv2.Endpoint{
-						PartitionID: "aws",
-						URL:         value,
+						PartitionID:   "aws",
+						URL:           value,
+						SigningRegion: region,
 					}, nil
 				})
 			opts = append(opts, awsv2cfg.WithEndpointResolverWithOptions(customResolver))


### PR DESCRIPTION
make sure to set `SigningRegion` while using custom endpoints for aws sdk v2 

fixes: #3218 
