### PR TITLE
docstore/driver: update Filter.Op comments for new in/not-in operators

### DIFF
--- a/docstore/driver/driver.go
+++ b/docstore/driver/driver.go
@@ -214,7 +214,7 @@ type Query struct {
 // TODO(#1762): support comparison of other types.
 type Filter struct {
 	FieldPath []string    // the field path to filter
-	Op        string      // the operation, supports =, >, >=, <, <=
+	Op        string      // the operation, supports `=`, `>`, `>=`, `<`, `<=`, `in`, `not-in`
 	Value     interface{} // the value to compare using the operation
 }
 


### PR DESCRIPTION
Align comments with the latest changes to docstore in v0.36.0 