### PR TITLE
s3blob/blob: support additional endpoint query parameters

### DIFF
--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -184,6 +184,10 @@ func TestV2ConfigFromURLParams(t *testing.T) {
 				HostnameImmutable: true,
 			},
 		},
+		{
+			name:  "FIPS and dual stack",
+			query: url.Values{"fips": {"true"}, "dualstack": {"true"}},
+		},
 		// Can't test "profile", since AWS validates that the profile exists.
 	}
 

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -476,6 +476,26 @@ func TestOpenBucketFromURL(t *testing.T) {
 		{"s3://mybucket?awssdk=v2", false},
 		// OK, use KMS Server Side Encryption
 		{"s3://mybucket?ssetype=aws:kms&kmskeyid=arn:aws:us-east-1:12345:key/1-a-2-b", false},
+		// OK, use S3 Transfer acceleration and dual stack endpoints
+		{"s3://mybucket?accelerate=true&dualstack=true", false},
+		// OK, use FIPS endpoints
+		{"s3://mybucket?fips=true", false},
+		// OK, use S3 Transfer accleration and dual stack endpoints (v1)
+		{"s3://mybucket?awssdk=v1&accelerate=true&dualstack=true", false},
+		// OK, use FIPS endpoints (v1)
+		{"s3://mybucket?awssdk=v1&fips=true", false},
+		// Invalid accelerate (v1)
+		{"s3://mybucket?awssdk=v1&accelerate=bogus", true},
+		// Invalid accelerate (v2)
+		{"s3://mybucket?accelerate=bogus", true},
+		// Invalid FIPS (v1)
+		{"s3://mybucket?awssdk=v1&fips=bogus", true},
+		// Invalid FIPS (v2)
+		{"s3://mybucket?fips=bogus", true},
+		// Invalid dualstack (v1)
+		{"s3://mybucket?awssdk=v1&dualstack=bad", true},
+		// Invalid dualstack (v2)
+		{"s3://mybucket?dualstack=bad", true},
 		// Invalid ssetype
 		{"s3://mybucket?ssetype=aws:notkmsoraes&kmskeyid=arn:aws:us-east-1:12345:key/1-a-2-b", true},
 		// Invalid parameter together with a valid one.


### PR DESCRIPTION
This commit adds the following query parameters for AWS:

1. `dualstack`
2. `fips`
3. `accelerate` (S3-only)

This avoids the need for users to specify `endpoint`. For example, if my AWS S3 bucket is `my-bucket` in `us-east-1`, and you want to enable transfer acceleration, dual-stack support, and/or FIPS, you would need to configure `endpoint` with one of the following:

1. `my-bucket.s3-accelerate.amazonaws.com`
2. `my-bucket.s3-accelerate.dualstack.amazonaws.com`
3. `my-bucket.s3-fips.us-gov-east-1.amazonaws.com`
4. `my-bucket.s3-fips.dualstack.us-east-1.amazonaws.com`

For example, for the last option, users can use `s3://my-bucket?fips=true&dualstack=true`.

Closes https://github.com/google/go-cloud/issues/3484
