### PR TITLE
internal/website: fix the s3 'awssdk' argument examples

### DIFF
--- a/blob/s3blob/example_test.go
+++ b/blob/s3blob/example_test.go
@@ -84,7 +84,7 @@ func Example_openBucketFromURL() {
 	defer bucket.Close()
 
 	// Forcing AWS SDK V2.
-	bucket, err = blob.OpenBucket(ctx, "s3://my-bucket?region=us-west-1&awssdk=2")
+	bucket, err = blob.OpenBucket(ctx, "s3://my-bucket?region=us-west-1&awssdk=v2")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -465,7 +465,7 @@ func TestOpenBucketFromURL(t *testing.T) {
 		// OK, setting both profile and region.
 		{"s3://mybucket?profile=main&region=us-west-1", false},
 		// OK, use V2.
-		{"s3://mybucket?awssdk=2", false},
+		{"s3://mybucket?awssdk=v2", false},
 		// Invalid parameter together with a valid one.
 		{"s3://mybucket?profile=main&param=value", true},
 		// Invalid parameter.

--- a/internal/website/data/examples.json
+++ b/internal/website/data/examples.json
@@ -69,7 +69,7 @@
 	},
 	"gocloud.dev/blob/s3blob.Example_openBucketFromURL": {
 		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/blob\"\n\t_ \"gocloud.dev/blob/s3blob\"\n)",
-		"code": "// blob.OpenBucket creates a *blob.Bucket from a URL.\nbucket, err := blob.OpenBucket(ctx, \"s3://my-bucket?region=us-west-1\")\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()\n\n// Forcing AWS SDK V2.\nbucket, err = blob.OpenBucket(ctx, \"s3://my-bucket?region=us-west-1\u0026awssdk=2\")\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()"
+		"code": "// blob.OpenBucket creates a *blob.Bucket from a URL.\nbucket, err := blob.OpenBucket(ctx, \"s3://my-bucket?region=us-west-1\")\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()\n\n// Forcing AWS SDK V2.\nbucket, err = blob.OpenBucket(ctx, \"s3://my-bucket?region=us-west-1\u0026awssdk=v2\")\nif err != nil {\n\treturn err\n}\ndefer bucket.Close()"
 	},
 	"gocloud.dev/docstore.ExampleCollection_Actions_bulkWrite": {
 		"imports": "import (\n\t\"context\"\n\n\t\"gocloud.dev/docstore\"\n)",


### PR DESCRIPTION
The actual values that [are supported](https://github.com/google/go-cloud/blob/master/aws/aws.go#L155) for the `awssdk` argument for s3 are `v2` and `V2`.