### PR TITLE
blob/s3blob: custom endpoints with s3 and aws sdk v2

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -202,19 +202,18 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 		default:
 			return awsv2.Config{}, fmt.Errorf("unknown query parameter %q", param)
 		}
-
-		if endpoint != "" {
-			customResolver := awsv2.EndpointResolverWithOptionsFunc(
-				func(service, region string, options ...interface{}) (awsv2.Endpoint, error) {
-					return awsv2.Endpoint{
-						PartitionID:       "aws",
-						URL:               endpoint,
-						SigningRegion:     region,
-						HostnameImmutable: hostnameImmutable,
-					}, nil
-				})
-			opts = append(opts, awsv2cfg.WithEndpointResolverWithOptions(customResolver))
-		}
+	}
+	if endpoint != "" {
+		customResolver := awsv2.EndpointResolverWithOptionsFunc(
+			func(service, region string, options ...interface{}) (awsv2.Endpoint, error) {
+				return awsv2.Endpoint{
+					PartitionID:       "aws",
+					URL:               endpoint,
+					SigningRegion:     region,
+					HostnameImmutable: hostnameImmutable,
+				}, nil
+			})
+		opts = append(opts, awsv2cfg.WithEndpointResolverWithOptions(customResolver))
 	}
 	return awsv2cfg.LoadDefaultConfig(ctx, opts...)
 }

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -177,6 +177,7 @@ func NewDefaultV2Config(ctx context.Context) (awsv2.Config, error) {
 //   - region: The AWS region for requests; sets WithRegion.
 //   - profile: The shared config profile to use; sets SharedConfigProfile.
 //   - endpoint: The AWS service endpoint to send HTTP request.
+//   - hostname_immutable: Make the hostname immutable, only works if endpoint is also set.
 func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, error) {
 	var endpoint string
 	var hostnameImmutable bool
@@ -184,11 +185,11 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 	for param, values := range q {
 		value := values[0]
 		switch param {
-		case "awsHostnameImmutable":
+		case "hostname_immutable":
 			var err error
 			hostnameImmutable, err = strconv.ParseBool(value)
 			if err != nil {
-				return awsv2.Config{}, err
+				return awsv2.Config{}, fmt.Errorf("invalid value for hostname_immutable: %w", err)
 			}
 		case "region":
 			opts = append(opts, awsv2cfg.WithRegion(value))

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -188,9 +188,10 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 			customResolver := awsv2.EndpointResolverWithOptionsFunc(
 				func(service, region string, options ...interface{}) (awsv2.Endpoint, error) {
 					return awsv2.Endpoint{
-						PartitionID:   "aws",
-						URL:           value,
-						SigningRegion: region,
+						PartitionID:       "aws",
+						URL:               value,
+						SigningRegion:     region,
+						HostnameImmutable: true,
 					}, nil
 				})
 			opts = append(opts, awsv2cfg.WithEndpointResolverWithOptions(customResolver))

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -17,8 +17,10 @@ package aws_test
 import (
 	"context"
 	"net/url"
+	"reflect"
 	"testing"
 
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/google/go-cmp/cmp"
 	gcaws "gocloud.dev/aws"
@@ -147,12 +149,16 @@ func TestUseV2(t *testing.T) {
 }
 
 func TestV2ConfigFromURLParams(t *testing.T) {
+	const service = "s3"
+	const region = "us-east-1"
+	const partitionID = "aws"
 	ctx := context.Background()
 	tests := []struct {
-		name       string
-		query      url.Values
-		wantRegion string
-		wantErr    bool
+		name         string
+		query        url.Values
+		wantRegion   string
+		wantErr      bool
+		wantEndpoint *awsv2.Endpoint
 	}{
 		{
 			name:  "No overrides",
@@ -167,6 +173,16 @@ func TestV2ConfigFromURLParams(t *testing.T) {
 			name:       "Region",
 			query:      url.Values{"region": {"my_region"}},
 			wantRegion: "my_region",
+		},
+		{
+			name:  "Endpoint and hostname immutable",
+			query: url.Values{"endpoint": {"foo"}, "awsHostnameImmutable": {"true"}},
+			wantEndpoint: &awsv2.Endpoint{
+				PartitionID:       partitionID,
+				SigningRegion:     region,
+				URL:               "foo",
+				HostnameImmutable: true,
+			},
 		},
 		// Can't test "profile", since AWS validates that the profile exists.
 	}
@@ -183,6 +199,19 @@ func TestV2ConfigFromURLParams(t *testing.T) {
 			}
 			if test.wantRegion != "" && got.Region != test.wantRegion {
 				t.Errorf("got region %q, want %q", got.Region, test.wantRegion)
+			}
+
+			if test.wantEndpoint != nil {
+				if got.EndpointResolverWithOptions == nil {
+					t.Fatalf("expected an EndpointResolverWithOptions, got nil")
+				}
+				gotE, err := got.EndpointResolverWithOptions.ResolveEndpoint(service, region)
+				if err != nil {
+					return
+				}
+				if !reflect.DeepEqual(gotE, *test.wantEndpoint) {
+					t.Errorf("got endpoint %+v, want %+v", gotE, *test.wantEndpoint)
+				}
 			}
 		})
 	}

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -176,7 +176,7 @@ func TestV2ConfigFromURLParams(t *testing.T) {
 		},
 		{
 			name:  "Endpoint and hostname immutable",
-			query: url.Values{"endpoint": {"foo"}, "awsHostnameImmutable": {"true"}},
+			query: url.Values{"endpoint": {"foo"}, "hostname_immutable": {"true"}},
 			wantEndpoint: &awsv2.Endpoint{
 				PartitionID:       partitionID,
 				SigningRegion:     region,


### PR DESCRIPTION
It seems that this is needed in aws-sdk-v2 for minio to work.

see: https://github.com/minio/docs/issues/406#issuecomment-1246316964
refs https://github.com/google/go-cloud/issues/3472