### PR TITLE
pubsub/rabbitpubsub: wrap pubsub rabbitmq errors

### DIFF
--- a/pubsub/rabbitpubsub/amqp.go
+++ b/pubsub/rabbitpubsub/amqp.go
@@ -136,10 +136,10 @@ func (ch *channel) NotifyClose(c chan *amqp.Error) chan *amqp.Error {
 
 func (ch *channel) ExchangeDeclare(name string) error {
 	return ch.ch.ExchangeDeclare(name,
-		"fanout", // kind
-		false,    // durable
-		false,    // delete when unused
-		false,    // internal
+		amqp.ExchangeFanout, // kind
+		false,               // durable
+		false,               // delete when unused
+		false,               // internal
 		wait,
 		nil) // args
 }

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -64,7 +64,7 @@ func (o *defaultDialer) defaultConn(ctx context.Context) (*URLOpener, error) {
 	}
 	conn, err := amqp.Dial(serverURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial RABBIT_SERVER_URL %q: %v", serverURL, err)
+		return nil, fmt.Errorf("failed to dial RABBIT_SERVER_URL %q: %w", serverURL, err)
 	}
 	o.conn = conn
 	o.opener = &URLOpener{Connection: conn}
@@ -74,7 +74,7 @@ func (o *defaultDialer) defaultConn(ctx context.Context) (*URLOpener, error) {
 func (o *defaultDialer) OpenTopicURL(ctx context.Context, u *url.URL) (*pubsub.Topic, error) {
 	opener, err := o.defaultConn(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("open topic %v: failed to open default connection: %v", u, err)
+		return nil, fmt.Errorf("open topic %v: failed to open default connection: %w", u, err)
 	}
 	return opener.OpenTopicURL(ctx, u)
 }
@@ -82,7 +82,7 @@ func (o *defaultDialer) OpenTopicURL(ctx context.Context, u *url.URL) (*pubsub.T
 func (o *defaultDialer) OpenSubscriptionURL(ctx context.Context, u *url.URL) (*pubsub.Subscription, error) {
 	opener, err := o.defaultConn(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("open subscription %v: failed to open default connection: %v", u, err)
+		return nil, fmt.Errorf("open subscription %v: failed to open default connection: %w", u, err)
 	}
 	return opener.OpenSubscriptionURL(ctx, u)
 }


### PR DESCRIPTION
I note that we mere add a %v reference to the original rabbitmq errors, and since we may need to unwrap such errors, it is better use %w

I also create few global errors to return instead allocate a new error in some trivial cases

Enjoy