### PR TITLE
blob/s3blob: Support S3 server side encryption headers for Write and Copy

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -103,6 +103,8 @@ func ConfigFromURLParams(q url.Values) (*aws.Config, error) {
 			}
 			cfg.S3ForcePathStyle = aws.Bool(b)
 		case "awssdk":
+		case "ssetype":
+		case "kmskeyid":
 			// ignore, should be handled before this
 		default:
 			return nil, fmt.Errorf("unknown query parameter %q", param)
@@ -198,6 +200,8 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 		case "profile":
 			opts = append(opts, awsv2cfg.WithSharedConfigProfile(value))
 		case "awssdk":
+		case "ssetype":
+		case "kmskeyid":
 			// ignore, should be handled before this
 		default:
 			return awsv2.Config{}, fmt.Errorf("unknown query parameter %q", param)

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -103,8 +103,6 @@ func ConfigFromURLParams(q url.Values) (*aws.Config, error) {
 			}
 			cfg.S3ForcePathStyle = aws.Bool(b)
 		case "awssdk":
-		case "ssetype":
-		case "kmskeyid":
 			// ignore, should be handled before this
 		default:
 			return nil, fmt.Errorf("unknown query parameter %q", param)
@@ -200,8 +198,6 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 		case "profile":
 			opts = append(opts, awsv2cfg.WithSharedConfigProfile(value))
 		case "awssdk":
-		case "ssetype":
-		case "kmskeyid":
 			// ignore, should be handled before this
 		default:
 			return awsv2.Config{}, fmt.Errorf("unknown query parameter %q", param)

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -154,7 +154,7 @@ func (o *URLOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.Bucket
 		clientV2 := s3v2.NewFromConfig(cfg)
 
 		o.Options.EncryptionType = u.Query().Get("ssetype")
-		o.Options.KMSEncryptionId = u.Query().Get("kmskeyid")
+		o.Options.KMSEncryptionID = u.Query().Get("kmskeyid")
 
 		return OpenBucketV2(ctx, clientV2, u.Host, &o.Options)
 	}
@@ -168,7 +168,7 @@ func (o *URLOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.Bucket
 	configProvider.Configs = append(configProvider.Configs, overrideCfg)
 
 	o.Options.EncryptionType = u.Query().Get("ssetype")
-	o.Options.KMSEncryptionId = u.Query().Get("kmskeyid")
+	o.Options.KMSEncryptionID = u.Query().Get("kmskeyid")
 
 	return OpenBucket(ctx, configProvider, u.Host, &o.Options)
 }
@@ -180,9 +180,15 @@ type Options struct {
 	// ListObjectsV2.
 	UseLegacyList bool
 
+	// EncryptionType sets the encryption type headers when making write or
+	// copy calls. This is required if the bucket has a restrictive bucket
+	// policy that enforces a specific encryption type
 	EncryptionType string
 
-	KMSEncryptionId string
+	// KMSEncryptionID sets the kms key id header for write or copy calls.
+	// This is required when a bucket policy enforces the use of a specific
+	// KMS key for uploads
+	KMSEncryptionID string
 }
 
 // openBucket returns an S3 Bucket.
