### PR TITLE
blob/s3blob - fix: S3 upload with io.Multireader fail on exceeded total allowed configured MaxUploadParts

### DIFF
--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -61,6 +61,9 @@ type WriterOptions struct {
 	// write in a single request, if supported. Larger objects will be split into
 	// multiple requests.
 	BufferSize int
+	// MaxUploadParts specifies the maximum number of uploaded parts.
+	// No all drivers set this value. Default S3 value is 10_000.
+	MaxUploadParts int
 	// MaxConcurrency changes the default concurrency for uploading parts.
 	MaxConcurrency int
 	// CacheControl specifies caching attributes that services may use

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -926,6 +926,9 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key string, contentType str
 			if opts.MaxConcurrency != 0 {
 				u.Concurrency = opts.MaxConcurrency
 			}
+			if opts.MaxUploadParts != 0 {
+				u.MaxUploadParts = int32(opts.MaxUploadParts)
+			}
 		})
 		md := make(map[string]string, len(opts.Metadata))
 		for k, v := range opts.Metadata {


### PR DESCRIPTION
== Description

S3 set a maximum number of 10K upload parts, setting a maximum file size of `BufferSize` * 10K, which, by default, is 10K *5MiB ~= 50GiB. 

Reported error
```
MultipartUpload: upload multipart failed
	upload id: XXXX
caused by: TotalPartsExceeded: exceeded total allowed configured MaxUploadParts (10000). Adjust PartSize to fit in this limit
```

**Proposed Change**
* New writer option: `MaxUploadParts` specifying the maximum number of uploaded parts.


== References
https://github.com/aws/aws-sdk-go/issues/2557


