### PR TITLE
aws/rds: Switch AWS RDS CA bundle to the officially documented URL

### DIFF
--- a/aws/rds/rds.go
+++ b/aws/rds/rds.go
@@ -41,7 +41,7 @@ type CertPoolProvider interface {
 }
 
 // caBundleURL is the URL to the public RDS Certificate Authority keys.
-const caBundleURL = "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem"
+const caBundleURL = "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
 
 // CertFetcher pulls the RDS CA certificates from Amazon's servers. The zero
 // value will fetch certificates using the default HTTP client.


### PR DESCRIPTION
Hi folks !

AWS recently started sending out emails about the expiration of the `rds-ca-2019` CA (expires in 2024), suggesting we upgrade our instance to `rds-ca-rsa2048-g1`, `rds-ca-rsa4096-g1`, or `rds-ca-ecc384-g1`.

The corresponding documentation is [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html), and includes instructions as to client configuration and where to retrieve CA information.

I'm assuming the URL used here is a former address, and that AWS has since then changed the address of the reference CA bundle, without updating the bundle at the former address.

## Reproduction

Creating RDS instances with both `rds-ca-2019` and `rds-ca-ecc384-g1`, I can confirm that the new bundle works with both, while the old one only works with `rds-ca-2019`. I have not, however, explicitly listed each certificate in the old bundle to see if it's present in the new one. We can double-check before merging if you wish so, I'm however assuming AWS would not remove still-valid CAs from its bundle.

I'm not using go-cloud directly however, only indirectly through https://github.com/cyrilgdn/terraform-provider-postgresql, so, I haven't been able to test this change directly.
However, using psql with `sslrootcert` should be a good indicator that the issue is in fact here.