### PR TITLE
blob: add Bucket.{Upload,Download} APIs

### DIFF
--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -226,6 +226,33 @@ type ListPage struct {
 	NextPageToken []byte
 }
 
+// Uploader is an optional interface that Bucket implementations may also implement.
+// If the underlying service can upload complete objects more efficiently than it can
+// implement TypedWriter, its Bucket implementation should implement Upload.
+type Uploader interface {
+	// Upload writes data from r to an object associated with key.
+	//
+	// A new object will be created unless an object with this key already exists.
+	// Otherwise any previous object with the same key will be replaced.
+	//
+	// contentType sets the MIME type of the object to be written. It must not be
+	// empty. opts is guaranteed to be non-nil.
+	Upload(ctx context.Context, key, contentType string, r io.Reader, opts *WriterOptions) error
+}
+
+// Downloader is an optional interface that Bucket implementations may also implement.
+// If the underlying service can upload complete objects more efficiently than it can
+// implement Downloader, its Bucket implementation should implement Download.
+type Downloader interface {
+	// DownloadRange copies part of an object to w, reading at most length bytes
+	// starting at the given offset. If length is negative, it will read until
+	// the end of the object. If the specified object does not exist,
+	// DownloadRange must return an error for which ErrorCode returns
+	// gcerrors.NotFound.
+	// opts is guaranteed to be non-nil.
+	DownloadRange(ctx context.Context, w io.Writer, key string, offset, length int64, opts *ReaderOptions) error
+}
+
 // Bucket provides read, write and delete operations on objects within it on the
 // blob service.
 type Bucket interface {


### PR DESCRIPTION
Add Upload and Download methods to blob.Bucket and optional Uploader and Downloader interfaces to driver. If a driver.Bucket implements those interfaces, Upload and Download will call through those interfaces. This allows backends that can implement pull-style uploads and push-style downloads more efficiently than push-style uploads and pull-style downloads to do so.

These changes include an implementation of driver.Uploader for s3blob.Bucket. That implementation allows s3blob.Bucket to avoid allocating temporary buffers if the input is an io.ReaderAt and an io.Seeker. This can dramatically reduce allocation volume for services that upload large amounts of data to S3.

Fixes #3245
Fixes #2807