### PR TITLE
blob/all: Don't require SetIOFSCallback be called to use io/fs.FS functions

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -693,7 +693,8 @@ var NewBucket = newBucket
 // function; see the package documentation for details.
 func newBucket(b driver.Bucket) *Bucket {
 	return &Bucket{
-		b: b,
+		b:            b,
+		ioFSCallback: func() (context.Context, *ReaderOptions) { return context.Background(), nil },
 		tracer: &oc.Tracer{
 			Package:        pkgName,
 			Provider:       oc.ProviderName(b),

--- a/blob/blob_fs.go
+++ b/blob/blob_fs.go
@@ -158,17 +158,15 @@ func (d *iofsDir) openOnce() error {
 //
 // fn should return a context.Context and *ReaderOptions that can be used in
 // calls to List and NewReader on b. It may be called more than once.
+//
+// If SetIOFSCallback is never called, io.FS functions will use context.Background
+// and a default ReaderOptions.
 func (b *Bucket) SetIOFSCallback(fn func() (context.Context, *ReaderOptions)) {
 	b.ioFSCallback = fn
 }
 
 // Open implements fs.FS.Open (https://pkg.go.dev/io/fs#FS).
-//
-// SetIOFSCallback must be called prior to calling this function.
 func (b *Bucket) Open(path string) (fs.File, error) {
-	if b.ioFSCallback == nil {
-		return nil, gcerr.Newf(gcerr.InvalidArgument, nil, "blob: Open -- SetIOFSCallback must be called before Open")
-	}
 	if !fs.ValidPath(path) {
 		return nil, &fs.PathError{Op: "open", Path: path, Err: fs.ErrInvalid}
 	}

--- a/blob/blob_fs_test.go
+++ b/blob/blob_fs_test.go
@@ -42,7 +42,6 @@ func initBucket(t *testing.T, files []string) *blob.Bucket {
 	ctx := context.Background()
 
 	b := memblob.OpenBucket(nil)
-	b.SetIOFSCallback(func() (context.Context, *blob.ReaderOptions) { return ctx, nil })
 	for _, f := range files {
 		if err := b.WriteAll(ctx, f, []byte("data"), nil); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Fixes #3474.