### PR TITLE
all: fix deprecated code and small lint issues detected by staticcheck

### DIFF
--- a/aws/rds/rds.go
+++ b/aws/rds/rds.go
@@ -21,7 +21,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/google/wire"
@@ -79,7 +78,7 @@ func (cf *CertFetcher) Fetch(ctx context.Context) ([]*x509.Certificate, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("fetch RDS certificates: HTTP %s", resp.Status)
 	}
-	pemData, err := ioutil.ReadAll(&io.LimitedReader{R: resp.Body, N: 1 << 20}) // limit to 1MiB
+	pemData, err := io.ReadAll(&io.LimitedReader{R: resp.Body, N: 1 << 20}) // limit to 1MiB
 	if err != nil {
 		return nil, fmt.Errorf("fetch RDS certificates: %v", err)
 	}

--- a/azure/azuredb/azuredb.go
+++ b/azure/azuredb/azuredb.go
@@ -21,7 +21,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"golang.org/x/net/context/ctxhttp"
@@ -70,7 +69,7 @@ func (cf *CertFetcher) Fetch(ctx context.Context) ([]*x509.Certificate, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("fetch Azure certificates: HTTP %s", resp.Status)
 	}
-	pemData, err := ioutil.ReadAll(&io.LimitedReader{R: resp.Body, N: 1 << 20}) // limit to 1MiB
+	pemData, err := io.ReadAll(&io.LimitedReader{R: resp.Body, N: 1 << 20}) // limit to 1MiB
 	if err != nil {
 		return nil, fmt.Errorf("fetch Azure certificates: %v", err)
 	}

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -70,7 +70,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime"
 	"net/http"
@@ -732,7 +731,7 @@ func (b *Bucket) ReadAll(ctx context.Context, key string) (_ []byte, err error) 
 		return nil, err
 	}
 	defer r.Close()
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 // Download writes the content of a blob into an io.Writer w.

