### PR TITLE
blob/azblob: Support AZURE_STORAGEBLOB_CONNECTIONSTRING as an alternative for AZURE_STORAGE_CONNECTION_STRING

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -34,7 +34,7 @@
 //   - AZURE_STORAGE_KEY: To use a shared key credential. The service account
 //     name and key are passed to NewSharedKeyCredential and then the
 //     resulting credential is passed to NewClientWithSharedKeyCredential.
-//   - AZURE_STORAGE_CONNECTION_STRING: To use a connection string, passed to
+//   - AZURE_STORAGE_CONNECTION_STRING or AZURE_STORAGEBLOB_CONNECTIONSTRING: To use a connection string, passed to
 //     NewClientFromConnectionString.
 //   - AZURE_STORAGE_SAS_TOKEN: To use a SAS token. The SAS token is added
 //     as a URL parameter to the service URL, and passed to
@@ -320,6 +320,9 @@ func newCredInfoFromEnv() *credInfoT {
 	accountKey := os.Getenv("AZURE_STORAGE_KEY")
 	sasToken := os.Getenv("AZURE_STORAGE_SAS_TOKEN")
 	connectionString := os.Getenv("AZURE_STORAGE_CONNECTION_STRING")
+	if connectionString == "" {
+		connectionString = os.Getenv("AZURE_STORAGEBLOB_CONNECTIONSTRING")
+	}
 	credInfo := &credInfoT{
 		AccountName: accountName,
 	}

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -311,14 +311,15 @@ func TestOpenBucket(t *testing.T) {
 
 func TestOpenerFromEnv(t *testing.T) {
 	tests := []struct {
-		accountName      string
-		accountKey       string
-		sasToken         string
-		connectionString string
-		domain           string
-		protocol         string
-		isCDN            bool
-		isLocalEmulator  bool
+		accountName       string
+		accountKey        string
+		sasToken          string
+		connectionString  string
+		connectionString2 string
+		domain            string
+		protocol          string
+		isCDN             bool
+		isLocalEmulator   bool
 
 		want     *credInfoT
 		wantOpts *ServiceURLOptions
@@ -353,6 +354,19 @@ func TestOpenerFromEnv(t *testing.T) {
 			// Connection string.
 			accountName:      "myaccount",
 			connectionString: "a-connection-string",
+			want: &credInfoT{
+				CredType:         credTypeConnectionString,
+				AccountName:      "myaccount",
+				ConnectionString: "a-connection-string",
+			},
+			wantOpts: &ServiceURLOptions{
+				AccountName: "myaccount",
+			},
+		},
+		{
+			// Alternate connection string.
+			accountName:       "myaccount",
+			connectionString2: "a-connection-string",
 			want: &credInfoT{
 				CredType:         credTypeConnectionString,
 				AccountName:      "myaccount",
@@ -407,6 +421,7 @@ func TestOpenerFromEnv(t *testing.T) {
 		t.Setenv("AZURE_STORAGE_KEY", test.accountKey)
 		t.Setenv("AZURE_STORAGE_SAS_TOKEN", test.sasToken)
 		t.Setenv("AZURE_STORAGE_CONNECTION_STRING", test.connectionString)
+		t.Setenv("AZURE_STORAGEBLOB_CONNECTIONSTRING", test.connectionString2)
 		t.Setenv("AZURE_STORAGE_DOMAIN", test.domain)
 		t.Setenv("AZURE_STORAGE_PROTOCOL", test.protocol)
 		if test.isCDN {


### PR DESCRIPTION
Fixes #3482.