### PR TITLE
blob: pass through reader/writer to `WriteTo`/`ReadFrom` if available

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -233,6 +233,12 @@ func (r *Reader) As(i interface{}) bool {
 //
 // It implements the io.WriterTo interface.
 func (r *Reader) WriteTo(w io.Writer) (int64, error) {
+	// If the writer has a ReaderFrom method, use it to do the copy.
+	// Avoids an allocation and a copy.
+	if rt, ok := w.(io.ReaderFrom); ok {
+		return rt.ReadFrom(r)
+	}
+
 	_, nw, err := readFromWriteTo(r, w)
 	return nw, err
 }
@@ -476,6 +482,12 @@ func (w *Writer) write(p []byte) (int, error) {
 //
 // It implements the io.ReaderFrom interface.
 func (w *Writer) ReadFrom(r io.Reader) (int64, error) {
+	// If the reader has a WriteTo method, use it to do the copy.
+	// Avoids an allocation and a copy.
+	if wt, ok := r.(io.WriterTo); ok {
+		return wt.WriteTo(w)
+	}
+
 	nr, _, err := readFromWriteTo(r, w)
 	return nr, err
 }


### PR DESCRIPTION
The blob `Reader` and `Writer` implement `WriterTo` and `ReaderFrom`, respectively, which is meant to avoid intermediary allocations and copies (passing readers and readers through all the way down). Unfortunately, the current implementation falls short and implements those interfaces by making a local copy ala io.Copy.

Instead, reproduce the strategy in newer versions of `io.Copy`: reflect on the reader/writer provided by the user, and if they implement these interface, too, then call into that.

Local benchmarks show significant performance improvements:

```
                         │   /tmp/old   │              /tmp/new               │
                         │    sec/op    │   sec/op     vs base                │
Memblob/BenchmarkRead-10   3.449µ ± 15%   1.919µ ± 2%  -44.37% (p=0.000 n=10)
```

Most benchmarks use `ReadAll` and `WriteAll`, which use slices directly and don't benefit from this change. I modified the `BenchmarkRead` to use a `bytes.Buffer` and a call to `io.Copy` to exercise the `WriteTo` path. I believe we should change the remaining benchmarks to do the same. I don't think `ReadAll`/`WriteAll` represent how most real-world applications interact with the library (piping readers/writer instead, but that assumption may be wrong!)

> The benchmark comparison above is fair; only the call to `WriteTo` was removed