### PR TITLE
Add disableHTTPS and usePathStyle s3v2.Options as query param

### DIFF
--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -482,6 +482,10 @@ func TestOpenBucketFromURL(t *testing.T) {
 		{"s3://mybucket?fips=true", false},
 		// OK, use S3 Transfer accleration and dual stack endpoints (v1)
 		{"s3://mybucket?awssdk=v1&accelerate=true&dualstack=true", false},
+		// OK, use use_path_style
+		{"s3://mybucket?use_path_style=true", false},
+		// OK, use disable_https
+		{"s3://mybucket?disable_https=true", false},
 		// OK, use FIPS endpoints (v1)
 		{"s3://mybucket?awssdk=v1&fips=true", false},
 		// Invalid accelerate (v1)
@@ -500,6 +504,10 @@ func TestOpenBucketFromURL(t *testing.T) {
 		{"s3://mybucket?ssetype=aws:notkmsoraes&kmskeyid=arn:aws:us-east-1:12345:key/1-a-2-b", true},
 		// Invalid parameter together with a valid one.
 		{"s3://mybucket?profile=main&param=value", true},
+		// Invalid use_path_style (v1)
+		{"s3://mybucket?awssdk=v1&usePathStyle=bad", true},
+		// Invalid disable_https (v2)
+		{"s3://mybucket?usePathStyle=bad", true},
 		// Invalid parameter.
 		{"s3://mybucket?param=value", true},
 	}


### PR DESCRIPTION
This ensures that we can use blob/blob with s3 compatible storage like minio.
Pass `usePathStyle=true` to force PathStyle for s3. Pass `disableHTTPS=true` to disable tls for endpoint.

Please use a title starting with the name of the affected package, or \"all\",
followed by a colon, followed by a short summary of the issue. Example:
`blob/gcsblob: fix typo in documentation`.

Fixes: https://github.com/google/go-cloud/issues/3490
