### PR TITLE
fix(docstore/mongodocstore): check length of sets in newUpdateDoc function

### DIFF
--- a/docstore/mongodocstore/mongo.go
+++ b/docstore/mongodocstore/mongo.go
@@ -416,7 +416,9 @@ func (c *collection) newUpdateDoc(mods []driver.Mod, writeRevision bool) (map[st
 		rev = driver.UniqueString()
 		sets = append(sets, bson.E{Key: c.revisionField, Value: rev})
 	}
-	updateDoc["$set"] = sets
+	if len(sets) > 0 {
+		updateDoc["$set"] = sets
+	}
 	if len(unsets) > 0 {
 		updateDoc["$unset"] = unsets
 	}


### PR DESCRIPTION
This PR resolves issue [#3393](https://github.com/google/go-cloud/issues/3393). 

This update modifies the newUpdateDoc function in the docstore/mongodocstore package to check the length of the 'sets' variable before adding the '$set' field to the 'updateDoc' map. This prevents an error when calling the update function with only 'unset' or 'inc' modifiers and no 'set' modifiers.