### PR TITLE
pubsub/rabbitpubsub: add query string to set the  routing key from metadata 

### DIFF
--- a/pubsub/kafkapubsub/kafka.go
+++ b/pubsub/kafkapubsub/kafka.go
@@ -136,7 +136,9 @@ const Scheme = "kafka"
 // URLOpener opens Kafka URLs like "kafka://mytopic" for topics and
 // "kafka://group?topic=mytopic" for subscriptions.
 //
-// For topics, the URL's host+path is used as the topic name.
+// For topics, the URL's host+path is used as the topic name,
+// and the "key_name" query parameter is used to extract the routing key
+// from metadata.
 //
 // For subscriptions, the URL's host+path is used as the group name,
 // and the "topic" query parameter(s) are used as the set of topics to

--- a/pubsub/rabbitpubsub/amqp.go
+++ b/pubsub/rabbitpubsub/amqp.go
@@ -29,10 +29,6 @@ const (
 	// response. We always want to wait.
 	wait = false
 
-	// Always use the empty routing key. This driver expects to be used with topic
-	// exchanges, which disregard the routing key.
-	routingKey = ""
-
 	// If the message can't be enqueued, return it to the sender rather than silently
 	// dropping it.
 	mandatory = true
@@ -49,7 +45,7 @@ type amqpConnection interface {
 
 // See https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel for the documentation of these methods.
 type amqpChannel interface {
-	Publish(exchange string, msg amqp.Publishing) error
+	Publish(exchange, routingKey string, msg amqp.Publishing) error
 	Consume(queue, consumer string) (<-chan amqp.Delivery, error)
 	Ack(tag uint64) error
 	Nack(tag uint64) error
@@ -93,7 +89,7 @@ type channel struct {
 	ch *amqp.Channel
 }
 
-func (ch *channel) Publish(exchange string, msg amqp.Publishing) error {
+func (ch *channel) Publish(exchange, routingKey string, msg amqp.Publishing) error {
 	return ch.ch.Publish(exchange, routingKey, mandatory, immediate, msg)
 }
 

--- a/pubsub/rabbitpubsub/fake_test.go
+++ b/pubsub/rabbitpubsub/fake_test.go
@@ -152,7 +152,7 @@ func (ch *fakeChannel) QueueDeclareAndBind(queueName, exchangeName string) error
 	return nil
 }
 
-func (ch *fakeChannel) Publish(exchangeName string, pub amqp.Publishing) error {
+func (ch *fakeChannel) Publish(exchangeName, routingKey string, pub amqp.Publishing) error {
 	if ch.isClosed() {
 		return amqp.ErrClosed
 	}
@@ -168,9 +168,10 @@ func (ch *fakeChannel) Publish(exchangeName string, pub amqp.Publishing) error {
 		// The message is unroutable. Send a Return to all channels registered with
 		// NotifyReturn.
 		ret := amqp.Return{
-			Exchange:  exchangeName,
-			ReplyCode: amqp.NoRoute,
-			ReplyText: "NO_ROUTE: no queues bound to exchange",
+			Exchange:   exchangeName,
+			ReplyCode:  amqp.NoRoute,
+			ReplyText:  "NO_ROUTE: no queues bound to exchange",
+			RoutingKey: routingKey,
 		}
 		for _, c := range ch.returnChans {
 			select {

--- a/pubsub/rabbitpubsub/rabbit_test.go
+++ b/pubsub/rabbitpubsub/rabbit_test.go
@@ -125,11 +125,11 @@ func (h *harness) CreateTopic(_ context.Context, testName string) (dt driver.Top
 		}
 		ch.ExchangeDelete(exchange)
 	}
-	return newTopic(h.conn, exchange), cleanup, nil
+	return newTopic(h.conn, exchange, nil), cleanup, nil
 }
 
 func (h *harness) MakeNonexistentTopic(context.Context) (driver.Topic, error) {
-	return newTopic(h.conn, "nonexistent-topic"), nil
+	return newTopic(h.conn, "nonexistent-topic", nil), nil
 }
 
 func (h *harness) CreateSubscription(_ context.Context, dt driver.Topic, testName string) (ds driver.Subscription, cleanup func(), err error) {
@@ -170,7 +170,7 @@ func TestUnroutable(t *testing.T) {
 	if err := declareExchange(conn, "u"); err != nil {
 		t.Fatal(err)
 	}
-	topic := newTopic(conn, "u")
+	topic := newTopic(conn, "u", nil)
 	msgs := []*driver.Message{
 		{Body: []byte("")},
 		{Body: []byte("")},
@@ -394,7 +394,9 @@ func TestOpenTopicFromURL(t *testing.T) {
 		WantErr     bool
 	}{
 		{"valid url", "rabbit://%s", false},
+		{"valid url with key name parameter", "rabbit://%s?key_name=foo", false},
 		{"invalid url with parameters", "rabbit://%s?param=value", true},
+		{"invalid url with key name parameter", "rabbit://%s?key_name=", true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #3432 

This development is similar to pull request #3431 
