### PR TITLE
 pubsub/rabbitpubsub: add query string set the qos prefetch count

### DIFF
--- a/pubsub/rabbitpubsub/amqp.go
+++ b/pubsub/rabbitpubsub/amqp.go
@@ -62,6 +62,7 @@ type amqpChannel interface {
 	QueueDeclareAndBind(qname, ename string) error
 	ExchangeDelete(string) error
 	QueueDelete(qname string) error
+	Qos(prefetchCount, prefetchSize int, global bool) error
 }
 
 // connection adapts an *amqp.Connection to the amqpConnection interface.
@@ -79,6 +80,7 @@ func (c *connection) Channel() (amqpChannel, error) {
 	if err := ch.Confirm(wait); err != nil {
 		return nil, err
 	}
+
 	return &channel{ch}, nil
 }
 
@@ -167,4 +169,8 @@ func (ch *channel) ExchangeDelete(name string) error {
 func (ch *channel) QueueDelete(qname string) error {
 	_, err := ch.ch.QueueDelete(qname, false, false, false)
 	return err
+}
+
+func (ch *channel) Qos(prefetchCount, prefetchSize int, global bool) error {
+	return ch.ch.Qos(prefetchCount, prefetchSize, global)
 }

--- a/pubsub/rabbitpubsub/fake_test.go
+++ b/pubsub/rabbitpubsub/fake_test.go
@@ -389,6 +389,14 @@ func (ch *fakeChannel) QueueDelete(name string) error {
 	return nil
 }
 
+func (ch *fakeChannel) Qos(_, _ int, _ bool) error {
+	if ch.isClosed() {
+		return amqp.ErrClosed
+	}
+
+	return nil
+}
+
 // Assumes nothing is ever written to the channel.
 func chanIsClosed(ch chan struct{}) bool {
 	select {

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -97,7 +97,9 @@ const Scheme = "rabbit"
 //
 // For subscriptions, the URL's host+path is used as the queue name.
 //
-// No query parameters are supported.
+// An optional query string can be used to set the Qos consumer prefetch on subscriptions
+// like "rabbit://myqueue?qos=1000" to set the consumer prefetch count to 1000
+// see also https://www.rabbitmq.com/docs/consumer-prefetch
 type URLOpener struct {
 	// Connection to use for communication with the server.
 	Connection *amqp.Connection

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -125,14 +125,13 @@ func (o *URLOpener) OpenSubscriptionURL(ctx context.Context, u *url.URL) (*pubsu
 	for param, value := range u.Query() {
 		switch param {
 		case "prefetch_count":
-			if len(value) == 0 {
+			if len(value) != 1 || len(value[0]) == 0 {
 				return nil, fmt.Errorf("open subscription %v: invalid query parameter %q", u, param)
 			}
-			count := value[0]
 
-			prefetchCount, err := strconv.Atoi(count)
+			prefetchCount, err := strconv.Atoi(value[0])
 			if err != nil {
-				return nil, fmt.Errorf("open subscription %v: invalid query parameter %q", u, count)
+				return nil, fmt.Errorf("open subscription %v: invalid query parameter %q: %w", u, param, err)
 			}
 
 			opts.PrefetchCount = &prefetchCount

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -558,6 +558,10 @@ type subscription struct {
 var nextConsumer int64 // atomic
 
 func newSubscription(conn amqpConnection, name string, opts *SubscriptionOptions) *subscription {
+	if opts == nil {
+		opts = &SubscriptionOptions{}
+	}
+
 	return &subscription{
 		conn:             conn,
 		queue:            name,
@@ -609,10 +613,6 @@ func (s *subscription) establishChannel(ctx context.Context) error {
 }
 
 func applyOptionsToChannel(opts *SubscriptionOptions, ch amqpChannel) error {
-	if opts == nil {
-		return nil
-	}
-
 	if err := ch.Qos(opts.PrefetchCount, 0, false); err != nil {
 		return fmt.Errorf("unable to set channel Qos: %w", err)
 	}

--- a/pubsub/rabbitpubsub/rabbit_test.go
+++ b/pubsub/rabbitpubsub/rabbit_test.go
@@ -427,6 +427,8 @@ func TestOpenSubscriptionFromURL(t *testing.T) {
 		{"rabbit://myqueue", true},
 		// Invalid parameter.
 		{"rabbit://myqueue?param=value", true},
+		// Invalid value for an existing parameter.
+		{"rabbit://myqueue?qos=value", true},
 	}
 
 	ctx := context.Background()
@@ -475,15 +477,15 @@ func TestOpenSubscriptionFromURLViaRealServer(t *testing.T) {
 
 			t.Cleanup(cleanupTopic)
 
-			_, cleanupSubscription, err := h.CreateSubscription(ctx, dt, t.Name())
+			ds, cleanupSubscription, err := h.CreateSubscription(ctx, dt, t.Name())
 			if err != nil {
 				t.Fatalf("unable to create subscription: %v", err)
 			}
 
 			t.Cleanup(cleanupSubscription)
 
-			exchange := dt.(*topic).exchange
-			url := fmt.Sprintf(test.URL, exchange)
+			queue := ds.(*subscription).queue
+			url := fmt.Sprintf(test.URL, queue)
 
 			sub, err := pubsub.OpenSubscription(ctx, url)
 			if (err != nil) != test.WantErr {

--- a/pubsub/rabbitpubsub/rabbit_test.go
+++ b/pubsub/rabbitpubsub/rabbit_test.go
@@ -428,7 +428,7 @@ func TestOpenSubscriptionFromURL(t *testing.T) {
 		// Invalid parameter.
 		{"rabbit://myqueue?param=value", true},
 		// Invalid value for an existing parameter.
-		{"rabbit://myqueue?qos=value", true},
+		{"rabbit://myqueue?prefetch_count=value", true},
 	}
 
 	ctx := context.Background()
@@ -452,10 +452,10 @@ func TestOpenSubscriptionFromURLViaRealServer(t *testing.T) {
 		WantErr bool
 	}{
 
-		{"url with no qos", "rabbit://%s", false},
+		{"url with no QoS prefetch count", "rabbit://%s", false},
 		{"invalid parameters", "rabbit://%s?param=value", true},
-		{"valid url with qos", "rabbit://%s?qos=1024", false},
-		{"invalid url with qos", "rabbit://%s?qos=value", true},
+		{"valid url with QoS prefetch count", "rabbit://%s?prefetch_count=1024", false},
+		{"invalid url with QoS prefetch count", "rabbit://%s?prefetch_count=value", true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #3430

Since we usually want to set the prefetch count, I simplify the rabbit url to support a single query string

we can use `rabbit://myqueue` (continues backward compatible) or the new one `rabbit://myqueue?prefetch_count=<prefetch-count-value>`

I tested locally using a rabbitmq docker image and it seems to work properly.