### PR TITLE
feat/docstore in query operation

### DIFF
--- a/docstore/drivertest/drivertest.go
+++ b/docstore/drivertest/drivertest.go
@@ -1424,6 +1424,16 @@ func testGetQuery(t *testing.T, _ Harness, coll *docstore.Collection) {
 			want: func(h *HighScore) bool { return h.Score >= 50 && h.Time.After(date(4, 1)) },
 		},
 		{
+			name: "PlayerIn",
+			q:    coll.Query().Where("Player", "in", []string{"pat", "billie"}),
+			want: func(h *HighScore) bool { return h.Player == "pat" || h.Player == "billie" },
+		},
+		{
+			name: "PlayerNotIn",
+			q:    coll.Query().Where("Player", "not-in", []string{"pat", "billie"}),
+			want: func(h *HighScore) bool { return h.Player != "pat" && h.Player != "billie" },
+		},
+		{
 			name:   "AllByPlayerAsc",
 			q:      coll.Query().OrderBy("Player", docstore.Ascending),
 			want:   func(h *HighScore) bool { return true },

--- a/docstore/gcpfirestore/query.go
+++ b/docstore/gcpfirestore/query.go
@@ -293,8 +293,7 @@ func (c *collection) filterToProto(f driver.Filter) (*pb.StructuredQuery_Filter,
 			FilterType: &pb.StructuredQuery_Filter_UnaryFilter{
 				UnaryFilter: &pb.StructuredQuery_UnaryFilter{
 					OperandType: &pb.StructuredQuery_UnaryFilter_Field{
-						Field: fieldRef(f.FieldPath),
-					},
+						Field: fieldRef(f.FieldPath)},
 					Op: uop,
 				},
 			},
@@ -346,6 +345,10 @@ func newFieldFilter(fp []string, op string, val *pb.Value) (*pb.StructuredQuery_
 		fop = pb.StructuredQuery_FieldFilter_GREATER_THAN_OR_EQUAL
 	case driver.EqualOp:
 		fop = pb.StructuredQuery_FieldFilter_EQUAL
+	case "in":
+		fop = pb.StructuredQuery_FieldFilter_IN
+	case "not-in":
+		fop = pb.StructuredQuery_FieldFilter_NOT_IN
 	// TODO(jba): can we support array-contains portably?
 	// case "array-contains":
 	// 	fop = pb.StructuredQuery_FieldFilter_ARRAY_CONTAINS

--- a/docstore/memdocstore/query.go
+++ b/docstore/memdocstore/query.go
@@ -86,7 +86,7 @@ func filterMatches(f driver.Filter, doc storedDoc) bool {
 	return applyComparison(f.Op, c)
 }
 
-// op is one of the five permitted docstore operators ("=", "<", etc.)
+// op is one of the permitted docstore operators ("=", "<", etc.)
 // c is the result of strings.Compare or the like.
 // TODO(jba): dedup from gcpfirestore/query?
 func applyComparison(op string, c int) bool {
@@ -101,6 +101,10 @@ func applyComparison(op string, c int) bool {
 		return c >= 0
 	case "<=":
 		return c <= 0
+	case "in":
+		return c == 0
+	case "not-in":
+		return c != 0
 	default:
 		panic("bad op")
 	}
@@ -109,6 +113,18 @@ func applyComparison(op string, c int) bool {
 func compare(x1, x2 interface{}) (int, bool) {
 	v1 := reflect.ValueOf(x1)
 	v2 := reflect.ValueOf(x2)
+	// this is for in/not-in queries.
+	// return 0 if x1 is in slice x2, -1 if not.
+	if v2.Kind() == reflect.Slice {
+		for i := 0; i < v2.Len(); i++ {
+			if c, ok := compare(x1, v2.Index(i).Interface()); ok {
+				if c == 0 {
+					return 0, true
+				}
+			}
+		}
+		return -1, true
+	}
 	if v1.Kind() == reflect.String && v2.Kind() == reflect.String {
 		return strings.Compare(v1.String(), v2.String()), true
 	}

--- a/docstore/memdocstore/query.go
+++ b/docstore/memdocstore/query.go
@@ -118,6 +118,9 @@ func compare(x1, x2 interface{}) (int, bool) {
 	if v2.Kind() == reflect.Slice {
 		for i := 0; i < v2.Len(); i++ {
 			if c, ok := compare(x1, v2.Index(i).Interface()); ok {
+				if !ok {
+					return 0, false
+				}
 				if c == 0 {
 					return 0, true
 				}

--- a/docstore/mongodocstore/mongo_test.go
+++ b/docstore/mongodocstore/mongo_test.go
@@ -301,4 +301,23 @@ func TestLowercaseFields(t *testing.T) {
 	var got6 S
 	must(coll.Query().OrderBy("G", docstore.Descending).Get(ctx).Next(ctx, &got6))
 	check(got6, *sdoc2)
+
+	// List queries
+	// select F from coll WHERE G IN (50, 51) ORDER BY G DESC
+	// test that F is 99
+	sdoc3 := &S{ID: 3, F: 99, G: 50}
+	sdoc4 := &S{ID: 4, F: 99, G: 51}
+	must(coll.Put(ctx, sdoc3))
+	must(coll.Put(ctx, sdoc4))
+	var got7, got8 S
+	iter := coll.Query().Where("G", "in", []int{50, 51}).OrderBy("G", docstore.Descending).Get(ctx)
+	must(iter.Next(ctx, &got7))
+	must(iter.Next(ctx, &got8))
+	check(got7, *sdoc4)
+	check(got8, *sdoc3)
+
+	// same query with not-in, expect to get sdoc2 back even though G is higher for sdoc3 and sdoc4
+	var got9 S
+	must(coll.Query().Where("G", "not-in", []int{50, 51}).OrderBy("G", docstore.Descending).Get(ctx).Next(ctx, &got9))
+	check(got9, *sdoc2)
 }

--- a/docstore/mongodocstore/query.go
+++ b/docstore/mongodocstore/query.go
@@ -75,6 +75,8 @@ var mongoQueryOps = map[string]string{
 	">=":           "$gte",
 	"<":            "$lt",
 	"<=":           "$lte",
+	"in":           "$in",
+	"not-in":       "$nin",
 }
 
 // filtersToBSON converts a []driver.Filter to the MongoDB equivalent, expressed

--- a/docstore/query.go
+++ b/docstore/query.go
@@ -37,7 +37,7 @@ func (c *Collection) Query() *Query {
 }
 
 // Where expresses a condition on the query.
-// Valid ops are: "=", ">", "<", ">=", "<=".
+// Valid ops are: "=", ">", "<", ">=", "<=, "in", "not-in".
 // Valid values are strings, integers, floating-point numbers, and time.Time values.
 func (q *Query) Where(fp FieldPath, op string, value interface{}) *Query {
 	if q.err != nil {
@@ -49,7 +49,7 @@ func (q *Query) Where(fp FieldPath, op string, value interface{}) *Query {
 		return q
 	}
 	if !validOp[op] {
-		return q.invalidf("invalid filter operator: %q. Use one of: =, >, <, >=, <=", op)
+		return q.invalidf("invalid filter operator: %q. Use one of: =, >, <, >=, <=, in, not-in", op)
 	}
 	if !validFilterValue(value) {
 		return q.invalidf("invalid filter value: %v", value)
@@ -63,11 +63,13 @@ func (q *Query) Where(fp FieldPath, op string, value interface{}) *Query {
 }
 
 var validOp = map[string]bool{
-	"=":  true,
-	">":  true,
-	"<":  true,
-	">=": true,
-	"<=": true,
+	"=":      true,
+	">":      true,
+	"<":      true,
+	">=":     true,
+	"<=":     true,
+	"in":     true,
+	"not-in": true,
 }
 
 func validFilterValue(v interface{}) bool {
@@ -86,6 +88,9 @@ func validFilterValue(v interface{}) bool {
 		return true
 	case reflect.Float32, reflect.Float64:
 		return true
+	// TODO: Properly validate slice values and the in/not-in operators.
+	case reflect.Slice:
+		return true
 	default:
 		return false
 	}
@@ -100,7 +105,7 @@ func (q *Query) Limit(n int) *Query {
 		return q
 	}
 	if n <= 0 {
-		return q.invalidf("limit value of %d must be greater than zero", n)
+		return q.invalidf("limit value of % must be greater than zero", n)
 	}
 	if q.dq.Limit > 0 {
 		return q.invalidf("query can have at most one limit clause")

--- a/docstore/query.go
+++ b/docstore/query.go
@@ -118,7 +118,7 @@ func (q *Query) Limit(n int) *Query {
 		return q
 	}
 	if n <= 0 {
-		return q.invalidf("limit value of % must be greater than zero", n)
+		return q.invalidf("limit value of %d must be greater than zero", n)
 	}
 	if q.dq.Limit > 0 {
 		return q.invalidf("query can have at most one limit clause")


### PR DESCRIPTION

fixes: https://github.com/google/go-cloud/issues/3352

This PR updates the docstore to allow in/not-in queries.

This isn't yet merge-able, I need some assistance to get this into shape.

Test replay data does not exist for this type of query, so tests that rely on that don't work currently. Am I able to generate those myself somehow?

I haven't tested the dynamodb changes at all.

I updated the local mongodb test, but haven't tried this against cosmo.

I tested firstore functionality with this snipit, and it seems to function, but the real tests continue to fail due to the missing replays. https://gist.github.com/coryschwartz/80c37f15f58ddf0d8c979073f30d6ccf

