### PR TITLE
blob: change howto docs to reflect awssdk=v2 is the default as of 0.39.

### DIFF
--- a/internal/website/content/howto/blob/_index.md
+++ b/internal/website/content/howto/blob/_index.md
@@ -218,7 +218,7 @@ alternatives, including using environment variables.
 If you set the "awssdk=v2" query parameter, it will instead create an AWS
 Config based on the AWS SDK V2; see [AWS V2 Config][] to learn more.
 
-If no "awssdk" query parameter is set, Go CDK will use a default (currently V1).
+If no "awssdk" query parameter is set, Go CDK will use a default (currently V2).
 
 Full details about acceptable URLs can be found under the API reference for
 [`s3blob.URLOpener`][].


### PR DESCRIPTION
One-character fix to docs. 