### PR TITLE
samples/guestbook/localdb/main.go: add docker platform flag

### DIFF
--- a/samples/guestbook/localdb/main.go
+++ b/samples/guestbook/localdb/main.go
@@ -53,6 +53,7 @@ func runLocalDB(containerName, guestbookDir string) error {
 		dockerArgs = append(dockerArgs, "--name", containerName)
 	}
 	dockerArgs = append(dockerArgs,
+		"--platform", "linux/amd64",
 		"--env", "MYSQL_DATABASE=guestbook",
 		"--env", "MYSQL_ROOT_PASSWORD=password",
 		"--detach",


### PR DESCRIPTION
Code didn't run on my m1 macbook pro, getting
```
$ go run localdb/main.go
go: downloading gopkg.in/pipe.v2 v2.0.0-20140414041502-3c2ca4d52544
localdb: Starting container running MySQL
Unable to find image 'mysql:5.6' locally
docker: Error response from daemon: no match for platform in manifest: not found.
See 'docker run --help'.
localdb: running [docker run --rm --env MYSQL_DATABASE=guestbook --env MYSQL_ROOT_PASSWORD=password --detach --publish 3306:3306 mysql:5.6]: exit status 125:
exit status 1
```

That's because mysql:5.6 only had a linux/amd64 image (https://hub.docker.com/layers/library/mysql/5.6/images/sha256-897086d07d1efa876224b147397ea8d3147e61dd84dce963aace1d5e9dc2802d?context=explore). Adding the platform flag tells docker to download it anyways, even on a mac. 

I always use this trick but honestly not sure why amd64 images run on m1 chips. Maybe there's no meaningful difference? Maybe its because of Rosetta? Or maybe I'll eventually hit a bug because some features are not available when running on different arch?

Please use a title starting with the name of the affected package, or \"all\",
followed by a colon, followed by a short summary of the issue. Example:
`blob/gcsblob: fix typo in documentation`.

Please reference any Issue related to this Pull Request. Example: `Fixes #1`.

See
[here](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
for tips on good Pull Request description.