--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -2275,7 +2274,7 @@ func testKeys(t *testing.T, newHarness HarnessMaker) {
 				if resp.StatusCode != 200 {
 					t.Errorf("got status code %d, want 200", resp.StatusCode)
 				}
-				got, err := ioutil.ReadAll(resp.Body)
+				got, err := io.ReadAll(resp.Body)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -2463,7 +2462,7 @@ func testSignedURL(t *testing.T, newHarness HarnessMaker) {
 			success := resp.StatusCode >= 200 && resp.StatusCode < 300
 			if success != test.wantSuccess {
 				t.Errorf("PUT to %q with ContentType %q got status code %d, wanted 2xx? %v", test.urlDescription, test.contentType, resp.StatusCode, test.wantSuccess)
-				gotBody, _ := ioutil.ReadAll(resp.Body)
+				gotBody, _ := io.ReadAll(resp.Body)
 				t.Errorf(string(gotBody))
 			}
 		}
@@ -2487,10 +2486,10 @@ func testSignedURL(t *testing.T, newHarness HarnessMaker) {
 			success := resp.StatusCode >= 200 && resp.StatusCode < 300
 			if success != test.wantSuccess {
 				t.Errorf("GET to %q got status code %d, want 2xx? %v", test.urlDescription, resp.StatusCode, test.wantSuccess)
-				gotBody, _ := ioutil.ReadAll(resp.Body)
+				gotBody, _ := io.ReadAll(resp.Body)
 				t.Errorf(string(gotBody))
 			} else if success {
-				gotBody, err := ioutil.ReadAll(resp.Body)
+				gotBody, err := io.ReadAll(resp.Body)
 				if err != nil {
 					t.Errorf("GET to %q failed to read response body: %v", test.urlDescription, err)
 				} else if gotBodyStr := string(gotBody); gotBodyStr != contents {
@@ -2519,7 +2518,7 @@ func testSignedURL(t *testing.T, newHarness HarnessMaker) {
 			defer resp.Body.Close()
 			success := resp.StatusCode >= 200 && resp.StatusCode < 300
 			if success != test.wantSuccess {
-				gotBody, _ := ioutil.ReadAll(resp.Body)
+				gotBody, _ := io.ReadAll(resp.Body)
 				t.Errorf(string(gotBody))
 				t.Fatalf("DELETE to %q got status code %d, want 2xx? %v", test.urlDescription, resp.StatusCode, test.wantSuccess)
 			}
@@ -2534,7 +2533,7 @@ func testSignedURL(t *testing.T, newHarness HarnessMaker) {
 			defer resp.Body.Close()
 			if resp.StatusCode != 404 {
 				t.Errorf("GET after DELETE got status code %d, want 404", resp.StatusCode)
-				gotBody, _ := ioutil.ReadAll(resp.Body)
+				gotBody, _ := io.ReadAll(resp.Body)
 				t.Errorf(string(gotBody))
 			}
 		}

--- a/blob/example_test.go
+++ b/blob/example_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -570,7 +569,7 @@ func ExampleAttributes_As() {
 }
 
 func newTempDir() (string, func()) {
-	dir, err := ioutil.TempDir("", "go-cloud-blob-example")
+	dir, err := os.MkdirTemp("", "go-cloud-blob-example")
 	if err != nil {
 		panic(err)
 	}

--- a/blob/fileblob/example_test.go
+++ b/blob/fileblob/example_test.go
@@ -17,7 +17,6 @@ package fileblob_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -46,7 +45,7 @@ func ExampleOpenBucket() {
 
 func Example_openBucketFromURL() {
 	// Create a temporary directory.
-	dir, err := ioutil.TempDir("", "go-cloud-fileblob-example")
+	dir, err := os.MkdirTemp("", "go-cloud-fileblob-example")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -73,7 +73,6 @@ import (
 	"hash"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -222,7 +221,7 @@ func (o *URLOpener) forParams(ctx context.Context, q url.Values) (*Options, erro
 		if err != nil {
 			return nil, err
 		}
-		sk, err := ioutil.ReadFile(keyPath)
+		sk, err := os.ReadFile(keyPath)
 		if err != nil {
 			return nil, err
 		}

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -215,22 +215,16 @@ func BenchmarkFileblob(b *testing.B) {
 // File-specific unit tests.
 func TestNewBucket(t *testing.T) {
 	t.Run("BucketDirMissing", func(t *testing.T) {
-		dir, err := os.MkdirTemp("", "fileblob")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
+
 		_, gotErr := OpenBucket(filepath.Join(dir, "notfound"), nil)
 		if gotErr == nil {
 			t.Errorf("got nil want error")
 		}
 	})
 	t.Run("BucketDirMissingWithCreateDir", func(t *testing.T) {
-		dir, err := os.MkdirTemp("", "fileblob")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
+
 		b, gotErr := OpenBucket(filepath.Join(dir, "notfound"), &Options{CreateDir: true})
 		if gotErr != nil {
 			t.Errorf("got error %v", gotErr)
@@ -244,11 +238,12 @@ func TestNewBucket(t *testing.T) {
 		}
 	})
 	t.Run("BucketIsFile", func(t *testing.T) {
-		f, err := ioutil.TempFile("", "fileblob")
+		dir := t.TempDir()
+
+		f, err := os.CreateTemp(dir, "fileblob")
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer os.Remove(f.Name())
 		_, gotErr := OpenBucket(f.Name(), nil)
 		if gotErr == nil {
 			t.Errorf("got nil want error")
@@ -257,11 +252,8 @@ func TestNewBucket(t *testing.T) {
 }
 
 func TestSignedURLReturnsUnimplementedWithNoURLSigner(t *testing.T) {
-	dir, err := os.MkdirTemp("", "fileblob")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
+
 	b, err := OpenBucket(dir, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -460,10 +452,8 @@ func TestListAtRoot(t *testing.T) {
 	}
 	defer b.Close()
 
-	dir, err := os.MkdirTemp("", "fileblob")
-	if err != nil {
-		t.Fatalf("Got error creating temp dir: %#v", err)
-	}
+	dir := t.TempDir()
+
 	f, err := os.Create(filepath.Join(dir, "file.txt"))
 	if err != nil {
 		t.Fatalf("Got error creating file: %#v", err)
@@ -487,11 +477,8 @@ func TestListAtRoot(t *testing.T) {
 }
 
 func TestSkipMetadata(t *testing.T) {
-	dir, err := os.MkdirTemp("", "fileblob*")
-	if err != nil {
-		t.Fatalf("Got error creating temp dir: %#v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
+
 	dirpath := filepath.ToSlash(dir)
 	if os.PathSeparator != '/' && !strings.HasPrefix(dirpath, "/") {
 		dirpath = "/" + dirpath

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -215,7 +215,7 @@ func BenchmarkFileblob(b *testing.B) {
 // File-specific unit tests.
 func TestNewBucket(t *testing.T) {
 	t.Run("BucketDirMissing", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "fileblob")
+		dir, err := os.MkdirTemp("", "fileblob")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -226,7 +226,7 @@ func TestNewBucket(t *testing.T) {
 		}
 	})
 	t.Run("BucketDirMissingWithCreateDir", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "fileblob")
+		dir, err := os.MkdirTemp("", "fileblob")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -257,7 +257,7 @@ func TestNewBucket(t *testing.T) {
 }
 
 func TestSignedURLReturnsUnimplementedWithNoURLSigner(t *testing.T) {
-	dir, err := ioutil.TempDir("", "fileblob")
+	dir, err := os.MkdirTemp("", "fileblob")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -460,7 +460,7 @@ func TestListAtRoot(t *testing.T) {
 	}
 	defer b.Close()
 
-	dir, err := ioutil.TempDir("", "fileblob")
+	dir, err := os.MkdirTemp("", "fileblob")
 	if err != nil {
 		t.Fatalf("Got error creating temp dir: %#v", err)
 	}
@@ -487,7 +487,7 @@ func TestListAtRoot(t *testing.T) {
 }
 
 func TestSkipMetadata(t *testing.T) {
-	dir, err := ioutil.TempDir("", "fileblob*")
+	dir, err := os.MkdirTemp("", "fileblob*")
 	if err != nil {
 		t.Fatalf("Got error creating temp dir: %#v", err)
 	}

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -344,15 +343,15 @@ func TestOpenBucketFromURL(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dir, subdir), os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "myfile.txt"), []byte("hello world"), 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "myfile.txt"), []byte("hello world"), 0666); err != nil {
 		t.Fatal(err)
 	}
 	// To avoid making another temp dir, use the bucket directory to hold the secret key file.
 	secretKeyPath := filepath.Join(dir, "secret.key")
-	if err := ioutil.WriteFile(secretKeyPath, []byte("secret key"), 0666); err != nil {
+	if err := os.WriteFile(secretKeyPath, []byte("secret key"), 0666); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, subdir, "myfileinsubdir.txt"), []byte("hello world in subdir"), 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, subdir, "myfileinsubdir.txt"), []byte("hello world in subdir"), 0666); err != nil {
 		t.Fatal(err)
 	}
 	// Convert dir to a URL path, adding a leading "/" if needed on Windows.

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -345,7 +345,7 @@ type bucket struct {
 	opts   *Options
 }
 
-var emptyBody = ioutil.NopCloser(strings.NewReader(""))
+var emptyBody = io.NopCloser(strings.NewReader(""))
 
 // reader reads a GCS object. It implements driver.Reader.
 type reader struct {

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -63,7 +63,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -248,7 +247,7 @@ func (o *URLOpener) forParams(ctx context.Context, q url.Values) (*Options, *gcp
 		}
 	}
 	if keyPath := q.Get("private_key_path"); keyPath != "" {
-		pk, err := ioutil.ReadFile(keyPath)
+		pk, err := os.ReadFile(keyPath)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -456,7 +457,7 @@ func TestPreconditions(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer reader.Close()
-	gotBytes, err := ioutil.ReadAll(reader)
+	gotBytes, err := io.ReadAll(reader)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -520,7 +519,7 @@ func TestURLOpenerForParams(t *testing.T) {
 
 	// Create a file for use as a dummy private key file.
 	privateKey := []byte("some content")
-	pkFile, err := ioutil.TempFile("", "my-private-key")
+	pkFile, err := os.CreateTemp("", "my-private-key")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -640,7 +639,7 @@ func TestOpenBucketFromURL(t *testing.T) {
 	cleanup := setup.FakeGCPDefaultCredentials(t)
 	defer cleanup()
 
-	pkFile, err := ioutil.TempFile("", "my-private-key")
+	pkFile, err := os.CreateTemp("", "my-private-key")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -75,7 +75,7 @@ func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
 			*pathToPrivateKey = filepath.Join(usr.HomeDir, "Downloads", "gcs-private-key.pem")
 		}
 		// Use a real private key for signing URLs during -record.
-		pk, err := ioutil.ReadFile(*pathToPrivateKey)
+		pk, err := os.ReadFile(*pathToPrivateKey)
 		if err != nil {
 			t.Fatalf("Couldn't find private key at %v: %v", *pathToPrivateKey, err)
 		}

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -645,7 +645,7 @@ func TestOpenBucketFromURL(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.Remove(pkFile.Name())
-	if err := ioutil.WriteFile(pkFile.Name(), []byte("key"), 0666); err != nil {
+	if err := os.WriteFile(pkFile.Name(), []byte("key"), 0666); err != nil {
 		t.Fatal(err)
 	}
 

--- a/blob/gcsblob/iam_test.go
+++ b/blob/gcsblob/iam_test.go
@@ -69,7 +69,7 @@ func TestIAMCredentialsClient(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := credentialsClient{err: test.connectErr, client: test.mockClient}
-			makeSignBytesFn := c.CreateMakeSignBytesWith(nil, serviceAccountID)
+			makeSignBytesFn := c.CreateMakeSignBytesWith(context.TODO(), serviceAccountID)
 
 			signBytesFn := makeSignBytesFn(nil) // Our mocks don't read any context.
 			haveOutput, haveErr := signBytesFn(test.input)

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -155,7 +155,7 @@ func toServerSideEncryptionType(value string) (typesv2.ServerSideEncryption, err
 			return sseType, nil
 		}
 	}
-	return "", fmt.Errorf("'%s' is not a valid value for '%s'", value, sseTypeParamKey)
+	return "", fmt.Errorf("%q is not a valid value for %q", value, sseTypeParamKey)
 }
 
 // OpenBucketURL opens a blob.Bucket based on u.

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -151,7 +151,7 @@ const (
 
 func toServerSideEncryptionType(value string) (typesv2.ServerSideEncryption, error) {
 	for _, sseType := range typesv2.ServerSideEncryptionAes256.Values() {
-		if strings.ToLower(string(sseType)) == strings.ToLower(value) {
+		if strings.EqualFold(string(sseType), value) {
 			return sseType, nil
 		}
 	}

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -503,7 +503,7 @@ func TestToServerSideEncryptionType(t *testing.T) {
 		// OK, AES256 mixed case
 		{"Aes256", typesv2.ServerSideEncryptionAes256, nil},
 		// Invalid SSE type
-		{"invalid", "", fmt.Errorf("'invalid' is not a valid value for '%s'", sseTypeParamKey)},
+		{"invalid", "", fmt.Errorf("'invalid' is not a valid value for %q", sseTypeParamKey)},
 	}
 
 	for _, test := range tests {

--- a/blob/wrapped_bucket_test.go
+++ b/blob/wrapped_bucket_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestPrefixedBucket(t *testing.T) {
-	dir, cleanup := newTempDir()
-	defer cleanup()
+	dir := t.TempDir()
+
 	bucket, err := fileblob.OpenBucket(dir, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -38,8 +38,8 @@ func TestPrefixedBucket(t *testing.T) {
 }
 
 func TestSingleKeyBucket(t *testing.T) {
-	dir, cleanup := newTempDir()
-	defer cleanup()
+	dir := t.TempDir()
+
 	bucket, err := fileblob.OpenBucket(dir, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/docstore/awsdynamodb/dynamo.go
+++ b/docstore/awsdynamodb/dynamo.go
@@ -180,17 +180,17 @@ func (c *collection) runGets(ctx context.Context, actions []*driver.Action, errs
 		for i := 0; i < n; i++ {
 			i := i
 			t.Acquire()
-			go func() {
+			go func(group []*driver.Action) {
 				defer t.Release()
 				c.batchGet(ctx, group, errs, opts, batchSize*i, batchSize*(i+1)-1)
-			}()
+			}(group)
 		}
 		if n*batchSize < len(group) {
 			t.Acquire()
-			go func() {
+			go func(group []*driver.Action) {
 				defer t.Release()
 				c.batchGet(ctx, group, errs, opts, batchSize*n, len(group)-1)
-			}()
+			}(group)
 		}
 	}
 	t.Wait()

--- a/docstore/gcpfirestore/fs.go
+++ b/docstore/gcpfirestore/fs.go
@@ -602,7 +602,6 @@ func (c *collection) doCommitCall(ctx context.Context, call *commitCall, errs []
 			j++
 		}
 	}
-	return
 }
 
 func hasFollowingTransform(writes []*pb.Write, i int) bool {

--- a/docstore/gcpfirestore/fs.go
+++ b/docstore/gcpfirestore/fs.go
@@ -83,6 +83,7 @@ import (
 	"gocloud.dev/internal/useragent"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -98,7 +99,8 @@ func Dial(ctx context.Context, ts gcp.TokenSource) (*vkit.Client, func(), error)
 		useragent.ClientOption("docstore"),
 	}
 	if host := os.Getenv("FIRESTORE_EMULATOR_HOST"); host != "" {
-		conn, err := grpc.DialContext(ctx, host, grpc.WithInsecure())
+		conn, err := grpc.DialContext(ctx, host,
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/docstore/gcpfirestore/native_codec_test.go
+++ b/docstore/gcpfirestore/native_codec_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	tspb "google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -53,7 +54,7 @@ func newNativeCodec() (*nativeCodec, error) {
 	nc := &nativeCodec{}
 
 	conn, err := grpc.Dial(l.Addr().String(),
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithBlock(),
 		grpc.WithUnaryInterceptor(nc.interceptUnary),
 		grpc.WithStreamInterceptor(nc.interceptStream))

--- a/docstore/memdocstore/mem_test.go
+++ b/docstore/memdocstore/mem_test.go
@@ -163,12 +163,7 @@ func TestSortDocs(t *testing.T) {
 }
 
 func TestSaveAndLoad(t *testing.T) {
-	// Save and then load into a file.
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Load from nonexistent file should return empty data.
 	f := filepath.Join(dir, "saveAndLoad")

--- a/docstore/memdocstore/mem_test.go
+++ b/docstore/memdocstore/mem_test.go
@@ -16,7 +16,6 @@ package memdocstore
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -165,7 +164,7 @@ func TestSortDocs(t *testing.T) {
 
 func TestSaveAndLoad(t *testing.T) {
 	// Save and then load into a file.
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/docstore/memdocstore/urls.go
+++ b/docstore/memdocstore/urls.go
@@ -59,9 +59,7 @@ func (o *URLOpener) OpenCollectionURL(ctx context.Context, u *url.URL) (*docstor
 		return nil, fmt.Errorf("open collection %v: empty collection name", u)
 	}
 	keyName := u.Path
-	if strings.HasPrefix(keyName, "/") {
-		keyName = keyName[1:]
-	}
+	keyName = strings.TrimPrefix(keyName, "/")
 	if keyName == "" || strings.ContainsRune(keyName, '/') {
 		return nil, fmt.Errorf("open collection %v: invalid key name %q (must be non-empty and have no slashes)", u, keyName)
 	}

--- a/internal/releasehelper/releasehelper.go
+++ b/internal/releasehelper/releasehelper.go
@@ -246,7 +246,7 @@ func main() {
 		if len(input.Text()) > 0 && !strings.HasPrefix(input.Text(), "#") {
 			fields := strings.Fields(input.Text())
 			if len(fields) != 2 {
-				log.Fatalf("want 2 fields, got '%s'\n", input.Text())
+				log.Fatalf("want 2 fields, got %q\n", input.Text())
 			}
 			// "tag" only runs if the released field is "yes". Other commands run
 			// for every line.

--- a/internal/releasehelper/releasehelper_test.go
+++ b/internal/releasehelper/releasehelper_test.go
@@ -93,7 +93,7 @@ func Test(t *testing.T) {
 
 	for _, line := range replaceLines {
 		if !strings.Contains(string(c), line) {
-			t.Errorf("Expected to find '%s' in samples/go.mod", line)
+			t.Errorf("Expected to find %q in samples/go.mod", line)
 		}
 	}
 
@@ -106,7 +106,7 @@ func Test(t *testing.T) {
 
 	for _, line := range replaceLines {
 		if strings.Contains(string(c), line) {
-			t.Errorf("Expected to not find '%s' in samples/go.mod", line)
+			t.Errorf("Expected to not find %q in samples/go.mod", line)
 		}
 	}
 

--- a/internal/releasehelper/releasehelper_test.go
+++ b/internal/releasehelper/releasehelper_test.go
@@ -68,15 +68,12 @@ func createFilesForTest(root string) error {
 }
 
 func Test(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "releasehelper_test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempDir := t.TempDir()
+
 	fmt.Println("temp dir:", tempDir)
 	if err := createFilesForTest(tempDir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir)
 
 	if err := os.Chdir(tempDir); err != nil {
 		t.Fatal(err)

--- a/internal/releasehelper/releasehelper_test.go
+++ b/internal/releasehelper/releasehelper_test.go
@@ -68,7 +68,7 @@ func createFilesForTest(root string) error {
 }
 
 func Test(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "releasehelper_test")
+	tempDir, err := os.MkdirTemp("", "releasehelper_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/releasehelper/releasehelper_test.go
+++ b/internal/releasehelper/releasehelper_test.go
@@ -86,7 +86,7 @@ func Test(t *testing.T) {
 	gomodAddReplace("samples")
 
 	samplesGomod := filepath.Join("samples", "go.mod")
-	c, err := ioutil.ReadFile(samplesGomod)
+	c, err := os.ReadFile(samplesGomod)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func Test(t *testing.T) {
 
 	// Drop replace lines and expect not to find them.
 	gomodDropReplace("samples")
-	c, err = ioutil.ReadFile(samplesGomod)
+	c, err = os.ReadFile(samplesGomod)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +116,7 @@ func Test(t *testing.T) {
 
 	// Set new version and check it was set as expected.
 	gomodSetVersion("samples", "v1.8.99")
-	c, err = ioutil.ReadFile(samplesGomod)
+	c, err = os.ReadFile(samplesGomod)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/releasehelper/releasehelper_test.go
+++ b/internal/releasehelper/releasehelper_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,19 +48,19 @@ require (
 `)
 
 func createFilesForTest(root string) error {
-	if err := ioutil.WriteFile(filepath.Join(root, "go.mod"), mainGomod, 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), mainGomod, 0666); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(filepath.Join(root, "submod"), 0766); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(root, "submod", "go.mod"), submodGomod, 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "submod", "go.mod"), submodGomod, 0666); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(filepath.Join(root, "samples"), 0766); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(root, "samples", "go.mod"), samplesGomod, 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "samples", "go.mod"), samplesGomod, 0666); err != nil {
 		return err
 	}
 	return nil

--- a/internal/testing/setup/setup.go
+++ b/internal/testing/setup/setup.go
@@ -17,7 +17,6 @@ package setup // import "gocloud.dev/internal/testing/setup"
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -267,7 +266,7 @@ func NewAzureKeyVaultTestClient(ctx context.Context, t *testing.T) (*http.Client
 func FakeGCPDefaultCredentials(t *testing.T) func() {
 	const envVar = "GOOGLE_APPLICATION_CREDENTIALS"
 	jsonCred := []byte(`{"client_id": "foo.apps.googleusercontent.com", "client_secret": "bar", "refresh_token": "baz", "type": "authorized_user"}`)
-	f, err := ioutil.TempFile("", "fake-gcp-creds")
+	f, err := os.CreateTemp("", "fake-gcp-creds")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testing/setup/setup.go
+++ b/internal/testing/setup/setup.go
@@ -271,7 +271,7 @@ func FakeGCPDefaultCredentials(t *testing.T) func() {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(f.Name(), jsonCred, 0666); err != nil {
+	if err := os.WriteFile(f.Name(), jsonCred, 0666); err != nil {
 		t.Fatal(err)
 	}
 	oldEnvVal := os.Getenv(envVar)

--- a/internal/website/content/howto/blob/_index.md
+++ b/internal/website/content/howto/blob/_index.md
@@ -140,7 +140,7 @@ ignore the error because the write's failure is expected.
 
 Once you have written data to a bucket, you can read it back by creating a
 reader. The reader implements [`io.Reader`][], so you can use any functions
-that take an `io.Reader` like `io.Copy` or `io/ioutil.ReadAll`. You must
+that take an `io.Reader` like `io.Copy` or `io/io.ReadAll`. You must
 always close a reader after using it to avoid leaking resources.
 
 {{< goexample src="gocloud.dev/blob.ExampleBucket_NewReader" imports="0" >}}

--- a/internal/website/content/tutorials/cli-uploader.md
+++ b/internal/website/content/tutorials/cli-uploader.md
@@ -127,7 +127,7 @@ func main() {
     // ... previous code omitted
 
     // Prepare the file for upload.
-    data, err := ioutil.ReadFile(file)
+    data, err := os.ReadFile(file)
     if err != nil {
         log.Fatalf("Failed to read file: %s", err)
     }

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -71,7 +70,7 @@ func TestOpen(t *testing.T) {
 	}
 	confData := new(bytes.Buffer)
 	fmt.Fprintf(confData, "unix_socket_directories = '%s'\n", socketDir)
-	err = ioutil.WriteFile(filepath.Join(dataDir, "postgresql.conf"), confData.Bytes(), 0666)
+	err = os.WriteFile(filepath.Join(dataDir, "postgresql.conf"), confData.Bytes(), 0666)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -47,7 +47,7 @@ func TestOpen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dir, err := ioutil.TempDir("", "gocloud_postgres_test")
+	dir, err := os.MkdirTemp("", "gocloud_postgres_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -47,15 +47,9 @@ func TestOpen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dir, err := os.MkdirTemp("", "gocloud_postgres_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Errorf("Cleaning up: %v", err)
-		}
-	}()
+
+	dir := t.TempDir()
+
 	dataDir := filepath.Join(dir, "data")
 	initdbCmd := exec.Command(initdbPath, "-U", currUser.Username, "-D", dataDir)
 	initdbOutput := new(bytes.Buffer)

--- a/pubsub/acks_test.go
+++ b/pubsub/acks_test.go
@@ -159,11 +159,12 @@ func TestTooManyAcksForASingleBatchGoIntoMultipleBatches(t *testing.T) {
 	sub := pubsub.NewSubscription(ds, nil, nil)
 	defer sub.Shutdown(ctx)
 
+	errs := make(chan error, n)
 	// Receive and ack the messages concurrently.
 	recv := func() {
 		mr, err := sub.Receive(ctx)
 		if err != nil {
-			t.Fatal(err)
+			errs <- err
 		}
 		mr.Ack()
 	}
@@ -173,8 +174,14 @@ func TestTooManyAcksForASingleBatchGoIntoMultipleBatches(t *testing.T) {
 	}
 	wg.Wait()
 
+	close(errs)
+
 	if len(sentAckBatches) < 2 {
 		t.Errorf("got %d batches, want at least 2", len(sentAckBatches))
+	}
+
+	for err := range errs {
+		t.Fatalf("got error from goroutine: %v", err)
 	}
 }
 

--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -74,6 +74,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/oauth"
 	"google.golang.org/grpc/status"
 )
@@ -308,7 +309,9 @@ func Dial(ctx context.Context, ts gcp.TokenSource) (*grpc.ClientConn, func(), er
 
 // dialEmulator opens a gRPC connection to the GCP Pub Sub API.
 func dialEmulator(ctx context.Context, e string) (*grpc.ClientConn, error) {
-	conn, err := grpc.DialContext(ctx, e, grpc.WithInsecure(), useragent.GRPCDialOption("pubsub"))
+	conn, err := grpc.DialContext(ctx, e,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		useragent.GRPCDialOption("pubsub"))
 	if err != nil {
 		return nil, err
 	}

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -69,15 +69,16 @@ func NewDriverSub() *driverSub {
 }
 
 func (s *driverSub) ReceiveBatch(ctx context.Context, maxMessages int) ([]*driver.Message, error) {
-	select {
-	case <-s.sem:
-		ms := s.grabQueue(maxMessages)
-		if len(ms) != 0 {
-			return ms, nil
+	for{
+		select {
+		case <-s.sem:
+			ms := s.grabQueue(maxMessages)
+			if len(ms) != 0 {
+				return ms, nil
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
 	}
 }
 

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -69,7 +69,7 @@ func NewDriverSub() *driverSub {
 }
 
 func (s *driverSub) ReceiveBatch(ctx context.Context, maxMessages int) ([]*driver.Message, error) {
-	for{
+	for {
 		select {
 		case <-s.sem:
 			ms := s.grabQueue(maxMessages)

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -69,17 +69,15 @@ func NewDriverSub() *driverSub {
 }
 
 func (s *driverSub) ReceiveBatch(ctx context.Context, maxMessages int) ([]*driver.Message, error) {
-	for {
-		select {
-		case <-s.sem:
-			ms := s.grabQueue(maxMessages)
-			if len(ms) != 0 {
-				return ms, nil
-			}
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
+	select {
+	case <-s.sem:
+		ms := s.grabQueue(maxMessages)
+		if len(ms) != 0 {
+			return ms, nil
 		}
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
 	}
 }
 

--- a/pubsub/rabbitpubsub/amqp.go
+++ b/pubsub/rabbitpubsub/amqp.go
@@ -18,6 +18,8 @@ package rabbitpubsub
 // Fake implementations of the interfaces are in fake_test.go
 
 import (
+	"context"
+
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
@@ -46,6 +48,7 @@ type amqpConnection interface {
 // See https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel for the documentation of these methods.
 type amqpChannel interface {
 	Publish(exchange, routingKey string, msg amqp.Publishing) error
+	PublishWithContext(ctx context.Context, exchange, routingKey string, msg amqp.Publishing) error
 	Consume(queue, consumer string) (<-chan amqp.Delivery, error)
 	Ack(tag uint64) error
 	Nack(tag uint64) error
@@ -90,7 +93,11 @@ type channel struct {
 }
 
 func (ch *channel) Publish(exchange, routingKey string, msg amqp.Publishing) error {
-	return ch.ch.Publish(exchange, routingKey, mandatory, immediate, msg)
+	return ch.PublishWithContext(context.Background(), exchange, routingKey, msg)
+}
+
+func (ch *channel) PublishWithContext(ctx context.Context, exchange, routingKey string, msg amqp.Publishing) error {
+	return ch.ch.PublishWithContext(ctx, exchange, routingKey, mandatory, immediate, msg)
 }
 
 func (ch *channel) Consume(queue, consumer string) (<-chan amqp.Delivery, error) {

--- a/pubsub/rabbitpubsub/fake_test.go
+++ b/pubsub/rabbitpubsub/fake_test.go
@@ -153,6 +153,13 @@ func (ch *fakeChannel) QueueDeclareAndBind(queueName, exchangeName string) error
 }
 
 func (ch *fakeChannel) Publish(exchangeName, routingKey string, pub amqp.Publishing) error {
+	return ch.PublishWithContext(context.Background(), exchangeName, routingKey, pub)
+}
+
+func (ch *fakeChannel) PublishWithContext(ctx context.Context,
+	exchangeName, routingKey string,
+	pub amqp.Publishing,
+) error {
 	if ch.isClosed() {
 		return amqp.ErrClosed
 	}

--- a/runtimevar/blobvar/blobvar_test.go
+++ b/runtimevar/blobvar/blobvar_test.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -39,14 +38,15 @@ type harness struct {
 }
 
 func newHarness(t *testing.T) (drivertest.Harness, error) {
-	dir := path.Join(os.TempDir(), "go-cloud-blobvar")
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return nil, err
-	}
+	t.Helper()
+
+	dir := t.TempDir()
+
 	b, err := fileblob.OpenBucket(dir, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	return &harness{dir: dir, bucket: b}, nil
 }
 
@@ -96,17 +96,14 @@ func (verifyAs) ErrorCheck(v *runtimevar.Variable, err error) error {
 }
 
 func TestOpenVariable(t *testing.T) {
-	dir, err := os.MkdirTemp("", "gcdk-blob-var-example")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
+
 	if err := ioutil.WriteFile(filepath.Join(dir, "myvar.json"), []byte(`{"Foo": "Bar"}`), 0666); err != nil {
 		t.Fatal(err)
 	}
 	if err := ioutil.WriteFile(filepath.Join(dir, "myvar.txt"), []byte("hello world!"), 0666); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
 
 	// Convert dir to a URL path, adding a leading "/" if needed on Windows
 	// (on Unix, dirpath already has a leading "/").

--- a/runtimevar/blobvar/blobvar_test.go
+++ b/runtimevar/blobvar/blobvar_test.go
@@ -17,7 +17,6 @@ package blobvar
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -98,10 +97,10 @@ func (verifyAs) ErrorCheck(v *runtimevar.Variable, err error) error {
 func TestOpenVariable(t *testing.T) {
 	dir := t.TempDir()
 
-	if err := ioutil.WriteFile(filepath.Join(dir, "myvar.json"), []byte(`{"Foo": "Bar"}`), 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "myvar.json"), []byte(`{"Foo": "Bar"}`), 0666); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "myvar.txt"), []byte("hello world!"), 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "myvar.txt"), []byte("hello world!"), 0666); err != nil {
 		t.Fatal(err)
 	}
 

--- a/runtimevar/blobvar/blobvar_test.go
+++ b/runtimevar/blobvar/blobvar_test.go
@@ -96,7 +96,7 @@ func (verifyAs) ErrorCheck(v *runtimevar.Variable, err error) error {
 }
 
 func TestOpenVariable(t *testing.T) {
-	dir, err := ioutil.TempDir("", "gcdk-blob-var-example")
+	dir, err := os.MkdirTemp("", "gcdk-blob-var-example")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/runtimevar/filevar/example_test.go
+++ b/runtimevar/filevar/example_test.go
@@ -17,8 +17,8 @@ package filevar_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"gocloud.dev/runtimevar"
 	"gocloud.dev/runtimevar/filevar"
@@ -26,7 +26,7 @@ import (
 
 func ExampleOpenVariable() {
 	// Create a temporary file to hold our config.
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/runtimevar/filevar/filevar.go
+++ b/runtimevar/filevar/filevar.go
@@ -44,7 +44,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -280,7 +279,7 @@ func (w *watcher) watch(ctx context.Context, notifier *fsnotify.Watcher, file st
 		}
 
 		// Read the file.
-		b, err := ioutil.ReadFile(file)
+		b, err := os.ReadFile(file)
 		if err != nil {
 			// File probably does not exist. Try again later.
 			cur = w.updateState(&state{err: &errNotExist{err}}, cur)

--- a/runtimevar/filevar/filevar_test.go
+++ b/runtimevar/filevar/filevar_test.go
@@ -39,10 +39,10 @@ type harness struct {
 }
 
 func newHarness(t *testing.T) (drivertest.Harness, error) {
-	dir, err := os.MkdirTemp("", "filevar_test-")
-	if err != nil {
-		return nil, err
-	}
+	t.Helper()
+
+	dir := t.TempDir()
+
 	return &harness{
 		dir:    dir,
 		closer: func() { _ = os.RemoveAll(dir) },
@@ -114,10 +114,7 @@ func (verifyAs) ErrorCheck(v *runtimevar.Variable, err error) error {
 // Filevar-specific tests.
 
 func TestOpenVariable(t *testing.T) {
-	dir, err := os.MkdirTemp("", "filevar_test-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	tests := []struct {
 		description string
@@ -177,11 +174,7 @@ func TestOpenVariable(t *testing.T) {
 }
 
 func TestOpenVariableURL(t *testing.T) {
-	dir, err := os.MkdirTemp("", "gcdk-filevar-example")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	jsonPath := filepath.Join(dir, "myvar.json")
 	if err := ioutil.WriteFile(jsonPath, []byte(`{"Foo": "Bar"}`), 0666); err != nil {

--- a/runtimevar/filevar/filevar_test.go
+++ b/runtimevar/filevar/filevar_test.go
@@ -177,11 +177,11 @@ func TestOpenVariableURL(t *testing.T) {
 	dir := t.TempDir()
 
 	jsonPath := filepath.Join(dir, "myvar.json")
-	if err := ioutil.WriteFile(jsonPath, []byte(`{"Foo": "Bar"}`), 0666); err != nil {
+	if err := os.WriteFile(jsonPath, []byte(`{"Foo": "Bar"}`), 0666); err != nil {
 		t.Fatal(err)
 	}
 	txtPath := filepath.Join(dir, "myvar.txt")
-	if err := ioutil.WriteFile(txtPath, []byte("hello world!"), 0666); err != nil {
+	if err := os.WriteFile(txtPath, []byte("hello world!"), 0666); err != nil {
 		t.Fatal(err)
 	}
 	nonexistentPath := filepath.Join(dir, "filenotfound")
@@ -285,7 +285,7 @@ func setupTestSecrets(ctx context.Context, dir, secretsPath string) (func(), err
 	if err != nil {
 		return cleanup, err
 	}
-	if err := ioutil.WriteFile(secretsPath, sc, 0666); err != nil {
+	if err := os.WriteFile(secretsPath, sc, 0666); err != nil {
 		return cleanup, err
 	}
 	return cleanup, nil

--- a/runtimevar/filevar/filevar_test.go
+++ b/runtimevar/filevar/filevar_test.go
@@ -17,7 +17,6 @@ package filevar
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -58,7 +57,7 @@ func (h *harness) MakeWatcher(ctx context.Context, name string, decoder *runtime
 func (h *harness) CreateVariable(ctx context.Context, name string, val []byte) error {
 	// Write to a temporary file and rename; otherwise,
 	// Watch can read an empty file during the write.
-	tmp, err := ioutil.TempFile(h.dir, "tmp")
+	tmp, err := os.CreateTemp(h.dir, "tmp")
 	if err != nil {
 		return err
 	}

--- a/runtimevar/filevar/filevar_test.go
+++ b/runtimevar/filevar/filevar_test.go
@@ -39,7 +39,7 @@ type harness struct {
 }
 
 func newHarness(t *testing.T) (drivertest.Harness, error) {
-	dir, err := ioutil.TempDir("", "filevar_test-")
+	dir, err := os.MkdirTemp("", "filevar_test-")
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (verifyAs) ErrorCheck(v *runtimevar.Variable, err error) error {
 // Filevar-specific tests.
 
 func TestOpenVariable(t *testing.T) {
-	dir, err := ioutil.TempDir("", "filevar_test-")
+	dir, err := os.MkdirTemp("", "filevar_test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func TestOpenVariable(t *testing.T) {
 }
 
 func TestOpenVariableURL(t *testing.T) {
-	dir, err := ioutil.TempDir("", "gcdk-filevar-example")
+	dir, err := os.MkdirTemp("", "gcdk-filevar-example")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/runtimevar/httpvar/httpvar.go
+++ b/runtimevar/httpvar/httpvar.go
@@ -36,7 +36,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -234,7 +234,7 @@ func (w *watcher) WatchVariable(ctx context.Context, prev driver.State) (driver.
 		return errorState(err, prev), w.wait
 	}
 
-	respBodyBytes, err := ioutil.ReadAll(resp.Body)
+	respBodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errorState(err, prev), w.wait
 	}

--- a/runtimevar/runtimevar_test.go
+++ b/runtimevar/runtimevar_test.go
@@ -310,17 +310,15 @@ func TestVariable_Latest(t *testing.T) {
 	wg.Add(numGoroutines)
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
-			for {
-				val, err := v.Latest(ctx)
-				if err != nil {
-					// Errors are unexpected at this point.
-					t.Error(err)
-				} else if val.Value != content2 {
-					t.Errorf("got %v want %s", val.Value, content2)
-				}
-				wg.Done()
-				return
+			val, err := v.Latest(ctx)
+			if err != nil {
+				// Errors are unexpected at this point.
+				t.Error(err)
+			} else if val.Value != content2 {
+				t.Errorf("got %v want %s", val.Value, content2)
 			}
+			wg.Done()
+			return
 		}()
 	}
 	wg.Wait()

--- a/samples/guestbook/aws/provision_db/main.go
+++ b/samples/guestbook/aws/provision_db/main.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"

--- a/samples/guestbook/aws/provision_db/main.go
+++ b/samples/guestbook/aws/provision_db/main.go
@@ -66,7 +66,7 @@ func provisionDb(dbHost, region, securityGroupID, dbName, dbPassword, schemaPath
 	// Create a temporary directory to hold the certificates.
 	// We resolve all symlinks to avoid Docker on Mac issues, see
 	// https://github.com/google/go-cloud/issues/110.
-	tempdir, err := ioutil.TempDir("", "guestbook-ca")
+	tempdir, err := os.MkdirTemp("", "guestbook-ca")
 	if err != nil {
 		return fmt.Errorf("creating temp dir for certs: %v", err)
 	}

--- a/samples/guestbook/gcp/deploy/main.go
+++ b/samples/guestbook/gcp/deploy/main.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"

--- a/samples/guestbook/gcp/deploy/main.go
+++ b/samples/guestbook/gcp/deploy/main.go
@@ -93,7 +93,7 @@ func deploy(guestbookDir, tfStatePath string) error {
 	for old, new := range replacements {
 		gby = strings.Replace(gby, old, new, -1)
 	}
-	if err := ioutil.WriteFile(filepath.Join(tempDir, "guestbook.yaml"), []byte(gby), 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, "guestbook.yaml"), []byte(gby), 0666); err != nil {
 		return fmt.Errorf("writing guestbook.yaml: %v", err)
 	}
 

--- a/samples/guestbook/gcp/deploy/main.go
+++ b/samples/guestbook/gcp/deploy/main.go
@@ -77,7 +77,7 @@ func deploy(guestbookDir, tfStatePath string) error {
 	// Fill in Kubernetes template parameters.
 	proj := strings.Replace(tfState.Project.Value, ":", "/", -1)
 	imageName := fmt.Sprintf("gcr.io/%s/guestbook", proj)
-	gbyin, err := ioutil.ReadFile(filepath.Join(guestbookDir, "gcp", "guestbook.yaml.in"))
+	gbyin, err := os.ReadFile(filepath.Join(guestbookDir, "gcp", "guestbook.yaml.in"))
 	if err != nil {
 		return fmt.Errorf("reading guestbook.yaml.in: %v", err)
 	}

--- a/samples/guestbook/gcp/deploy/main.go
+++ b/samples/guestbook/gcp/deploy/main.go
@@ -68,7 +68,7 @@ func deploy(guestbookDir, tfStatePath string) error {
 	if zone == "" {
 		return fmt.Errorf("empty or missing cluster_zone in %s", tfStatePath)
 	}
-	tempDir, err := ioutil.TempDir("", "guestbook-k8s-")
+	tempDir, err := os.MkdirTemp("", "guestbook-k8s-")
 	if err != nil {
 		return fmt.Errorf("making temp dir: %v", err)
 	}

--- a/samples/guestbook/gcp/provision_db/main.go
+++ b/samples/guestbook/gcp/provision_db/main.go
@@ -78,7 +78,7 @@ func provisionDB(projectID, serviceAccount, dbInstance, dbName, dbPassword, sche
 	// Create a temporary directory to hold the service account key.
 	// We resolve all symlinks to avoid Docker on Mac issues, see
 	// https://github.com/google/go-cloud/issues/110.
-	serviceAccountVolDir, err := ioutil.TempDir("", "guestbook-service-acct")
+	serviceAccountVolDir, err := os.MkdirTemp("", "guestbook-service-acct")
 	if err != nil {
 		return fmt.Errorf("creating temp dir to hold service account key: %v", err)
 	}

--- a/samples/guestbook/gcp/provision_db/main.go
+++ b/samples/guestbook/gcp/provision_db/main.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"

--- a/samples/guestbook/gcp/provision_db/main.go
+++ b/samples/guestbook/gcp/provision_db/main.go
@@ -93,7 +93,7 @@ func provisionDB(projectID, serviceAccount, dbInstance, dbName, dbPassword, sche
 	if _, err := run(gcp.cmd("iam", "service-accounts", "keys", "create", "--iam-account="+serviceAccount, serviceAccountVolDir+"/key.json")...); err != nil {
 		return fmt.Errorf("creating new service account key: %v", err)
 	}
-	keyJSONb, err := ioutil.ReadFile(filepath.Join(serviceAccountVolDir, "key.json"))
+	keyJSONb, err := os.ReadFile(filepath.Join(serviceAccountVolDir, "key.json"))
 	if err != nil {
 		return fmt.Errorf("reading key.json file: %v", err)
 	}

--- a/samples/guestbook/localdb/main.go
+++ b/samples/guestbook/localdb/main.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"

--- a/samples/guestbook/localdb/main.go
+++ b/samples/guestbook/localdb/main.go
@@ -95,11 +95,11 @@ func runLocalDB(containerName, guestbookDir string) error {
 	}
 
 	log.Printf("Initializing database schema and users")
-	schema, err := ioutil.ReadFile(filepath.Join(guestbookDir, "schema.sql"))
+	schema, err := os.ReadFile(filepath.Join(guestbookDir, "schema.sql"))
 	if err != nil {
 		return fmt.Errorf("reading schema: %v", err)
 	}
-	roles, err := ioutil.ReadFile(filepath.Join(guestbookDir, "roles.sql"))
+	roles, err := os.ReadFile(filepath.Join(guestbookDir, "roles.sql"))
 	if err != nil {
 		return fmt.Errorf("reading roles: %v", err)
 	}

--- a/samples/order/frontend_test.go
+++ b/samples/order/frontend_test.go
@@ -47,7 +47,7 @@ func TestOrderForm(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	gotb, err := ioutil.ReadAll(res.Body)
+	gotb, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestCreateOrder(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer r.Close()
-	gotb, err := ioutil.ReadAll(r)
+	gotb, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func TestListOrders(t *testing.T) {
 	if res.StatusCode != 200 {
 		t.Fatalf("got %d, want 200", res.StatusCode)
 	}
-	gotb, err := ioutil.ReadAll(res.Body)
+	gotb, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/samples/order/frontend_test.go
+++ b/samples/order/frontend_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"

--- a/samples/order/frontend_test.go
+++ b/samples/order/frontend_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http/httptest"
 	"strings"
 	"testing"

--- a/samples/order/frontend_test.go
+++ b/samples/order/frontend_test.go
@@ -43,7 +43,7 @@ func TestOrderForm(t *testing.T) {
 	if res.StatusCode != 200 {
 		t.Fatalf("got %d, want 200", res.StatusCode)
 	}
-	wantb, err := ioutil.ReadFile("order-form.htmlt")
+	wantb, err := os.ReadFile("order-form.htmlt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/samples/order/order.go
+++ b/samples/order/order.go
@@ -28,7 +28,6 @@ package main
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"

--- a/samples/order/order.go
+++ b/samples/order/order.go
@@ -128,7 +128,7 @@ func setup(conf config) (_ *frontend, _ *processor, cleanup func(), err error) {
 
 	burl := conf.bucketURL
 	if burl == "" {
-		dir, err := ioutil.TempDir("", "gocdk-order")
+		dir, err := os.MkdirTemp("", "gocdk-order")
 		if err != nil {
 			return nil, nil, cleanup, err
 		}

--- a/samples/order/processor.go
+++ b/samples/order/processor.go
@@ -55,7 +55,6 @@ func (p *processor) run(ctx context.Context) error {
 			return err
 		}
 	}
-	return nil
 }
 
 // handleRequest handles one image-processing request.

--- a/samples/tutorial/main.go
+++ b/samples/tutorial/main.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"os"
 

--- a/samples/tutorial/main.go
+++ b/samples/tutorial/main.go
@@ -46,7 +46,7 @@ func main() {
 	defer b.Close()
 
 	// Prepare the file for upload.
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		log.Fatalf("Failed to read file: %s", err)
 	}

--- a/server/requestlog/stackdriver_test.go
+++ b/server/requestlog/stackdriver_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -179,7 +178,7 @@ func BenchmarkStackdriverLog(b *testing.B) {
 	buf.Reset()
 	b.ResetTimer()
 
-	l = NewStackdriverLogger(ioutil.Discard, func(error) {})
+	l = NewStackdriverLogger(io.Discard, func(error) {})
 	for i := 0; i < b.N; i++ {
 		l.Log(ent)
 	}
@@ -195,7 +194,7 @@ func BenchmarkE2E(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			io.Copy(ioutil.Discard, resp.Body)
+			io.Copy(io.Discard, resp.Body)
 			resp.Body.Close()
 		}
 	}
@@ -203,7 +202,7 @@ func BenchmarkE2E(b *testing.B) {
 		run(b, http.HandlerFunc(benchHandler))
 	})
 	b.Run("WithLog", func(b *testing.B) {
-		l := NewStackdriverLogger(ioutil.Discard, func(error) {})
+		l := NewStackdriverLogger(io.Discard, func(error) {})
 		run(b, NewHandler(l, http.HandlerFunc(benchHandler)))
 	})
 }


### PR DESCRIPTION
by running `staticcheck ./...` I found several small issues including

- usage of deprecated ioutil package
- grpc.Insecure() option
- explicit temp dir creation inside tests -- instead use t.TempDir()
- deprecated amqp Publish instead PublishWithContext
- and few other small changes

should not change any existing functionality.