### PR TITLE
docstore/all - add support for boolean filter

### DIFF
--- a/docstore/awsdynamodb/create_tables.sh
+++ b/docstore/awsdynamodb/create_tables.sh
@@ -42,7 +42,6 @@ aws dynamodb create-table \
         AttributeName=Player,AttributeType=S \
         AttributeName=Score,AttributeType=N \
         AttributeName=Time,AttributeType=S \
-        AttributeName=WithGlitch,AttributeType=BOOL \
   --key-schema AttributeName=Game,KeyType=HASH AttributeName=Player,KeyType=RANGE \
   --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 \
   --local-secondary-indexes \

--- a/docstore/awsdynamodb/create_tables.sh
+++ b/docstore/awsdynamodb/create_tables.sh
@@ -42,6 +42,7 @@ aws dynamodb create-table \
         AttributeName=Player,AttributeType=S \
         AttributeName=Score,AttributeType=N \
         AttributeName=Time,AttributeType=S \
+        AttributeName=WithGlitch,AttributeType=BOOL \
   --key-schema AttributeName=Game,KeyType=HASH AttributeName=Player,KeyType=RANGE \
   --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 \
   --local-secondary-indexes \

--- a/docstore/drivertest/drivertest.go
+++ b/docstore/drivertest/drivertest.go
@@ -1272,6 +1272,7 @@ type HighScore struct {
 	Player           string
 	Score            int
 	Time             time.Time
+	WithGlitch       bool
 	DocstoreRevision interface{}
 }
 
