### PR TITLE
blob/s3blob: fix data race

### DIFF
--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -380,7 +380,6 @@ func (w *writer) open(r io.Reader, closePipeOnError bool) {
 		if err != nil {
 			if closePipeOnError {
 				w.pr.CloseWithError(err)
-				w.pr = nil
 			}
 			w.err = err
 		}


### PR DESCRIPTION
w.pr cannot be used to indicate that the pipe has been closed. Instead, we use an atomic.Bool. The problem with using w.pr is that a write to it in the goroutine launched by writer.open can race with a read on w.pr in Close.

Note that it's still possible that w.pr.CloseWithError runs concurrently with w.pr.Close. But this is fine.
