### PR TITLE
blob/azureblob: Do not panic if Content-Length and Content-Range are missing

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -568,7 +568,7 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 	}
 	attrs := driver.ReaderAttributes{
 		ContentType: to.String(blobDownloadResponse.ContentType),
-		Size:        getSize(*blobDownloadResponse.ContentLength, to.String(blobDownloadResponse.ContentRange)),
+		Size:        getSize(blobDownloadResponse.ContentLength, to.String(blobDownloadResponse.ContentRange)),
 		ModTime:     *blobDownloadResponse.LastModified,
 	}
 	var body io.ReadCloser
@@ -584,11 +584,14 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 	}, nil
 }
 
-func getSize(contentLength int64, contentRange string) int64 {
+func getSize(contentLength *int64, contentRange string) int64 {
+	var size int64
 	// Default size to ContentLength, but that's incorrect for partial-length reads,
 	// where ContentLength refers to the size of the returned Body, not the entire
 	// size of the blob. ContentRange has the full size.
-	size := contentLength
+	if contentLength != nil {
+		size = *contentLength
+	}
 	if contentRange != "" {
 		// Sample: bytes 10-14/27 (where 27 is the full size).
 		parts := strings.Split(contentRange, "/")


### PR DESCRIPTION
I found that when we're downloading an a gzipped object with `Content-Encoding: gzip`, AZB is transparently sending back an uncompressed object rather than the gzipped object, and when this happens, I also discovered that go-cloud fails and panics because the Content-Length and the Content-Range fields are not set in this situation.

To gracefully handle this, check if the ContentLength field is nil before using it, and return 0 if both ContentRange and ContentLength are missing. This unfortunately does mean `Size()` may return 0 in some cases, but I don't see a good way to fix that without a bigger change in design. With this patch, I can confirm our issue is resolved.

Unfortunately, I did not see a good reference for how I could write a unit test for this. It seems existing conformance tests rely on a live bucket, and there's no unit tests that mock the underlying response or server for any of the existing drivers that I could reference either. If you have a suggestion for testing, let me know, but currently no new tests are added as part of this PR.