@@ -1316,14 +1317,14 @@ const (
 )
 
 var highScores = []*HighScore{
-	{game1, "pat", 49, date(3, 13), nil},
-	{game1, "mel", 60, date(4, 10), nil},
-	{game1, "andy", 81, date(2, 1), nil},
-	{game1, "fran", 33, date(3, 19), nil},
-	{game2, "pat", 120, date(4, 1), nil},
-	{game2, "billie", 111, date(4, 10), nil},
-	{game2, "mel", 190, date(4, 18), nil},
-	{game2, "fran", 33, date(3, 20), nil},
+	{game1, "pat", 49, date(3, 13), false, nil},
+	{game1, "mel", 60, date(4, 10), false, nil},
+	{game1, "andy", 81, date(2, 1), false, nil},
+	{game1, "fran", 33, date(3, 19), false, nil},
+	{game2, "pat", 120, date(4, 1), true, nil},
+	{game2, "billie", 111, date(4, 10), false, nil},
+	{game2, "mel", 190, date(4, 18), true, nil},
+	{game2, "fran", 33, date(3, 20), false, nil},
 }
 
 func addHighScores(t *testing.T, coll *docstore.Collection) {
@@ -1486,6 +1487,11 @@ func testGetQuery(t *testing.T, _ Harness, coll *docstore.Collection) {
 			want: func(h *HighScore) bool { return h.Player != "pat" && h.Player != "billie" },
 		},
 		{
+			name: "WithGlitch",
+			q:    coll.Query().Where("WithGlitch", "=", true),
+			want: func(h *HighScore) bool { return h.WithGlitch },
+		},
+		{
 			name:   "AllByPlayerAsc",
 			q:      coll.Query().OrderBy("Player", docstore.Ascending),
 			want:   func(h *HighScore) bool { return true },
@@ -1522,13 +1528,14 @@ func testGetQuery(t *testing.T, _ Harness, coll *docstore.Collection) {
 			want: func(h *HighScore) bool {
 				h.Score = 0
 				h.Time = time.Time{}
+				h.WithGlitch = false
 				return true
 			},
 		},
 		{
 			name:   "AllWithScore",
 			q:      coll.Query(),
-			fields: []docstore.FieldPath{"Game", "Player", "Score", docstore.FieldPath(docstore.DefaultRevisionField)},
+			fields: []docstore.FieldPath{"Game", "Player", "Score", "WithGlitch", docstore.FieldPath(docstore.DefaultRevisionField)},
 			want: func(h *HighScore) bool {
 				h.Time = time.Time{}
 				return true
@@ -2118,7 +2125,7 @@ func testAs(t *testing.T, coll *docstore.Collection, st AsTest) {
 	}
 
 	// ErrorCheck
-	doc := &HighScore{game3, "steph", 24, date(4, 25), nil}
+	doc := &HighScore{game3, "steph", 24, date(4, 25), false, nil}
 	if err := coll.Create(ctx, doc); err != nil {
 		t.Fatal(err)
 	}

--- a/docstore/drivertest/drivertest.go
+++ b/docstore/drivertest/drivertest.go
@@ -1492,6 +1492,16 @@ func testGetQuery(t *testing.T, _ Harness, coll *docstore.Collection) {
 			want: func(h *HighScore) bool { return h.WithGlitch },
 		},
 		{
+			name: "WithGlitchIn",
+			q:    coll.Query().Where("WithGlitch", "in", []bool{true}),
+			want: func(h *HighScore) bool { return h.WithGlitch },
+		},
+		{
+			name: "WithGlitchNotIn",
+			q:    coll.Query().Where("WithGlitch", "not-in", []bool{true}),
+			want: func(h *HighScore) bool { return !h.WithGlitch },
+		},
+		{
 			name:   "AllByPlayerAsc",
 			q:      coll.Query().OrderBy("Player", docstore.Ascending),
 			want:   func(h *HighScore) bool { return true },

--- a/docstore/gcpfirestore/query.go
+++ b/docstore/gcpfirestore/query.go
@@ -150,6 +150,17 @@ func evaluateFilter(f driver.Filter, doc driver.Document) bool {
 		return applyComparison(f.Op, strings.Compare(lhs.String(), rhs.String()))
 	}
 
+	if lhs.Kind() == reflect.Bool {
+		if rhs.Kind() != reflect.Bool {
+			return false
+		}
+		cmp := 0
+		if lhs.Bool() != rhs.Bool() {
+			cmp = -1
+		}
+		return applyComparison(f.Op, cmp)
+	}
+
 	cmp, err := driver.CompareNumbers(lhs, rhs)
 	if err != nil {
 		return false

--- a/docstore/memdocstore/query.go
+++ b/docstore/memdocstore/query.go
@@ -149,6 +149,12 @@ func compare(x1, x2 interface{}) (int, bool) {
 			return driver.CompareTimes(t1, t2), true
 		}
 	}
+	if v1.Kind() == reflect.Bool && v2.Kind() == reflect.Bool {
+		if v1.Bool() == v2.Bool() {
+			return 0, true
+		}
+		return -1, true
+	}
 	return 0, false
 }
 

--- a/docstore/query.go
+++ b/docstore/query.go
@@ -38,7 +38,7 @@ func (c *Collection) Query() *Query {
 
 // Where expresses a condition on the query.
 // Valid ops are: "=", ">", "<", ">=", "<=, "in", "not-in".
-// Valid values are strings, integers, floating-point numbers, and time.Time values.
+// Valid values are strings, integers, floating-point numbers, time.Time and boolean (only for "=", "in" and "not-in") values.
 func (q *Query) Where(fp FieldPath, op string, value interface{}) *Query {
 	if q.err != nil {
 		return q
@@ -66,13 +66,23 @@ func (q *Query) Where(fp FieldPath, op string, value interface{}) *Query {
 type valueValidator func(interface{}) bool
 
 var validOp = map[string]valueValidator{
-	"=":      validFilterValue,
+	"=":      validEqualValue,
 	">":      validFilterValue,
 	"<":      validFilterValue,
 	">=":     validFilterValue,
 	"<=":     validFilterValue,
 	"in":     validFilterSlice,
 	"not-in": validFilterSlice,
+}
+
+func validEqualValue(v interface{}) bool {
+	if v == nil {
+		return false
+	}
+	if reflect.TypeOf(v).Kind() == reflect.Bool {
+		return true
+	}
+	return validFilterValue(v)
 }
 
 func validFilterValue(v interface{}) bool {
@@ -102,7 +112,7 @@ func validFilterSlice(v interface{}) bool {
 	}
 	vv := reflect.ValueOf(v)
 	for i := 0; i < vv.Len(); i++ {
-		if !validFilterValue(vv.Index(i).Interface()) {
+		if !validEqualValue(vv.Index(i).Interface()) {
 			return false
 		}
 	}


### PR DESCRIPTION
This PR updates Docstore to allow boolean filters in the queries, as it's supported by all the different implementations.

This isn't yet merge-able as the replay data needs to be re-generated, and I don't have the permission to do it.

I have tested it with Firestore, the local version of MongoDB but haven't tested it with AWS or Azure as I don't have an account.
