### PR TITLE
pubsub/azuresb: new auth method  to support Service principal/kubelet identity/Workload identity auth methods

### DIFF
--- a/pubsub/azuresb/azuresb.go
+++ b/pubsub/azuresb/azuresb.go
@@ -21,7 +21,7 @@
 // For pubsub.OpenTopic and pubsub.OpenSubscription, azuresb registers
 // for the scheme "azuresb".
 // The default URL opener will use a Service Bus Connection String based on
-// AZURE_SERVICEBUS_HOSTNAME or SERVICEBUS_CONNECTION_STRING environment variables. SERVICEBUS_CONNECTION_STRING takes presendence.
+// AZURE_SERVICEBUS_HOSTNAME or SERVICEBUS_CONNECTION_STRING environment variables. SERVICEBUS_CONNECTION_STRING takes precedence.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
 // See https://gocloud.dev/concepts/urls/ for background information.
@@ -101,7 +101,7 @@ func init() {
 
 // defaultURLOpener creates an URLOpener with ConnectionString initialized from
 // AZURE_SERVICEBUS_HOSTNAME or SERVICEBUS_CONNECTION_STRING environment variables.
-// SERVICEBUS_CONNECTION_STRING takes presendence.
+// SERVICEBUS_CONNECTION_STRING takes precedence.
 type defaultOpener struct {
 	init   sync.Once
 	opener *URLOpener

--- a/pubsub/azuresb/azuresb.go
+++ b/pubsub/azuresb/azuresb.go
@@ -21,7 +21,7 @@
 // For pubsub.OpenTopic and pubsub.OpenSubscription, azuresb registers
 // for the scheme "azuresb".
 // The default URL opener will use a Service Bus Connection String based on
-// the environment variable "SERVICEBUS_CONNECTION_STRING".
+// AZURE_SERVICEBUS_HOSTNAME or SERVICEBUS_CONNECTION_STRING environment variables. SERVICEBUS_CONNECTION_STRING takes presendence.
 // To customize the URL opener, or for more details on the URL format,
 // see URLOpener.
 // See https://gocloud.dev/concepts/urls/ for background information.
@@ -65,6 +65,7 @@ import (
 	"time"
 
 	common "github.com/Azure/azure-amqp-common-go/v3"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	servicebus "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 	"github.com/Azure/go-amqp"
 	"gocloud.dev/gcerrors"
@@ -99,7 +100,8 @@ func init() {
 }
 
 // defaultURLOpener creates an URLOpener with ConnectionString initialized from
-// the environment variable SERVICEBUS_CONNECTION_STRING.
+// AZURE_SERVICEBUS_HOSTNAME or SERVICEBUS_CONNECTION_STRING environment variables.
+// SERVICEBUS_CONNECTION_STRING takes presendence.
 type defaultOpener struct {
 	init   sync.Once
 	opener *URLOpener
@@ -109,11 +111,12 @@ type defaultOpener struct {
 func (o *defaultOpener) defaultOpener() (*URLOpener, error) {
 	o.init.Do(func() {
 		cs := os.Getenv("SERVICEBUS_CONNECTION_STRING")
-		if cs == "" {
-			o.err = errors.New("SERVICEBUS_CONNECTION_STRING environment variable not set")
+		sbHostname := os.Getenv("AZURE_SERVICEBUS_HOSTNAME")
+		if cs == "" && sbHostname == "" {
+			o.err = errors.New("SERVICEBUS_CONNECTION_STRING or AZURE_SERVICEBUS_HOSTNAME environment variables not set")
 			return
 		}
-		o.opener = &URLOpener{ConnectionString: cs}
+		o.opener = &URLOpener{ConnectionString: cs, ServiceBusHostname: sbHostname}
 	})
 	return o.opener, o.err
 }
@@ -147,9 +150,13 @@ const Scheme = "azuresb"
 //
 // No other query parameters are supported.
 type URLOpener struct {
-	// ConnectionString is the Service Bus connection string (required).
+	// ConnectionString is the Service Bus connection string (required if ServiceBusHostname is not defined).
 	// https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dotnet-get-started-with-queues
 	ConnectionString string
+
+	// Azure ServiceBus hostname
+	// https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-go-how-to-use-queues?tabs=bash
+	ServiceBusHostname string
 
 	// ClientOptions are options when creating the Client.
 	ServiceBusClientOptions *servicebus.ClientOptions
@@ -165,14 +172,29 @@ type URLOpener struct {
 }
 
 func (o *URLOpener) sbClient(kind string, u *url.URL) (*servicebus.Client, error) {
-	if o.ConnectionString == "" {
-		return nil, fmt.Errorf("open %s %v: ConnectionString is required", kind, u)
+	if o.ConnectionString == "" && o.ServiceBusHostname == "" {
+		return nil, fmt.Errorf("open %s %v: ConnectionString or ServiceBusHostname is required", kind, u)
 	}
-	client, err := NewClientFromConnectionString(o.ConnectionString, o.ServiceBusClientOptions)
-	if err != nil {
-		return nil, fmt.Errorf("open %s %v: invalid connection string %q: %v", kind, u, o.ConnectionString, err)
+
+	// auth using shared key (old method)
+	// ConnectionString approach takes presendence
+	if o.ConnectionString != "" {
+		client, err := NewClientFromConnectionString(o.ConnectionString, o.ServiceBusClientOptions)
+		if err != nil {
+			return nil, fmt.Errorf("open %s %v: invalid connection string %q: %v", kind, u, o.ConnectionString, err)
+		}
+		return client, nil
 	}
-	return client, nil
+
+	// auth using Azure AAD Workload Identity/AAD Pod Identities/AKS Kubelet Identity/Service Principal
+	if o.ServiceBusHostname != "" {
+		client, err := NewClientFromServiceBusHostname(o.ServiceBusHostname, o.ServiceBusClientOptions)
+		if err != nil {
+			return nil, fmt.Errorf("open %s %v: invalid service bus hostname %q: %v", kind, u, o.ServiceBusHostname, err)
+		}
+		return client, nil
+	}
+	return nil, fmt.Errorf("open %s: please set ServiceBusHostname or ConnectionString", kind)
 }
 
 // OpenTopicURL opens a pubsub.Topic based on u.
@@ -234,10 +256,25 @@ type TopicOptions struct {
 	BatcherOptions batcher.Options
 }
 
-// NewClientFromConnectionString returns a *servicebus.Client from a Service Bus connection string.
+// NewClientFromConnectionString returns a *servicebus.Client from a Service Bus connection string.(using shared key for auth)
 // https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dotnet-get-started-with-queues
 func NewClientFromConnectionString(connectionString string, opts *servicebus.ClientOptions) (*servicebus.Client, error) {
 	return servicebus.NewClientFromConnectionString(connectionString, opts)
+}
+
+// NewClientFromConnectionString returns a *servicebus.Client from a Service Bus connection string.(using shared key for auth)
+// for example you can use workload identity autorization.
+// https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-go-how-to-use-queues?tabs=bash
+func NewClientFromServiceBusHostname(serviceBusHostname string, opts *servicebus.ClientOptions) (*servicebus.Client, error) {
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, err
+	}
+	client, err := servicebus.NewClient(serviceBusHostname, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
 }
 
 // NewSender returns a *servicebus.Sender associated with a Service Bus Client.

--- a/pubsub/azuresb/azuresb_test.go
+++ b/pubsub/azuresb/azuresb_test.go
@@ -343,9 +343,7 @@ func BenchmarkAzureServiceBusPubSub(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-	}
-
-	if sbHostname != "" {
+	} else if sbHostname != "" {
 		cred, err := azidentity.NewDefaultAzureCredential(nil)
 		if err != nil {
 			b.Fatal(err)

--- a/pubsub/azuresb/azuresb_test.go
+++ b/pubsub/azuresb/azuresb_test.go
@@ -34,6 +34,7 @@ var (
 	// See docs below on how to provision an Azure Service Bus Namespace and obtaining the connection string.
 	// https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dotnet-get-started-with-queues
 	connString = os.Getenv("SERVICEBUS_CONNECTION_STRING")
+	sbHostname = os.Getenv("AZURE_SERVICEBUS_HOSTNAME")
 )
 
 const (
@@ -56,8 +57,8 @@ type harness struct {
 }
 
 func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
-	if connString == "" {
-		return nil, fmt.Errorf("azuresb: test harness requires environment variable SERVICEBUS_CONNECTION_STRING to run")
+	if connString == "" && sbHostname == "" {
+		return nil, fmt.Errorf("azuresb: test harness requires environment variable SERVICEBUS_CONNECTION_STRING or AZURE_SERVICEBUS_HOSTNAME to run")
 	}
 	adminClient, err := admin.NewClientFromConnectionString(connString, nil)
 	if err != nil {

--- a/pubsub/azuresb/azuresb_test.go
+++ b/pubsub/azuresb/azuresb_test.go
@@ -26,6 +26,7 @@ import (
 	"gocloud.dev/pubsub/driver"
 	"gocloud.dev/pubsub/drivertest"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	servicebus "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
 )
@@ -311,6 +312,13 @@ func deleteSubscription(ctx context.Context, topicName string, subscriptionName 
 	return nil
 }
 
+// to run test using Azure Entra credentials:
+// 1. grant access to ${AZURE_CLIENT_ID} to Service Bus namespace
+// 2. run test:
+// AZURE_CLIENT_SECRET='secret' \
+// AZURE_CLIENT_ID=client_id_uud \
+// AZURE_TENANT_ID=tenant_id_uuid \
+// AZURE_SERVICEBUS_HOSTNAME=hostname go test -benchmem -run=^$ -bench ^BenchmarkAzureServiceBusPubSub$ gocloud.dev/pubsub/azuresb
 func BenchmarkAzureServiceBusPubSub(b *testing.B) {
 	const (
 		benchmarkTopicName        = "benchmark-topic"
@@ -318,16 +326,38 @@ func BenchmarkAzureServiceBusPubSub(b *testing.B) {
 	)
 	ctx := context.Background()
 
-	if connString == "" {
-		b.Fatal("azuresb: benchmark requires environment variable SERVICEBUS_CONNECTION_STRING to run")
+	var adminClient *admin.Client
+	var sbClient *servicebus.Client
+	var err error
+
+	if connString == "" && sbHostname == "" {
+		b.Fatal("azuresb: benchmark requires environment variable SERVICEBUS_CONNECTION_STRING or AZURE_SERVICEBUS_HOSTNAME to run")
 	}
-	adminClient, err := admin.NewClientFromConnectionString(connString, nil)
-	if err != nil {
-		b.Fatal(err)
+
+	if connString != "" {
+		adminClient, err = admin.NewClientFromConnectionString(connString, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		sbClient, err = NewClientFromConnectionString(connString, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
-	sbClient, err := NewClientFromConnectionString(connString, nil)
-	if err != nil {
-		b.Fatal(err)
+
+	if sbHostname != "" {
+		cred, err := azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		adminClient, err = admin.NewClient(sbHostname, cred, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		sbClient, err = NewClientFromServiceBusHostname(sbHostname, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	// Make topic.


### PR DESCRIPTION
new auth method to support Service principal/kubelet identity/Workload identity auth methods.(handled by Azure golang SDK)

How to use:
depends on method(Workload, kubelet, Service), set ENV variables:
`AZURE_SERVICEBUS_HOSTNAME` - to trigger new method

For service principal auth, set ENV variables described [here](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet)

If you use workload/kubelet identities,  ENV variables are injected by AKS, some details can be found [here](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet)

closes https://github.com/google/go-cloud/issues/3359

was able to run performance test using new auth model:
```
AZURE_CLIENT_SECRET='secret' AZURE_CLIENT_ID=2f370f8b-XXXX-4c60-b3c7-XXXXX AZURE_TENANT_ID=XXXX-a475-466f-ab08-XXXX AZURE_SERVICEBUS_HOSTNAME=xxxxxx.servicebus.windows.net /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^BenchmarkAzureServiceBusPubSub$ gocloud.dev/pubsub/azuresb

benchmark-topic
goos: darwin
goarch: arm64
pkg: gocloud.dev/pubsub/azuresb
BenchmarkAzureServiceBusPubSub/BenchmarkReceive-10         	       1	154489245124 ns/op	  64.73 MB/s	88464128 B/op	 1556345 allocs/op
--- BENCH: BenchmarkAzureServiceBusPubSub/BenchmarkReceive-10
    drivertest.go:1039: published 10000 messages
    drivertest.go:1049: MB/s is actually number of messages received per second


BenchmarkAzureServiceBusPubSub/BenchmarkSend-10            	       1	4310127584 ns/op	2320.12 MB/s	45803056 B/op	  805866 allocs/op
--- BENCH: BenchmarkAzureServiceBusPubSub/BenchmarkSend-10
    drivertest.go:1039: published 10000 messages
    drivertest.go:1049: MB/s is actually number of messages received per second
PASS
ok  	gocloud.dev/pubsub/azuresb	289.383s
```

Not sure how to test it(should be tested against Azure cloud with real credentials) 