@@ -210,7 +216,7 @@ func openBucket(ctx context.Context, useV2 bool, sess client.ConfigProvider, cli
 		client:         client,
 		clientV2:       clientV2,
 		useLegacyList:  opts.UseLegacyList,
-		kmsKeyId:       opts.KMSEncryptionId,
+		kmsKeyId:       opts.KMSEncryptionID,
 		encryptionType: opts.EncryptionType,
 	}, nil
 }

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -144,8 +144,8 @@ type URLOpener struct {
 }
 
 const (
-	SSETypeParamKey  = "ssetype"
-	KMSKeyIdParamKey = "kmskeyid"
+	sseTypeParamKey  = "ssetype"
+	kmsKeyIdParamKey = "kmskeyid"
 )
 
 func IsValidServerSideEncryptionType(value string) bool {
@@ -162,8 +162,8 @@ func IsValidServerSideEncryptionType(value string) bool {
 func (o *URLOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.Bucket, error) {
 	q := u.Query()
 
-	if sseType := q.Get(SSETypeParamKey); sseType != "" {
-		q.Del(SSETypeParamKey)
+	if sseType := q.Get(sseTypeParamKey); sseType != "" {
+		q.Del(sseTypeParamKey)
 
 		if !IsValidServerSideEncryptionType(sseType) {
 			return nil, fmt.Errorf("ssetype invalid %v", sseType)
@@ -172,8 +172,8 @@ func (o *URLOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.Bucket
 		o.Options.EncryptionType = typesv2.ServerSideEncryption(sseType)
 	}
 
-	if kmsKeyID := u.Query().Get(KMSKeyIdParamKey); kmsKeyID != "" {
-		q.Del(KMSKeyIdParamKey)
+	if kmsKeyID := u.Query().Get(kmsKeyIdParamKey); kmsKeyID != "" {
+		q.Del(kmsKeyIdParamKey)
 		o.Options.KMSEncryptionID = kmsKeyID
 	}
 

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -173,7 +173,7 @@ func (o *URLOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.Bucket
 		o.Options.EncryptionType = sseType
 	}
 
-	if kmsKeyID := u.Query().Get(kmsKeyIdParamKey); kmsKeyID != "" {
+	if kmsKeyID := q.Get(kmsKeyIdParamKey); kmsKeyID != "" {
 		q.Del(kmsKeyIdParamKey)
 		o.Options.KMSEncryptionID = kmsKeyID
 	}

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -466,6 +466,8 @@ func TestOpenBucketFromURL(t *testing.T) {
 		{"s3://mybucket?profile=main&region=us-west-1", false},
 		// OK, use V2.
 		{"s3://mybucket?awssdk=v2", false},
+		// OK, use KMS Server Side Encryption
+		{"s3://mybucket?ssetype=aws:kms&kmskeyid=arn:aws:us-east-1:12345:key/1-a-2-b", false},
 		// Invalid parameter together with a valid one.
 		{"s3://mybucket?profile=main&param=value", true},
 		// Invalid parameter.

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -487,3 +487,32 @@ func TestOpenBucketFromURL(t *testing.T) {
 		}
 	}
 }
+
+func TestToServerSideEncryptionType(t *testing.T) {
+	tests := []struct {
+		value         string
+		sseType       typesv2.ServerSideEncryption
+		expectedError error
+	}{
+		// OK.
+		{"AES256", typesv2.ServerSideEncryptionAes256, nil},
+		// OK, KMS
+		{"aws:kms", typesv2.ServerSideEncryptionAwsKms, nil},
+		// OK, KMS
+		{"aws:kms:dsse", typesv2.ServerSideEncryptionAwsKmsDsse, nil},
+		// OK, AES256 mixed case
+		{"Aes256", typesv2.ServerSideEncryptionAes256, nil},
+		// Invalid SSE type
+		{"invalid", "", fmt.Errorf("'invalid' is not a valid value for '%s'", sseTypeParamKey)},
+	}
+
+	for _, test := range tests {
+		sseType, err := toServerSideEncryptionType(test.value)
+		if ((err != nil) != (test.expectedError != nil)) && err.Error() != test.expectedError.Error() {
+			t.Errorf("%s: got error \"%v\", want error \"%v\"", test.value, err, test.expectedError)
+		}
+		if sseType != test.sseType {
+			t.Errorf("%s: got type %v, want type %v", test.value, sseType, test.sseType)
+		}
+	}
+}

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -468,6 +468,8 @@ func TestOpenBucketFromURL(t *testing.T) {
 		{"s3://mybucket?awssdk=v2", false},
 		// OK, use KMS Server Side Encryption
 		{"s3://mybucket?ssetype=aws:kms&kmskeyid=arn:aws:us-east-1:12345:key/1-a-2-b", false},
+		// Invalid ssetype
+		{"s3://mybucket?ssetype=aws:notkmsoraes&kmskeyid=arn:aws:us-east-1:12345:key/1-a-2-b", true},
 		// Invalid parameter together with a valid one.
 		{"s3://mybucket?profile=main&param=value", true},
 		// Invalid parameter.


### PR DESCRIPTION
Adds support to s3blob for setting AWS S3 server side encryption headers when making requests that require such headers. The additional settings can be specified with the `ssetype` and `kmskeyid` URL params, similar to the other configuration settings

Fixes #3337

### Local testing
#### SDKv2
Bucket policy enforces KMS headers - none provided (effectively the issue described in #3337)
Expect: `AccessDenied` failure
![image](https://github.com/google/go-cloud/assets/28725980/efbc5ab2-8c16-48fe-9678-bb6dd705d838)

Bucket policy enforces KMS headers - values provided
Expect: No errors. Object is uploaded
![image](https://github.com/google/go-cloud/assets/28725980/89ecce69-f59a-406d-b081-503478a57a73)

Bucket policy doesn't enforce KMS - no values provided 
Expect: No errors. Object is uploaded
![image](https://github.com/google/go-cloud/assets/28725980/3d687062-a386-496c-8192-2641292aa9a9)

#### SDKv1
Bucket policy enforces KMS headers - none provided (effectively the issue described in #3337)
Expect: `AccessDenied` failure
![image](https://github.com/google/go-cloud/assets/28725980/159dc82d-3960-4383-bcd5-e3b279de2e92)


Bucket policy enforces KMS headers - values provided
Expect: No errors. Object is uploaded
![image](https://github.com/google/go-cloud/assets/28725980/66a662fd-e82a-4e83-a664-f393bf2bbf81)


Bucket policy doesn't enforce KMS - no values provided 
Expect: No errors. Object is uploaded
![image](https://github.com/google/go-cloud/assets/28725980/41006020-3f5d-45af-871a-5c70e99fa6ad)
