### PR TITLE
docstore/gcpfilestore: add support for non-default databases.

### DIFF
--- a/docstore/gcpfirestore/fs.go
+++ b/docstore/gcpfirestore/fs.go
@@ -149,6 +149,10 @@ func CollectionResourceID(projectID, collPath string) string {
 	return fmt.Sprintf("projects/%s/databases/(default)/documents/%s", projectID, collPath)
 }
 
+func CollectionResourceIDWithDatabase(projectID, databaseID, collPath string) string {
+	return fmt.Sprintf("projects/%s/databases/%s/documents/%s", projectID, databaseID, collPath)
+}
+
 // OpenCollection creates a *docstore.Collection representing a Firestore collection.
 //
 // collResourceID must be of the form "project/<projectID>/databases/(default)/documents/<collPath>".
@@ -193,7 +197,7 @@ func OpenCollectionWithNameFunc(client *vkit.Client, collResourceID string, name
 	return docstore.NewCollection(c), nil
 }
 
-var resourceIDRE = regexp.MustCompile(`^(projects/[^/]+/databases/\(default\))/documents/.+`)
+var resourceIDRE = regexp.MustCompile(`^(projects/[^/]+/databases/[^/]+)/documents/.+`)
 
 func newCollection(client *vkit.Client, collResourceID, nameField string, nameFunc func(docstore.Document) string, opts *Options) (*collection, error) {
 	if nameField == "" && nameFunc == nil {

--- a/docstore/gcpfirestore/fs.go
+++ b/docstore/gcpfirestore/fs.go
@@ -149,6 +149,8 @@ func CollectionResourceID(projectID, collPath string) string {
 	return fmt.Sprintf("projects/%s/databases/(default)/documents/%s", projectID, collPath)
 }
 
+// CollectResoureceIDWithDatabase constructs a resource ID for a collection from the project ID, database ID, and the collection path.
+// See the OpenCollection example for use.
 func CollectionResourceIDWithDatabase(projectID, databaseID, collPath string) string {
 	return fmt.Sprintf("projects/%s/databases/%s/documents/%s", projectID, databaseID, collPath)
 }

--- a/docstore/gcpfirestore/fs_test.go
+++ b/docstore/gcpfirestore/fs_test.go
@@ -194,7 +194,6 @@ func TestResourceIDRegexp(t *testing.T) {
 		"Projects/P/databases/(default)/documents/C",
 		"P/databases/(default)/documents/C",
 		"projects/P/Q/databases/(default)/documents/C",
-		"projects/P/databases/mydb/documents/C",
 		"projects/P/databases/(default)/C",
 		"projects/P/databases/(default)/documents/",
 		"projects/P/databases/(default)",

--- a/docstore/gcpfirestore/fs_test.go
+++ b/docstore/gcpfirestore/fs_test.go
@@ -183,6 +183,7 @@ func TestResourceIDRegexp(t *testing.T) {
 	for _, good := range []string{
 		"projects/abc-_.309/databases/(default)/documents/C",
 		"projects/P/databases/(default)/documents/C/D/E",
+		"projects/P/databases/mydb/documents/E/F/G",
 	} {
 		if !resourceIDRE.MatchString(good) {
 			t.Errorf("%q did not match but should have", good)


### PR DESCRIPTION
Fixes: https://github.com/google/go-cloud/issues/3339

This edits the regex to allow non-default database names when creating Firestore collections.

In line with prior art, this also creates a helper function to assist with creating a valid scheme.