### PR TITLE
all: rename interface{} to any

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -262,7 +262,7 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 	}
 	if endpoint != "" {
 		customResolver := awsv2.EndpointResolverWithOptionsFunc(
-			func(service, region string, options ...interface{}) (awsv2.Endpoint, error) {
+			func(service, region string, options ...any) (awsv2.Endpoint, error) {
 				return awsv2.Endpoint{
 					PartitionID:       "aws",
 					URL:               endpoint,

--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -468,7 +468,7 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 	srcBlobClient := b.client.NewBlobClient(srcKey)
 	copyOptions := &azblobblob.StartCopyFromURLOptions{}
 	if opts.BeforeCopy != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			switch v := i.(type) {
 			case **azblobblob.StartCopyFromURLOptions:
 				*v = copyOptions
@@ -533,7 +533,7 @@ func (r *reader) Attributes() *driver.ReaderAttributes {
 	return &r.attrs
 }
 
-func (r *reader) As(i interface{}) bool {
+func (r *reader) As(i any) bool {
 	p, ok := i.(*azblobblob.DownloadStreamResponse)
 	if !ok {
 		return false
@@ -554,7 +554,7 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 		downloadOpts.Range.Count = length
 	}
 	if opts.BeforeRead != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			if p, ok := i.(**azblobblob.DownloadStreamOptions); ok {
 				*p = &downloadOpts
 				return true
@@ -608,7 +608,7 @@ func getSize(contentLength *int64, contentRange string) int64 {
 }
 
 // As implements driver.As.
-func (b *bucket) As(i interface{}) bool {
+func (b *bucket) As(i any) bool {
 	p, ok := i.(**container.Client)
 	if !ok {
 		return false
@@ -618,7 +618,7 @@ func (b *bucket) As(i interface{}) bool {
 }
 
 // As implements driver.ErrorAs.
-func (b *bucket) ErrorAs(err error, i interface{}) bool {
+func (b *bucket) ErrorAs(err error, i any) bool {
 	switch v := err.(type) {
 	case *azcore.ResponseError:
 		if p, ok := i.(**azcore.ResponseError); ok {
@@ -687,7 +687,7 @@ func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes
 		MD5:                blobPropertiesResponse.ContentMD5,
 		ETag:               eTag,
 		Metadata:           md,
-		AsFunc: func(i interface{}) bool {
+		AsFunc: func(i any) bool {
 			p, ok := i.(*azblobblob.GetPropertiesResponse)
 			if !ok {
 				return false
@@ -719,7 +719,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 		Marker:     marker,
 	}
 	if opts.BeforeList != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			p, ok := i.(**container.ListBlobsHierarchyOptions)
 			if !ok {
 				return false
@@ -745,7 +745,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 			Key:   unescapeKey(to.String(blobPrefix.Name)),
 			Size:  0,
 			IsDir: true,
-			AsFunc: func(i interface{}) bool {
+			AsFunc: func(i any) bool {
 				v, ok := i.(*container.BlobPrefix)
 				if ok {
 					*v = *blobPrefix
@@ -762,7 +762,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 			Size:    *blobInfo.Properties.ContentLength,
 			MD5:     blobInfo.Properties.ContentMD5,
 			IsDir:   false,
-			AsFunc: func(i interface{}) bool {
+			AsFunc: func(i any) bool {
 				v, ok := i.(*container.BlobItem)
 				if ok {
 					*v = *blobInfo
@@ -804,7 +804,7 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 	}
 
 	if opts.BeforeSign != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			v, ok := i.(**sas.BlobPermissions)
 			if ok {
 				*v = &perms
@@ -914,7 +914,7 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key, contentType string, op
 		},
 	}
 	if opts.BeforeWrite != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			p, ok := i.(**azblob.UploadStreamOptions)
 			if !ok {
 				return false

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -184,7 +184,7 @@ func (verifyContentLanguage) ErrorCheck(b *blob.Bucket, err error) error {
 	return nil
 }
 
-func (verifyContentLanguage) BeforeRead(as func(interface{}) bool) error {
+func (verifyContentLanguage) BeforeRead(as func(any) bool) error {
 	var u *azblob.DownloadStreamOptions
 	if !as(&u) {
 		return fmt.Errorf("BeforeRead As failed to get %T", u)
@@ -192,7 +192,7 @@ func (verifyContentLanguage) BeforeRead(as func(interface{}) bool) error {
 	return nil
 }
 
-func (verifyContentLanguage) BeforeWrite(as func(interface{}) bool) error {
+func (verifyContentLanguage) BeforeWrite(as func(any) bool) error {
 	var azOpts *azblob.UploadStreamOptions
 	if !as(&azOpts) {
 		return errors.New("Writer.As failed")
@@ -201,7 +201,7 @@ func (verifyContentLanguage) BeforeWrite(as func(interface{}) bool) error {
 	return nil
 }
 
-func (verifyContentLanguage) BeforeCopy(as func(interface{}) bool) error {
+func (verifyContentLanguage) BeforeCopy(as func(any) bool) error {
 	var co *azblobblob.StartCopyFromURLOptions
 	if !as(&co) {
 		return errors.New("BeforeCopy.As failed")
@@ -209,7 +209,7 @@ func (verifyContentLanguage) BeforeCopy(as func(interface{}) bool) error {
 	return nil
 }
 
-func (verifyContentLanguage) BeforeList(as func(interface{}) bool) error {
+func (verifyContentLanguage) BeforeList(as func(any) bool) error {
 	var azOpts *container.ListBlobsHierarchyOptions
 	if !as(&azOpts) {
 		return errors.New("BeforeList.As failed")
@@ -217,7 +217,7 @@ func (verifyContentLanguage) BeforeList(as func(interface{}) bool) error {
 	return nil
 }
 
-func (verifyContentLanguage) BeforeSign(as func(interface{}) bool) error {
+func (verifyContentLanguage) BeforeSign(as func(any) bool) error {
 	var azOpts *sas.BlobPermissions
 	if !as(&azOpts) {
 		return errors.New("BeforeSign.As failed")

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -226,7 +226,7 @@ func (r *Reader) Size() int64 {
 // See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the driver package
 // documentation for the specific types supported for that driver.
-func (r *Reader) As(i interface{}) bool {
+func (r *Reader) As(i any) bool {
 	return r.r.As(i)
 }
 
@@ -339,14 +339,14 @@ type Attributes struct {
 	// ETag for the blob; see https://en.wikipedia.org/wiki/HTTP_ETag.
 	ETag string
 
-	asFunc func(interface{}) bool
+	asFunc func(any) bool
 }
 
 // As converts i to driver-specific types.
 // See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the driver package
 // documentation for the specific types supported for that driver.
-func (a *Attributes) As(i interface{}) bool {
+func (a *Attributes) As(i any) bool {
 	if a.asFunc == nil {
 		return false
 	}
@@ -556,7 +556,7 @@ type ListOptions struct {
 	// the underlying service's list functionality.
 	// asFunc converts its argument to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	BeforeList func(asFunc func(interface{}) bool) error
+	BeforeList func(asFunc func(any) bool) error
 }
 
 // ListIterator iterates over List results.
@@ -623,14 +623,14 @@ type ListObject struct {
 	// Fields other than Key and IsDir will not be set if IsDir is true.
 	IsDir bool
 
-	asFunc func(interface{}) bool
+	asFunc func(any) bool
 }
 
 // As converts i to driver-specific types.
 // See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the driver package
 // documentation for the specific types supported for that driver.
-func (o *ListObject) As(i interface{}) bool {
+func (o *ListObject) As(i any) bool {
 	if o.asFunc == nil {
 		return false
 	}
@@ -707,7 +707,7 @@ func newBucket(b driver.Bucket) *Bucket {
 // See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the driver package
 // documentation for the specific types supported for that driver.
-func (b *Bucket) As(i interface{}) bool {
+func (b *Bucket) As(i any) bool {
 	if i == nil {
 		return false
 	}
@@ -718,7 +718,7 @@ func (b *Bucket) As(i interface{}) bool {
 // ErrorAs panics if i is nil or not a pointer.
 // ErrorAs returns false if err == nil.
 // See https://gocloud.dev/concepts/as/ for background information.
-func (b *Bucket) ErrorAs(err error, i interface{}) bool {
+func (b *Bucket) ErrorAs(err error, i any) bool {
 	return gcerr.ErrorAs(err, i, b.b.ErrorAs)
 }
 
@@ -1330,7 +1330,7 @@ type SignedURLOptions struct {
 	// the underlying service's sign functionality.
 	// asFunc converts its argument to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	BeforeSign func(asFunc func(interface{}) bool) error
+	BeforeSign func(asFunc func(any) bool) error
 }
 
 // ReaderOptions sets options for NewReader and NewRangeReader.
@@ -1344,7 +1344,7 @@ type ReaderOptions struct {
 	//
 	// asFunc converts its argument to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	BeforeRead func(asFunc func(interface{}) bool) error
+	BeforeRead func(asFunc func(any) bool) error
 }
 
 // WriterOptions sets options for NewWriter.
@@ -1421,7 +1421,7 @@ type WriterOptions struct {
 	//
 	// asFunc converts its argument to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	BeforeWrite func(asFunc func(interface{}) bool) error
+	BeforeWrite func(asFunc func(any) bool) error
 }
 
 // CopyOptions sets options for Copy.
@@ -1431,7 +1431,7 @@ type CopyOptions struct {
 	//
 	// asFunc converts its argument to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	BeforeCopy func(asFunc func(interface{}) bool) error
+	BeforeCopy func(asFunc func(any) bool) error
 }
 
 // BucketURLOpener represents types that can open buckets based on a URL.

--- a/blob/blob_fs.go
+++ b/blob/blob_fs.go
@@ -44,7 +44,7 @@ func (f *iofsFileInfo) Size() int64                { return f.lo.Size }
 func (f *iofsFileInfo) Mode() fs.FileMode          { return fs.ModeIrregular }
 func (f *iofsFileInfo) ModTime() time.Time         { return f.lo.ModTime }
 func (f *iofsFileInfo) IsDir() bool                { return false }
-func (f *iofsFileInfo) Sys() interface{}           { return f.lo }
+func (f *iofsFileInfo) Sys() any                   { return f.lo }
 func (f *iofsFileInfo) Info() (fs.FileInfo, error) { return f, nil }
 func (f *iofsFileInfo) Type() fs.FileMode          { return fs.ModeIrregular }
 
@@ -58,7 +58,7 @@ type iofsOpenFile struct {
 func (f *iofsOpenFile) Name() string               { return f.name }
 func (f *iofsOpenFile) Mode() fs.FileMode          { return fs.ModeIrregular }
 func (f *iofsOpenFile) IsDir() bool                { return false }
-func (f *iofsOpenFile) Sys() interface{}           { return f.r }
+func (f *iofsOpenFile) Sys() any                   { return f.r }
 func (f *iofsOpenFile) Stat() (fs.FileInfo, error) { return f, nil }
 
 // iofsDir describes a single directory in an io/fs.FS.
@@ -83,7 +83,7 @@ func (d *iofsDir) Mode() fs.FileMode          { return fs.ModeDir }
 func (d *iofsDir) Type() fs.FileMode          { return fs.ModeDir }
 func (d *iofsDir) ModTime() time.Time         { return time.Time{} }
 func (d *iofsDir) IsDir() bool                { return true }
-func (d *iofsDir) Sys() interface{}           { return d }
+func (d *iofsDir) Sys() any                   { return d }
 func (d *iofsDir) Info() (fs.FileInfo, error) { return d, nil }
 func (d *iofsDir) Stat() (fs.FileInfo, error) { return d, nil }
 func (d *iofsDir) Read([]byte) (int, error) {

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -34,7 +34,7 @@ type ReaderOptions struct {
 	// which case it should not be called at all.
 	// asFunc allows drivers to expose driver-specific types;
 	// see Bucket.As for more details.
-	BeforeRead func(asFunc func(interface{}) bool) error
+	BeforeRead func(asFunc func(any) bool) error
 }
 
 // Reader reads an object from the blob.
@@ -47,7 +47,7 @@ type Reader interface {
 
 	// As allows drivers to expose driver-specific types;
 	// see Bucket.As for more details.
-	As(interface{}) bool
+	As(any) bool
 }
 
 // Downloader has an optional extra method for readers.
@@ -109,7 +109,7 @@ type WriterOptions struct {
 	// which case it should not be called.
 	// asFunc allows drivers to expose driver-specific types;
 	// see Bucket.As for more details.
-	BeforeWrite func(asFunc func(interface{}) bool) error
+	BeforeWrite func(asFunc func(any) bool) error
 }
 
 // CopyOptions controls options for Copy.
@@ -117,7 +117,7 @@ type CopyOptions struct {
 	// BeforeCopy is a callback that must be called before initiating the Copy.
 	// asFunc allows drivers to expose driver-specific types;
 	// see Bucket.As for more details.
-	BeforeCopy func(asFunc func(interface{}) bool) error
+	BeforeCopy func(asFunc func(any) bool) error
 }
 
 // ReaderAttributes contains a subset of attributes about a blob that are
@@ -171,7 +171,7 @@ type Attributes struct {
 	// AsFunc allows drivers to expose driver-specific types;
 	// see Bucket.As for more details.
 	// If not set, no driver-specific types are supported.
-	AsFunc func(interface{}) bool
+	AsFunc func(any) bool
 }
 
 // ListOptions sets options for listing objects in the bucket.
@@ -202,7 +202,7 @@ type ListOptions struct {
 	// before the underlying service's list is executed.
 	// asFunc allows drivers to expose driver-specific types;
 	// see Bucket.As for more details.
-	BeforeList func(asFunc func(interface{}) bool) error
+	BeforeList func(asFunc func(any) bool) error
 }
 
 // ListObject represents a specific blob object returned from ListPaged.
@@ -223,7 +223,7 @@ type ListObject struct {
 	// AsFunc allows drivers to expose driver-specific types;
 	// see Bucket.As for more details.
 	// If not set, no driver-specific types are supported.
-	AsFunc func(interface{}) bool
+	AsFunc func(any) bool
 }
 
 // ListPage represents a page of results return from ListPaged.
@@ -252,12 +252,12 @@ type Bucket interface {
 
 	// As converts i to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	As(i interface{}) bool
+	As(i any) bool
 
 	// ErrorAs allows drivers to expose driver-specific types for returned
 	// errors.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	ErrorAs(error, interface{}) bool
+	ErrorAs(error, any) bool
 
 	// Attributes returns attributes for the blob. If the specified object does
 	// not exist, Attributes must return an error for which ErrorCode returns
@@ -368,7 +368,7 @@ type SignedURLOptions struct {
 	// the underlying service's sign functionality.
 	// asFunc converts its argument to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	BeforeSign func(asFunc func(interface{}) bool) error
+	BeforeSign func(asFunc func(any) bool) error
 }
 
 // prefixedBucket implements Bucket by prepending prefix to all keys.
@@ -384,8 +384,8 @@ func NewPrefixedBucket(b Bucket, prefix string) Bucket {
 }
 
 func (b *prefixedBucket) ErrorCode(err error) gcerrors.ErrorCode { return b.base.ErrorCode(err) }
-func (b *prefixedBucket) As(i interface{}) bool                  { return b.base.As(i) }
-func (b *prefixedBucket) ErrorAs(err error, i interface{}) bool  { return b.base.ErrorAs(err, i) }
+func (b *prefixedBucket) As(i any) bool                          { return b.base.As(i) }
+func (b *prefixedBucket) ErrorAs(err error, i any) bool          { return b.base.ErrorAs(err, i) }
 func (b *prefixedBucket) Attributes(ctx context.Context, key string) (*Attributes, error) {
 	return b.base.Attributes(ctx, b.prefix+key)
 }
@@ -442,8 +442,8 @@ func NewSingleKeyBucket(b Bucket, key string) Bucket {
 }
 
 func (b *singleKeyBucket) ErrorCode(err error) gcerrors.ErrorCode { return b.base.ErrorCode(err) }
-func (b *singleKeyBucket) As(i interface{}) bool                  { return b.base.As(i) }
-func (b *singleKeyBucket) ErrorAs(err error, i interface{}) bool  { return b.base.ErrorAs(err, i) }
+func (b *singleKeyBucket) As(i any) bool                          { return b.base.As(i) }
+func (b *singleKeyBucket) ErrorAs(err error, i any) bool          { return b.base.ErrorAs(err, i) }
 func (b *singleKeyBucket) Attributes(ctx context.Context, _ string) (*Attributes, error) {
 	return b.base.Attributes(ctx, b.key)
 }

--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -102,19 +102,19 @@ type AsTest interface {
 	ErrorCheck(b *blob.Bucket, err error) error
 	// BeforeRead will be passed directly to ReaderOptions as part of reading
 	// a test blob.
-	BeforeRead(as func(interface{}) bool) error
+	BeforeRead(as func(any) bool) error
 	// BeforeWrite will be passed directly to WriterOptions as part of creating
 	// a test blob.
-	BeforeWrite(as func(interface{}) bool) error
+	BeforeWrite(as func(any) bool) error
 	// BeforeCopy will be passed directly to CopyOptions as part of copying
 	// the test blob.
-	BeforeCopy(as func(interface{}) bool) error
+	BeforeCopy(as func(any) bool) error
 	// BeforeList will be passed directly to ListOptions as part of listing the
 	// test blob.
-	BeforeList(as func(interface{}) bool) error
+	BeforeList(as func(any) bool) error
 	// BeforeSign will be passed directly to SignedURLOptions as part of
 	// generating a signed URL to the test blob.
-	BeforeSign(as func(interface{}) bool) error
+	BeforeSign(as func(any) bool) error
 	// AttributesCheck will be called after fetching the test blob's attributes.
 	// It should call attrs.As and verify the results.
 	AttributesCheck(attrs *blob.Attributes) error
@@ -149,35 +149,35 @@ func (verifyAsFailsOnNil) ErrorCheck(b *blob.Bucket, err error) (ret error) {
 	return nil
 }
 
-func (verifyAsFailsOnNil) BeforeRead(as func(interface{}) bool) error {
+func (verifyAsFailsOnNil) BeforeRead(as func(any) bool) error {
 	if as(nil) {
 		return errors.New("want BeforeReader's As to return false when passed nil")
 	}
 	return nil
 }
 
-func (verifyAsFailsOnNil) BeforeWrite(as func(interface{}) bool) error {
+func (verifyAsFailsOnNil) BeforeWrite(as func(any) bool) error {
 	if as(nil) {
 		return errors.New("want BeforeWrite's As to return false when passed nil")
 	}
 	return nil
 }
 
-func (verifyAsFailsOnNil) BeforeCopy(as func(interface{}) bool) error {
+func (verifyAsFailsOnNil) BeforeCopy(as func(any) bool) error {
 	if as(nil) {
 		return errors.New("want BeforeCopy's As to return false when passed nil")
 	}
 	return nil
 }
 
-func (verifyAsFailsOnNil) BeforeList(as func(interface{}) bool) error {
+func (verifyAsFailsOnNil) BeforeList(as func(any) bool) error {
 	if as(nil) {
 		return errors.New("want BeforeList's As to return false when passed nil")
 	}
 	return nil
 }
 
-func (verifyAsFailsOnNil) BeforeSign(as func(interface{}) bool) error {
+func (verifyAsFailsOnNil) BeforeSign(as func(any) bool) error {
 	if as(nil) {
 		return errors.New("want BeforeSign's As to return false when passed nil")
 	}

--- a/blob/example_test.go
+++ b/blob/example_test.go
@@ -403,7 +403,7 @@ func ExampleWriterOptions() {
 	}
 	defer b.Close()
 
-	beforeWrite := func(as func(interface{}) bool) error {
+	beforeWrite := func(as func(any) bool) error {
 		var sw *storage.Writer
 		if as(&sw) {
 			fmt.Println(sw.ChunkSize)
@@ -462,7 +462,7 @@ func ExampleListOptions() {
 	}
 	defer b.Close()
 
-	beforeList := func(as func(interface{}) bool) error {
+	beforeList := func(as func(any) bool) error {
 		// Access storage.Query via q here.
 		var q *storage.Query
 		if as(&q) {

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -477,7 +477,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 		if err != nil {
 			return err
 		}
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			p, ok := i.(*os.FileInfo)
 			if !ok {
 				return false
@@ -554,7 +554,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 }
 
 // As implements driver.As.
-func (b *bucket) As(i interface{}) bool {
+func (b *bucket) As(i any) bool {
 	p, ok := i.(*os.FileInfo)
 	if !ok {
 		return false
@@ -568,7 +568,7 @@ func (b *bucket) As(i interface{}) bool {
 }
 
 // As implements driver.ErrorAs.
-func (b *bucket) ErrorAs(err error, i interface{}) bool {
+func (b *bucket) ErrorAs(err error, i any) bool {
 	if perr, ok := err.(*os.PathError); ok {
 		if p, ok := i.(**os.PathError); ok {
 			*p = perr
@@ -596,7 +596,7 @@ func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes
 		Size:    info.Size(),
 		MD5:     xa.MD5,
 		ETag:    fmt.Sprintf("\"%x-%x\"", info.ModTime().UnixNano(), info.Size()),
-		AsFunc: func(i interface{}) bool {
+		AsFunc: func(i any) bool {
 			p, ok := i.(*os.FileInfo)
 			if !ok {
 				return false
@@ -618,7 +618,7 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 		return nil, err
 	}
 	if opts.BeforeRead != nil {
-		if err := opts.BeforeRead(func(i interface{}) bool {
+		if err := opts.BeforeRead(func(i any) bool {
 			p, ok := i.(**os.File)
 			if !ok {
 				return false
@@ -673,7 +673,7 @@ func (r *reader) Attributes() *driver.ReaderAttributes {
 	return &r.attrs
 }
 
-func (r *reader) As(i interface{}) bool {
+func (r *reader) As(i any) bool {
 	p, ok := i.(*io.Reader)
 	if !ok {
 		return false
@@ -725,7 +725,7 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key, contentType string, op
 		return nil, err
 	}
 	if opts.BeforeWrite != nil {
-		if err := opts.BeforeWrite(func(i interface{}) bool {
+		if err := opts.BeforeWrite(func(i any) bool {
 			p, ok := i.(**os.File)
 			if !ok {
 				return false
@@ -925,7 +925,7 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 		return "", gcerr.New(gcerr.Unimplemented, nil, 1, "fileblob.SignedURL: bucket does not have an Options.URLSigner")
 	}
 	if opts.BeforeSign != nil {
-		if err := opts.BeforeSign(func(interface{}) bool { return false }); err != nil {
+		if err := opts.BeforeSign(func(any) bool { return false }); err != nil {
 			return "", err
 		}
 	}

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -288,7 +288,7 @@ func (verifyAs) BucketCheck(b *blob.Bucket) error {
 	return nil
 }
 
-func (verifyAs) BeforeRead(as func(interface{}) bool) error {
+func (verifyAs) BeforeRead(as func(any) bool) error {
 	var f *os.File
 	if !as(&f) {
 		return errors.New("BeforeRead.As failed")
@@ -296,7 +296,7 @@ func (verifyAs) BeforeRead(as func(interface{}) bool) error {
 	return nil
 }
 
-func (verifyAs) BeforeWrite(as func(interface{}) bool) error {
+func (verifyAs) BeforeWrite(as func(any) bool) error {
 	var f *os.File
 	if !as(&f) {
 		return errors.New("BeforeWrite.As failed")
@@ -304,15 +304,15 @@ func (verifyAs) BeforeWrite(as func(interface{}) bool) error {
 	return nil
 }
 
-func (verifyAs) BeforeCopy(as func(interface{}) bool) error {
+func (verifyAs) BeforeCopy(as func(any) bool) error {
 	var f *os.File
 	if !as(&f) {
 		return errors.New("BeforeCopy.As failed")
 	}
 	return nil
 }
-func (verifyAs) BeforeList(as func(interface{}) bool) error { return nil }
-func (verifyAs) BeforeSign(as func(interface{}) bool) error { return nil }
+func (verifyAs) BeforeList(as func(any) bool) error { return nil }
+func (verifyAs) BeforeSign(as func(any) bool) error { return nil }
 func (verifyAs) AttributesCheck(attrs *blob.Attributes) error {
 	var fi os.FileInfo
 	if !attrs.As(&fi) {

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -379,7 +379,7 @@ func (r *reader) Attributes() *driver.ReaderAttributes {
 	return &r.attrs
 }
 
-func (r *reader) As(i interface{}) bool {
+func (r *reader) As(i any) bool {
 	p, ok := i.(**storage.Reader)
 	if !ok {
 		return false
@@ -421,7 +421,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 		Delimiter: escapeKey(opts.Delimiter),
 	}
 	if opts.BeforeList != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			p, ok := i.(**storage.Query)
 			if !ok {
 				return false
@@ -449,7 +449,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 		page.Objects = make([]*driver.ListObject, len(objects))
 		for i, obj := range objects {
 			toCopy := obj
-			asFunc := func(val interface{}) bool {
+			asFunc := func(val any) bool {
 				p, ok := val.(*storage.ObjectAttrs)
 				if !ok {
 					return false
@@ -484,7 +484,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 }
 
 // As implements driver.As.
-func (b *bucket) As(i interface{}) bool {
+func (b *bucket) As(i any) bool {
 	p, ok := i.(**storage.Client)
 	if !ok {
 		return false
@@ -494,7 +494,7 @@ func (b *bucket) As(i interface{}) bool {
 }
 
 // As implements driver.ErrorAs.
-func (b *bucket) ErrorAs(err error, i interface{}) bool {
+func (b *bucket) ErrorAs(err error, i any) bool {
 	switch v := err.(type) {
 	case *googleapi.Error:
 		if p, ok := i.(**googleapi.Error); ok {
@@ -532,7 +532,7 @@ func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes
 		Size:               attrs.Size,
 		MD5:                attrs.MD5,
 		ETag:               eTag,
-		AsFunc: func(i interface{}) bool {
+		AsFunc: func(i any) bool {
 			p, ok := i.(*storage.ObjectAttrs)
 			if !ok {
 				return false
@@ -561,7 +561,7 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 	var rerr error
 	madeReader := false
 	if opts.BeforeRead != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			if p, ok := i.(***storage.ObjectHandle); ok && !madeReader {
 				*p = objp
 				return true
@@ -646,7 +646,7 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key, contentType string, op
 
 	var w *storage.Writer
 	if opts.BeforeWrite != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			if p, ok := i.(***storage.ObjectHandle); ok && w == nil {
 				*p = objp
 				return true
@@ -695,7 +695,7 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 
 	var copier *storage.Copier
 	if opts.BeforeCopy != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			if p, ok := i.(**CopyObjectHandles); ok && copier == nil {
 				*p = &handles
 				return true
@@ -756,7 +756,7 @@ func (b *bucket) SignedURL(ctx context.Context, key string, dopts *driver.Signed
 		opts.SignBytes = b.opts.MakeSignBytes(ctx)
 	}
 	if dopts.BeforeSign != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			v, ok := i.(**storage.SignedURLOptions)
 			if ok {
 				*v = opts

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -156,7 +156,7 @@ func (verifyContentLanguage) ErrorCheck(b *blob.Bucket, err error) error {
 	return nil
 }
 
-func (verifyContentLanguage) BeforeRead(as func(interface{}) bool) error {
+func (verifyContentLanguage) BeforeRead(as func(any) bool) error {
 	var objp **storage.ObjectHandle
 	if !as(&objp) {
 		return errors.New("BeforeRead.As failed to get ObjectHandle")
@@ -168,7 +168,7 @@ func (verifyContentLanguage) BeforeRead(as func(interface{}) bool) error {
 	return nil
 }
 
-func (verifyContentLanguage) BeforeWrite(as func(interface{}) bool) error {
+func (verifyContentLanguage) BeforeWrite(as func(any) bool) error {
 	var objp **storage.ObjectHandle
 	if !as(&objp) {
 		return errors.New("Writer.As failed to get ObjectHandle")
@@ -181,7 +181,7 @@ func (verifyContentLanguage) BeforeWrite(as func(interface{}) bool) error {
 	return nil
 }
 
-func (verifyContentLanguage) BeforeCopy(as func(interface{}) bool) error {
+func (verifyContentLanguage) BeforeCopy(as func(any) bool) error {
 	var coh *CopyObjectHandles
 	if !as(&coh) {
 		return errors.New("BeforeCopy.As failed to get CopyObjectHandles")
@@ -193,7 +193,7 @@ func (verifyContentLanguage) BeforeCopy(as func(interface{}) bool) error {
 	return nil
 }
 
-func (verifyContentLanguage) BeforeList(as func(interface{}) bool) error {
+func (verifyContentLanguage) BeforeList(as func(any) bool) error {
 	var q *storage.Query
 	if !as(&q) {
 		return errors.New("List.As failed")
@@ -202,7 +202,7 @@ func (verifyContentLanguage) BeforeList(as func(interface{}) bool) error {
 	return nil
 }
 
-func (verifyContentLanguage) BeforeSign(as func(interface{}) bool) error {
+func (verifyContentLanguage) BeforeSign(as func(any) bool) error {
 	var opts *storage.SignedURLOptions
 	if !as(&opts) {
 		return errors.New("BeforeSign.As failed")
@@ -346,7 +346,7 @@ func TestBeforeReadNonExistentKey(t *testing.T) {
 
 	// Try reading a nonexistent key.
 	_, err = bucket.NewReader(ctx, "nonexistent-key", &blob.ReaderOptions{
-		BeforeRead: func(asFunc func(interface{}) bool) error {
+		BeforeRead: func(asFunc func(any) bool) error {
 			var objp **storage.ObjectHandle
 			if !asFunc(&objp) {
 				return errors.New("Reader.As failed to get ObjectHandle")
@@ -387,7 +387,7 @@ func TestPreconditions(t *testing.T) {
 
 	// Try writing with a failing precondition.
 	if err := bucket.WriteAll(ctx, key, []byte(content), &blob.WriterOptions{
-		BeforeWrite: func(asFunc func(interface{}) bool) error {
+		BeforeWrite: func(asFunc func(any) bool) error {
 			var objp **storage.ObjectHandle
 			if !asFunc(&objp) {
 				return errors.New("Writer.As failed to get ObjectHandle")
@@ -402,7 +402,7 @@ func TestPreconditions(t *testing.T) {
 
 	// Repeat with a precondition that will pass.
 	if err := bucket.WriteAll(ctx, key, []byte(content), &blob.WriterOptions{
-		BeforeWrite: func(asFunc func(interface{}) bool) error {
+		BeforeWrite: func(asFunc func(any) bool) error {
 			var objp **storage.ObjectHandle
 			if !asFunc(&objp) {
 				return errors.New("Writer.As failed to get ObjectHandle")
@@ -418,7 +418,7 @@ func TestPreconditions(t *testing.T) {
 
 	// Try reading with a failing precondition.
 	_, err = bucket.NewReader(ctx, key, &blob.ReaderOptions{
-		BeforeRead: func(asFunc func(interface{}) bool) error {
+		BeforeRead: func(asFunc func(any) bool) error {
 			var objp **storage.ObjectHandle
 			if !asFunc(&objp) {
 				return errors.New("Reader.As failed to get ObjectHandle")
@@ -444,7 +444,7 @@ func TestPreconditions(t *testing.T) {
 
 	// Repeat with a precondition that will pass.
 	reader, err := bucket.NewReader(ctx, key, &blob.ReaderOptions{
-		BeforeRead: func(asFunc func(interface{}) bool) error {
+		BeforeRead: func(asFunc func(any) bool) error {
 			var objp **storage.ObjectHandle
 			if !asFunc(&objp) {
 				return errors.New("Reader.As failed to get ObjectHandle")
@@ -468,7 +468,7 @@ func TestPreconditions(t *testing.T) {
 
 	// Try copying with a failing precondition on Dst.
 	err = bucket.Copy(ctx, key2, key, &blob.CopyOptions{
-		BeforeCopy: func(asFunc func(interface{}) bool) error {
+		BeforeCopy: func(asFunc func(any) bool) error {
 			var coh *CopyObjectHandles
 			if !asFunc(&coh) {
 				return errors.New("Copy.As failed to get CopyObjectHandles")
@@ -484,7 +484,7 @@ func TestPreconditions(t *testing.T) {
 
 	// Try copying with a failing precondition on Src.
 	err = bucket.Copy(ctx, key2, key, &blob.CopyOptions{
-		BeforeCopy: func(asFunc func(interface{}) bool) error {
+		BeforeCopy: func(asFunc func(any) bool) error {
 			var coh *CopyObjectHandles
 			if !asFunc(&coh) {
 				return errors.New("Copy.As failed to get CopyObjectHandles")
@@ -500,7 +500,7 @@ func TestPreconditions(t *testing.T) {
 
 	// Repeat with preconditions on Dst and Src that will succeed.
 	err = bucket.Copy(ctx, key2, key, &blob.CopyOptions{
-		BeforeCopy: func(asFunc func(interface{}) bool) error {
+		BeforeCopy: func(asFunc func(any) bool) error {
 			var coh *CopyObjectHandles
 			if !asFunc(&coh) {
 				return errors.New("Reader.As failed to get CopyObjectHandles")

--- a/blob/memblob/memblob.go
+++ b/blob/memblob/memblob.go
@@ -195,10 +195,10 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 }
 
 // As implements driver.As.
-func (b *bucket) As(i interface{}) bool { return false }
+func (b *bucket) As(i any) bool { return false }
 
 // As implements driver.ErrorAs.
-func (b *bucket) ErrorAs(err error, i interface{}) bool { return false }
+func (b *bucket) ErrorAs(err error, i any) bool { return false }
 
 // Attributes implements driver.Attributes.
 func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes, error) {
@@ -223,7 +223,7 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 	}
 
 	if opts.BeforeRead != nil {
-		if err := opts.BeforeRead(func(interface{}) bool { return false }); err != nil {
+		if err := opts.BeforeRead(func(any) bool { return false }); err != nil {
 			return nil, err
 		}
 	}
@@ -272,7 +272,7 @@ func (r *reader) Attributes() *driver.ReaderAttributes {
 	return &r.attrs
 }
 
-func (r *reader) As(i interface{}) bool { return false }
+func (r *reader) As(i any) bool { return false }
 
 // NewTypedWriter implements driver.NewTypedWriter.
 func (b *bucket) NewTypedWriter(ctx context.Context, key, contentType string, opts *driver.WriterOptions) (driver.Writer, error) {
@@ -283,7 +283,7 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key, contentType string, op
 	defer b.mu.Unlock()
 
 	if opts.BeforeWrite != nil {
-		if err := opts.BeforeWrite(func(interface{}) bool { return false }); err != nil {
+		if err := opts.BeforeWrite(func(any) bool { return false }); err != nil {
 			return nil, err
 		}
 	}
@@ -367,7 +367,7 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 	defer b.mu.Unlock()
 
 	if opts.BeforeCopy != nil {
-		if err := opts.BeforeCopy(func(interface{}) bool { return false }); err != nil {
+		if err := opts.BeforeCopy(func(any) bool { return false }); err != nil {
 			return err
 		}
 	}

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -342,7 +342,7 @@ func (r *reader) Close() error {
 	return r.body.Close()
 }
 
-func (r *reader) As(i interface{}) bool {
+func (r *reader) As(i any) bool {
 	if r.useV2 {
 		p, ok := i.(*s3v2.GetObjectOutput)
 		if !ok {
@@ -540,7 +540,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 					ModTime: *obj.LastModified,
 					Size:    aws.Int64Value(obj.Size),
 					MD5:     eTagToMD5(obj.ETag),
-					AsFunc: func(i interface{}) bool {
+					AsFunc: func(i any) bool {
 						p, ok := i.(*typesv2.Object)
 						if !ok {
 							return false
@@ -555,7 +555,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 				page.Objects[i+len(resp.Contents)] = &driver.ListObject{
 					Key:   unescapeKey(aws.StringValue(prefix.Prefix)),
 					IsDir: true,
-					AsFunc: func(i interface{}) bool {
+					AsFunc: func(i any) bool {
 						p, ok := i.(*typesv2.CommonPrefix)
 						if !ok {
 							return false
@@ -604,7 +604,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 					ModTime: *obj.LastModified,
 					Size:    *obj.Size,
 					MD5:     eTagToMD5(obj.ETag),
-					AsFunc: func(i interface{}) bool {
+					AsFunc: func(i any) bool {
 						p, ok := i.(*s3.Object)
 						if !ok {
 							return false
@@ -619,7 +619,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 				page.Objects[i+len(resp.Contents)] = &driver.ListObject{
 					Key:   unescapeKey(aws.StringValue(prefix.Prefix)),
 					IsDir: true,
-					AsFunc: func(i interface{}) bool {
+					AsFunc: func(i any) bool {
 						p, ok := i.(*s3.CommonPrefix)
 						if !ok {
 							return false
@@ -644,7 +644,7 @@ func (b *bucket) listObjectsV2(ctx context.Context, in *s3v2.ListObjectsV2Input,
 	if !b.useLegacyList {
 		var varopt []func(*s3v2.Options)
 		if opts.BeforeList != nil {
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				if p, ok := i.(**s3v2.ListObjectsV2Input); ok {
 					*p = in
 					return true
@@ -673,7 +673,7 @@ func (b *bucket) listObjectsV2(ctx context.Context, in *s3v2.ListObjectsV2Input,
 		RequestPayer: in.RequestPayer,
 	}
 	if opts.BeforeList != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			p, ok := i.(**s3v2.ListObjectsInput)
 			if !ok {
 				return false
@@ -706,7 +706,7 @@ func (b *bucket) listObjectsV2(ctx context.Context, in *s3v2.ListObjectsV2Input,
 func (b *bucket) listObjects(ctx context.Context, in *s3.ListObjectsV2Input, opts *driver.ListOptions) (*s3.ListObjectsV2Output, error) {
 	if !b.useLegacyList {
 		if opts.BeforeList != nil {
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				if p, ok := i.(**s3.ListObjectsV2Input); ok {
 					*p = in
 					return true
@@ -731,7 +731,7 @@ func (b *bucket) listObjects(ctx context.Context, in *s3.ListObjectsV2Input, opt
 		RequestPayer: in.RequestPayer,
 	}
 	if opts.BeforeList != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			p, ok := i.(**s3.ListObjectsInput)
 			if !ok {
 				return false
@@ -762,7 +762,7 @@ func (b *bucket) listObjects(ctx context.Context, in *s3.ListObjectsV2Input, opt
 }
 
 // As implements driver.As.
-func (b *bucket) As(i interface{}) bool {
+func (b *bucket) As(i any) bool {
 	if b.useV2 {
 		p, ok := i.(**s3v2.Client)
 		if !ok {
@@ -780,7 +780,7 @@ func (b *bucket) As(i interface{}) bool {
 }
 
 // As implements driver.ErrorAs.
-func (b *bucket) ErrorAs(err error, i interface{}) bool {
+func (b *bucket) ErrorAs(err error, i any) bool {
 	if b.useV2 {
 		return errors.As(err, i)
 	}
@@ -825,7 +825,7 @@ func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes
 			Size:    aws.Int64Value(resp.ContentLength),
 			MD5:     eTagToMD5(resp.ETag),
 			ETag:    aws.StringValue(resp.ETag),
-			AsFunc: func(i interface{}) bool {
+			AsFunc: func(i any) bool {
 				p, ok := i.(*s3v2.HeadObjectOutput)
 				if !ok {
 					return false
@@ -862,7 +862,7 @@ func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes
 			Size:    aws.Int64Value(resp.ContentLength),
 			MD5:     eTagToMD5(resp.ETag),
 			ETag:    aws.StringValue(resp.ETag),
-			AsFunc: func(i interface{}) bool {
+			AsFunc: func(i any) bool {
 				p, ok := i.(*s3.HeadObjectOutput)
 				if !ok {
 					return false
@@ -895,7 +895,7 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 		}
 		var varopt []func(*s3v2.Options)
 		if opts.BeforeRead != nil {
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				if p, ok := i.(**s3v2.GetObjectInput); ok {
 					*p = in
 					return true
@@ -935,7 +935,7 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 			Range:  byteRange,
 		}
 		if opts.BeforeRead != nil {
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				if p, ok := i.(**s3.GetObjectInput); ok {
 					*p = in
 					return true
@@ -1084,7 +1084,7 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key, contentType string, op
 			reqV2.SSEKMSKeyId = aws.String(b.kmsKeyId)
 		}
 		if opts.BeforeWrite != nil {
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				// Note that since the Go CDK Blob
 				// abstraction does not expose AWS's
 				// Uploader concept, there does not
@@ -1163,7 +1163,7 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key, contentType string, op
 			req.SSEKMSKeyId = aws.String(b.kmsKeyId)
 		}
 		if opts.BeforeWrite != nil {
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				pu, ok := i.(**s3manager.Uploader)
 				if ok {
 					*pu = uploader
@@ -1207,7 +1207,7 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 			input.SSEKMSKeyId = aws.String(b.kmsKeyId)
 		}
 		if opts.BeforeCopy != nil {
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				switch v := i.(type) {
 				case **s3v2.CopyObjectInput:
 					*v = input
@@ -1234,7 +1234,7 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 			input.SSEKMSKeyId = aws.String(b.kmsKeyId)
 		}
 		if opts.BeforeCopy != nil {
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				switch v := i.(type) {
 				case **s3.CopyObjectInput:
 					*v = input
@@ -1285,7 +1285,7 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 				Key:    aws.String(key),
 			}
 			if opts.BeforeSign != nil {
-				asFunc := func(i interface{}) bool {
+				asFunc := func(i any) bool {
 					v, ok := i.(**s3v2.GetObjectInput)
 					if ok {
 						*v = in
@@ -1307,7 +1307,7 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 				Key:    aws.String(key),
 			}
 			if opts.BeforeSign != nil {
-				asFunc := func(i interface{}) bool {
+				asFunc := func(i any) bool {
 					v, ok := i.(**s3.GetObjectInput)
 					if ok {
 						*v = in
@@ -1332,7 +1332,7 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 				return "", gcerr.New(gcerr.Unimplemented, nil, 1, "s3blob: AWS SDK v2 does not supported enforcing ContentType in SignedURLs for PUT")
 			}
 			if opts.BeforeSign != nil {
-				asFunc := func(i interface{}) bool {
+				asFunc := func(i any) bool {
 					v, ok := i.(**s3v2.PutObjectInput)
 					if ok {
 						*v = in
@@ -1357,7 +1357,7 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 				in.ContentType = aws.String(opts.ContentType)
 			}
 			if opts.BeforeSign != nil {
-				asFunc := func(i interface{}) bool {
+				asFunc := func(i any) bool {
 					v, ok := i.(**s3.PutObjectInput)
 					if ok {
 						*v = in
@@ -1381,7 +1381,7 @@ func (b *bucket) SignedURL(ctx context.Context, key string, opts *driver.SignedU
 			Key:    aws.String(key),
 		}
 		if opts.BeforeSign != nil {
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				v, ok := i.(**s3.DeleteObjectInput)
 				if ok {
 					*v = in

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -178,7 +178,7 @@ func (v verifyContentLanguage) ErrorCheck(b *blob.Bucket, err error) error {
 	return nil
 }
 
-func (v verifyContentLanguage) BeforeRead(as func(interface{}) bool) error {
+func (v verifyContentLanguage) BeforeRead(as func(any) bool) error {
 	if v.useV2 {
 		var (
 			req  *s3v2.GetObjectInput
@@ -196,7 +196,7 @@ func (v verifyContentLanguage) BeforeRead(as func(interface{}) bool) error {
 	return nil
 }
 
-func (v verifyContentLanguage) BeforeWrite(as func(interface{}) bool) error {
+func (v verifyContentLanguage) BeforeWrite(as func(any) bool) error {
 	if v.useV2 {
 		var (
 			req      *s3v2.PutObjectInput
@@ -224,7 +224,7 @@ func (v verifyContentLanguage) BeforeWrite(as func(interface{}) bool) error {
 	return nil
 }
 
-func (v verifyContentLanguage) BeforeCopy(as func(interface{}) bool) error {
+func (v verifyContentLanguage) BeforeCopy(as func(any) bool) error {
 	if v.useV2 {
 		var in *s3v2.CopyObjectInput
 		if !as(&in) {
@@ -239,7 +239,7 @@ func (v verifyContentLanguage) BeforeCopy(as func(interface{}) bool) error {
 	return nil
 }
 
-func (v verifyContentLanguage) BeforeList(as func(interface{}) bool) error {
+func (v verifyContentLanguage) BeforeList(as func(any) bool) error {
 	if v.useV2 {
 		if v.usingLegacyList {
 			var req *s3v2.ListObjectsInput
@@ -272,7 +272,7 @@ func (v verifyContentLanguage) BeforeList(as func(interface{}) bool) error {
 	return nil
 }
 
-func (v verifyContentLanguage) BeforeSign(as func(interface{}) bool) error {
+func (v verifyContentLanguage) BeforeSign(as func(any) bool) error {
 	if v.useV2 {
 		var (
 			get *s3v2.GetObjectInput

--- a/internal/gcerr/gcerr.go
+++ b/internal/gcerr/gcerr.go
@@ -132,7 +132,7 @@ func New(c ErrorCode, err error, callDepth int, msg string) *Error {
 }
 
 // Newf uses format and args to format a message, then calls New.
-func Newf(c ErrorCode, err error, format string, args ...interface{}) *Error {
+func Newf(c ErrorCode, err error, format string, args ...any) *Error {
 	return New(c, err, 2, fmt.Sprintf(format, args...))
 }
 
@@ -187,7 +187,7 @@ func GRPCCode(err error) ErrorCode {
 // It performs some initial nil checks, and does a single level of unwrapping
 // when err is a *gcerr.Error. Then it calls its errorAs argument, which should
 // be a driver implementation of ErrorAs.
-func ErrorAs(err error, target interface{}, errorAs func(error, interface{}) bool) bool {
+func ErrorAs(err error, target any, errorAs func(error, any) bool) bool {
 	if err == nil {
 		return false
 	}

--- a/internal/oc/trace.go
+++ b/internal/oc/trace.go
@@ -36,7 +36,7 @@ type Tracer struct {
 // ProviderName returns the name of the provider associated with the driver value.
 // It is intended to be used to set Tracer.Provider.
 // It actually returns the package path of the driver's type.
-func ProviderName(driver interface{}) string {
+func ProviderName(driver any) string {
 	// Return the last component of the package path.
 	if driver == nil {
 		return ""

--- a/internal/oc/trace_test.go
+++ b/internal/oc/trace_test.go
@@ -23,7 +23,7 @@ type testDriver struct{}
 
 func TestProviderName(t *testing.T) {
 	for _, test := range []struct {
-		in   interface{}
+		in   any
 		want string
 	}{
 		{nil, ""},

--- a/internal/openurl/openurl.go
+++ b/internal/openurl/openurl.go
@@ -25,7 +25,7 @@ import (
 // SchemeMap maps URL schemes to values. The zero value is an empty map, ready for use.
 type SchemeMap struct {
 	api string
-	m   map[string]interface{}
+	m   map[string]any
 }
 
 // Register registers scheme for value; subsequent calls to FromString or
@@ -34,9 +34,9 @@ type SchemeMap struct {
 // be passed. It should be in all lowercase.
 // typ is the portable type (e.g., "Bucket").
 // Register panics if scheme has already been registered.
-func (m *SchemeMap) Register(api, typ, scheme string, value interface{}) {
+func (m *SchemeMap) Register(api, typ, scheme string, value any) {
 	if m.m == nil {
-		m.m = map[string]interface{}{}
+		m.m = map[string]any{}
 	}
 	if api != strings.ToLower(api) {
 		panic(fmt.Errorf("api should be lowercase: %q", api))
@@ -53,7 +53,7 @@ func (m *SchemeMap) Register(api, typ, scheme string, value interface{}) {
 }
 
 // FromString parses urlstr as an URL and looks up the value for the URL's scheme.
-func (m *SchemeMap) FromString(typ, urlstr string) (interface{}, *url.URL, error) {
+func (m *SchemeMap) FromString(typ, urlstr string) (any, *url.URL, error) {
 	u, err := url.Parse(urlstr)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open %s.%s: %v", m.api, typ, err)
@@ -66,7 +66,7 @@ func (m *SchemeMap) FromString(typ, urlstr string) (interface{}, *url.URL, error
 }
 
 // FromURL looks up the value for u's scheme.
-func (m *SchemeMap) FromURL(typ string, u *url.URL) (interface{}, error) {
+func (m *SchemeMap) FromURL(typ string, u *url.URL) (any, error) {
 	scheme := u.Scheme
 	if scheme == "" {
 		return nil, fmt.Errorf("open %s.%s: no scheme in URL %q", m.api, typ, u)

--- a/internal/openurl/openurl_test.go
+++ b/internal/openurl/openurl_test.go
@@ -26,7 +26,7 @@ func TestSchemeMap(t *testing.T) {
 	tests := []struct {
 		url     string
 		wantErr bool
-		want    interface{}
+		want    any
 	}{
 		{"invalid url", true, nil},
 		{"foo://a/b/c", false, foo},

--- a/internal/testing/terraform/terraform.go
+++ b/internal/testing/terraform/terraform.go
@@ -39,7 +39,7 @@ func ReadOutput(dir string) (map[string]Output, error) {
 
 // Output describes a single output value.
 type Output struct {
-	Type      string      `json:"type"` // one of "string", "list", or "map"
-	Sensitive bool        `json:"sensitive"`
-	Value     interface{} `json:"value"`
+	Type      string `json:"type"` // one of "string", "list", or "map"
+	Sensitive bool   `json:"sensitive"`
+	Value     any    `json:"value"`
 }

--- a/internal/website/gatherexamples/gatherexamples_test.go
+++ b/internal/website/gatherexamples/gatherexamples_test.go
@@ -34,7 +34,7 @@ func TestGather(t *testing.T) {
 			name: "NoExamples",
 			module: packagestest.Module{
 				Name: "example.com/foo",
-				Files: map[string]interface{}{
+				Files: map[string]any{
 					"foo.go": "package foo\nfunc main() {}\n",
 				},
 			},
@@ -44,7 +44,7 @@ func TestGather(t *testing.T) {
 			name: "EmptyExample",
 			module: packagestest.Module{
 				Name: "example.com/foo",
-				Files: map[string]interface{}{
+				Files: map[string]any{
 					"foo.go": "package foo\n",
 					"example_test.go": `package foo_test
 
@@ -57,7 +57,7 @@ func Example() {}`,
 			name: "EmptyExampleFoo",
 			module: packagestest.Module{
 				Name: "example.com/foo",
-				Files: map[string]interface{}{
+				Files: map[string]any{
 					"foo.go": "package foo\n",
 					"example_test.go": `package foo_test
 
@@ -71,7 +71,7 @@ func ExampleFoo() {
 			name: "NonSignifiedExampleWithPragma",
 			module: packagestest.Module{
 				Name: "example.com/foo",
-				Files: map[string]interface{}{
+				Files: map[string]any{
 					"foo.go": "package foo\n",
 					"example_test.go": `package foo_test
 
@@ -87,7 +87,7 @@ func ExampleFoo() {
 			name: "EmptyExampleWithComment",
 			module: packagestest.Module{
 				Name: "example.com/foo",
-				Files: map[string]interface{}{
+				Files: map[string]any{
 					"foo.go": "package foo\n",
 					"example_test.go": `package foo_test
 
@@ -104,7 +104,7 @@ func Example() {
 			name: "EmptyExampleFooWithComment",
 			module: packagestest.Module{
 				Name: "example.com/foo",
-				Files: map[string]interface{}{
+				Files: map[string]any{
 					"foo.go": "package foo\n",
 					"example_test.go": `package foo_test
 
@@ -121,7 +121,7 @@ func ExampleFoo() {
 			name: "NoImportsExample",
 			module: packagestest.Module{
 				Name: "example.com/foo",
-				Files: map[string]interface{}{
+				Files: map[string]any{
 					"foo.go": "package foo\n",
 					"example_test.go": `package foo_test
 
@@ -151,7 +151,7 @@ func Example() {
 			name: "OneImportExample",
 			module: packagestest.Module{
 				Name: "example.com/foo",
-				Files: map[string]interface{}{
+				Files: map[string]any{
 					"foo.go": "package foo\n",
 					"example_test.go": `package foo_test
 
@@ -174,7 +174,7 @@ func Example() {
 			name: "TwoImportsExample",
 			module: packagestest.Module{
 				Name: "example.com/foo",
-				Files: map[string]interface{}{
+				Files: map[string]any{
 					"foo.go": "package foo\n",
 					"example_test.go": `package foo_test
 
@@ -198,7 +198,7 @@ func Example() {
 			name: "LogFatalToReturnErr",
 			module: packagestest.Module{
 				Name: "example.com/foo",
-				Files: map[string]interface{}{
+				Files: map[string]any{
 					"foo.go": "package foo\n",
 					"example_test.go": `package foo_test
 
@@ -222,7 +222,7 @@ func Example() {
 			name: "IgnoreSections",
 			module: packagestest.Module{
 				Name: "example.com/foo",
-				Files: map[string]interface{}{
+				Files: map[string]any{
 					"foo.go": "package foo\n",
 					"example_test.go": `package foo_test
 
@@ -252,7 +252,7 @@ func Example() {
 			name: "BlankImports",
 			module: packagestest.Module{
 				Name: "example.com/foo",
-				Files: map[string]interface{}{
+				Files: map[string]any{
 					"foo.go": "package foo\n",
 					"example_test.go": `package foo_test
 

--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -539,7 +539,7 @@ func (t *snsTopic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 				// with the fields from PublishBatchRequestEntry that were set, and
 				// then copy all of the matching fields back after calling dm.BeforeSend.
 				var pi *snsv2.PublishInput
-				asFunc := func(i interface{}) bool {
+				asFunc := func(i any) bool {
 					if p, ok := i.(**snsv2.PublishInput); ok {
 						pi = &snsv2.PublishInput{
 							// Id does not exist on PublishInput.
@@ -581,7 +581,7 @@ func (t *snsTopic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 		if len(resp.Successful) == len(dms) {
 			for n, dm := range dms {
 				if dm.AfterSend != nil {
-					asFunc := func(i interface{}) bool {
+					asFunc := func(i any) bool {
 						if p, ok := i.(*snstypesv2.PublishBatchResultEntry); ok {
 							*p = resp.Successful[n]
 							return true
@@ -638,7 +638,7 @@ func (t *snsTopic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 			// with the fields from PublishBatchRequestEntry that were set, and
 			// then copy all of the matching fields back after calling dm.BeforeSend.
 			var pi *sns.PublishInput
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				if p, ok := i.(**sns.PublishInput); ok {
 					pi = &sns.PublishInput{
 						// Id does not exist on PublishInput.
@@ -680,7 +680,7 @@ func (t *snsTopic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 	if len(resp.Successful) == len(dms) {
 		for n, dm := range dms {
 			if dm.AfterSend != nil {
-				asFunc := func(i interface{}) bool {
+				asFunc := func(i any) bool {
 					if p, ok := i.(*sns.PublishBatchResultEntry); ok {
 						*p = *resp.Successful[n]
 						return true
@@ -711,7 +711,7 @@ func (t *snsTopic) IsRetryable(error) bool {
 }
 
 // As implements driver.Topic.As.
-func (t *snsTopic) As(i interface{}) bool {
+func (t *snsTopic) As(i any) bool {
 	if t.useV2 {
 		c, ok := i.(**snsv2.Client)
 		if !ok {
@@ -729,7 +729,7 @@ func (t *snsTopic) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Topic.ErrorAs.
-func (t *snsTopic) ErrorAs(err error, i interface{}) bool {
+func (t *snsTopic) ErrorAs(err error, i any) bool {
 	return errorAs(err, t.useV2, i)
 }
 
@@ -844,7 +844,7 @@ func (t *sqsTopic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 			}
 			reviseSqsV2EntryAttributes(dm, entry)
 			if dm.BeforeSend != nil {
-				asFunc := func(i interface{}) bool {
+				asFunc := func(i any) bool {
 					if p, ok := i.(**sqstypesv2.SendMessageBatchRequestEntry); ok {
 						*p = entry
 						return true
@@ -868,7 +868,7 @@ func (t *sqsTopic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 		if len(resp.Successful) == len(dms) {
 			for n, dm := range dms {
 				if dm.AfterSend != nil {
-					asFunc := func(i interface{}) bool {
+					asFunc := func(i any) bool {
 						if p, ok := i.(*sqstypesv2.SendMessageBatchResultEntry); ok {
 							*p = resp.Successful[n]
 							return true
@@ -918,7 +918,7 @@ func (t *sqsTopic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 			// with the fields from SendMessageBatchRequestEntry that were set, and
 			// then copy all of the matching fields back after calling dm.BeforeSend.
 			var smi *sqs.SendMessageInput
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				if p, ok := i.(**sqs.SendMessageInput); ok {
 					smi = &sqs.SendMessageInput{
 						// Id does not exist on SendMessageInput.
@@ -958,7 +958,7 @@ func (t *sqsTopic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 	if len(resp.Successful) == len(dms) {
 		for n, dm := range dms {
 			if dm.AfterSend != nil {
-				asFunc := func(i interface{}) bool {
+				asFunc := func(i any) bool {
 					if p, ok := i.(**sqs.SendMessageBatchResultEntry); ok {
 						*p = resp.Successful[n]
 						return true
@@ -981,7 +981,7 @@ func (t *sqsTopic) IsRetryable(error) bool {
 }
 
 // As implements driver.Topic.As.
-func (t *sqsTopic) As(i interface{}) bool {
+func (t *sqsTopic) As(i any) bool {
 	if t.useV2 {
 		c, ok := i.(**sqsv2.Client)
 		if !ok {
@@ -999,7 +999,7 @@ func (t *sqsTopic) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Topic.ErrorAs.
-func (t *sqsTopic) ErrorAs(err error, i interface{}) bool {
+func (t *sqsTopic) ErrorAs(err error, i any) bool {
 	return errorAs(err, t.useV2, i)
 }
 
@@ -1213,7 +1213,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 				Body:       b,
 				Metadata:   attrs,
 				AckID:      m.ReceiptHandle,
-				AsFunc: func(i interface{}) bool {
+				AsFunc: func(i any) bool {
 					p, ok := i.(*sqstypesv2.Message)
 					if !ok {
 						return false
@@ -1277,7 +1277,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 				Body:       b,
 				Metadata:   attrs,
 				AckID:      m.ReceiptHandle,
-				AsFunc: func(i interface{}) bool {
+				AsFunc: func(i any) bool {
 					p, ok := i.(**sqs.Message)
 					if !ok {
 						return false
@@ -1455,7 +1455,7 @@ func (*subscription) IsRetryable(error) bool {
 }
 
 // As implements driver.Subscription.As.
-func (s *subscription) As(i interface{}) bool {
+func (s *subscription) As(i any) bool {
 	if s.useV2 {
 		c, ok := i.(**sqsv2.Client)
 		if !ok {
@@ -1473,7 +1473,7 @@ func (s *subscription) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Subscription.ErrorAs.
-func (s *subscription) ErrorAs(err error, i interface{}) bool {
+func (s *subscription) ErrorAs(err error, i any) bool {
 	return errorAs(err, s.useV2, i)
 }
 
@@ -1482,7 +1482,7 @@ func (s *subscription) ErrorCode(err error) gcerrors.ErrorCode {
 	return errorCode(err)
 }
 
-func errorAs(err error, useV2 bool, i interface{}) bool {
+func errorAs(err error, useV2 bool, i any) bool {
 	if useV2 {
 		return errors.As(err, i)
 	}

--- a/pubsub/awssnssqs/awssnssqs_test.go
+++ b/pubsub/awssnssqs/awssnssqs_test.go
@@ -562,7 +562,7 @@ func (t awsAsTest) MessageCheck(m *pubsub.Message) error {
 	return nil
 }
 
-func (t awsAsTest) BeforeSend(as func(interface{}) bool) error {
+func (t awsAsTest) BeforeSend(as func(any) bool) error {
 	switch t.topicKind {
 	case topicKindSNS, topicKindSNSRaw:
 		if t.useV2 {
@@ -606,7 +606,7 @@ func (t awsAsTest) BeforeSend(as func(interface{}) bool) error {
 	return nil
 }
 
-func (t awsAsTest) AfterSend(as func(interface{}) bool) error {
+func (t awsAsTest) AfterSend(as func(any) bool) error {
 	switch t.topicKind {
 	case topicKindSNS, topicKindSNSRaw:
 		if t.useV2 {

--- a/pubsub/azuresb/azuresb.go
+++ b/pubsub/azuresb/azuresb.go
@@ -323,13 +323,13 @@ func (t *topic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 	dm := dms[0]
 	sbms := &servicebus.Message{Body: dm.Body}
 	if len(dm.Metadata) > 0 {
-		sbms.ApplicationProperties = map[string]interface{}{}
+		sbms.ApplicationProperties = map[string]any{}
 		for k, v := range dm.Metadata {
 			sbms.ApplicationProperties[k] = v
 		}
 	}
 	if dm.BeforeSend != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			if p, ok := i.(**servicebus.Message); ok {
 				*p = sbms
 				return true
@@ -345,7 +345,7 @@ func (t *topic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 		return err
 	}
 	if dm.AfterSend != nil {
-		asFunc := func(i interface{}) bool { return false }
+		asFunc := func(i any) bool { return false }
 		if err := dm.AfterSend(asFunc); err != nil {
 			return err
 		}
@@ -358,7 +358,7 @@ func (t *topic) IsRetryable(err error) bool {
 	return retryable
 }
 
-func (t *topic) As(i interface{}) bool {
+func (t *topic) As(i any) bool {
 	p, ok := i.(**servicebus.Sender)
 	if !ok {
 		return false
@@ -368,11 +368,11 @@ func (t *topic) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Topic.ErrorAs
-func (*topic) ErrorAs(err error, i interface{}) bool {
+func (*topic) ErrorAs(err error, i any) bool {
 	return errorAs(err, i)
 }
 
-func errorAs(err error, i interface{}) bool {
+func errorAs(err error, i any) bool {
 	switch v := err.(type) {
 	case *amqp.LinkError:
 		if p, ok := i.(**amqp.LinkError); ok {
@@ -466,7 +466,7 @@ func (s *subscription) IsRetryable(err error) bool {
 }
 
 // As implements driver.Subscription.As.
-func (s *subscription) As(i interface{}) bool {
+func (s *subscription) As(i any) bool {
 	p, ok := i.(**servicebus.Receiver)
 	if !ok {
 		return false
@@ -476,7 +476,7 @@ func (s *subscription) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Subscription.ErrorAs
-func (s *subscription) ErrorAs(err error, i interface{}) bool {
+func (s *subscription) ErrorAs(err error, i any) bool {
 	return errorAs(err, i)
 }
 
@@ -517,8 +517,8 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 	return messages, err
 }
 
-func messageAsFunc(sbmsg *servicebus.ReceivedMessage) func(interface{}) bool {
-	return func(i interface{}) bool {
+func messageAsFunc(sbmsg *servicebus.ReceivedMessage) func(any) bool {
+	return func(i any) bool {
 		p, ok := i.(**servicebus.ReceivedMessage)
 		if !ok {
 			return false

--- a/pubsub/azuresb/azuresb_test.go
+++ b/pubsub/azuresb/azuresb_test.go
@@ -245,7 +245,7 @@ func (sbAsTest) MessageCheck(m *pubsub.Message) error {
 	return nil
 }
 
-func (sbAsTest) BeforeSend(as func(interface{}) bool) error {
+func (sbAsTest) BeforeSend(as func(any) bool) error {
 	var m *servicebus.Message
 	if !as(&m) {
 		return fmt.Errorf("cast failed for %T", &m)
@@ -253,7 +253,7 @@ func (sbAsTest) BeforeSend(as func(interface{}) bool) error {
 	return nil
 }
 
-func (sbAsTest) AfterSend(as func(interface{}) bool) error {
+func (sbAsTest) AfterSend(as func(any) bool) error {
 	return nil
 }
 

--- a/pubsub/batcher/batcher.go
+++ b/pubsub/batcher/batcher.go
@@ -64,7 +64,7 @@ func Split(n int, opts *Options) []int {
 // A Batcher batches items.
 type Batcher struct {
 	opts          Options
-	handler       func(interface{}) error
+	handler       func(any) error
 	itemSliceZero reflect.Value  // nil (zero value) for slice of items
 	wg            sync.WaitGroup // tracks active Add calls
 
@@ -82,7 +82,7 @@ type sizableItem interface {
 }
 
 type waiter struct {
-	item interface{}
+	item any
 	errc chan error
 }
 
@@ -150,7 +150,7 @@ func (o *Options) NewMergedOptions(opts *Options) *Options {
 //
 // handler is a function that will be called on each bundle. If itemExample is
 // of type T, the argument to handler is of type []T.
-func New(itemType reflect.Type, opts *Options, handler func(interface{}) error) *Batcher {
+func New(itemType reflect.Type, opts *Options, handler func(any) error) *Batcher {
 	return &Batcher{
 		opts:          newOptionsWithDefaults(opts),
 		handler:       handler,
@@ -161,7 +161,7 @@ func New(itemType reflect.Type, opts *Options, handler func(interface{}) error) 
 // Add adds an item to the batcher. It blocks until the handler has
 // processed the item and reports the error that the handler returned.
 // If Shutdown has been called, Add immediately returns an error.
-func (b *Batcher) Add(ctx context.Context, item interface{}) error {
+func (b *Batcher) Add(ctx context.Context, item any) error {
 	c := b.AddNoWait(item)
 	// Wait until either our result is ready or the context is done.
 	select {
@@ -175,7 +175,7 @@ func (b *Batcher) Add(ctx context.Context, item interface{}) error {
 // AddNoWait adds an item to the batcher and returns immediately. When the handler is
 // called on the item, the handler's error return value will be sent to the channel
 // returned from AddNoWait.
-func (b *Batcher) AddNoWait(item interface{}) <-chan error {
+func (b *Batcher) AddNoWait(item any) <-chan error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/pubsub/batcher/batcher_test.go
+++ b/pubsub/batcher/batcher_test.go
@@ -72,7 +72,7 @@ func TestSequential(t *testing.T) {
 	ctx := context.Background()
 	var got []int
 	e := errors.New("e")
-	b := batcher.New(reflect.TypeOf(int(0)), nil, func(items interface{}) error {
+	b := batcher.New(reflect.TypeOf(int(0)), nil, func(items any) error {
 		got = items.([]int)
 		return e
 	})
@@ -99,7 +99,7 @@ func (i *sizableItem) ByteSize() int {
 func TestPreventsAddingItemsLargerThanBatchMaxByteSize(t *testing.T) {
 	ctx := context.Background()
 	itemType := reflect.TypeOf(&sizableItem{})
-	b := batcher.New(itemType, &batcher.Options{MaxBatchByteSize: 1}, func(items interface{}) error {
+	b := batcher.New(itemType, &batcher.Options{MaxBatchByteSize: 1}, func(items any) error {
 		return nil
 	})
 
@@ -131,7 +131,7 @@ func TestBatchingConsidersMaxSizeAndMaxByteSize(t *testing.T) {
 
 	for _, test := range tests {
 		var got [][]*sizableItem
-		b := batcher.New(itemType, test.opts, func(items interface{}) error {
+		b := batcher.New(itemType, test.opts, func(items any) error {
 			got = append(got, items.([]*sizableItem))
 			return nil
 		})
@@ -157,7 +157,7 @@ func TestBatchingConsidersMaxSizeAndMaxByteSize(t *testing.T) {
 func TestMinBatchSize(t *testing.T) {
 	// Verify the MinBatchSize option works.
 	var got [][]int
-	b := batcher.New(reflect.TypeOf(int(0)), &batcher.Options{MinBatchSize: 3}, func(items interface{}) error {
+	b := batcher.New(reflect.TypeOf(int(0)), &batcher.Options{MinBatchSize: 3}, func(items any) error {
 		got = append(got, items.([]int))
 		return nil
 	})
@@ -184,7 +184,7 @@ func TestSaturation(t *testing.T) {
 		maxBatch         int             // size of largest batch
 		count            = map[int]int{} // how many of each item the handlers observe
 	)
-	b := batcher.New(reflect.TypeOf(int(0)), &batcher.Options{MaxHandlers: maxHandlers, MaxBatchSize: maxBatchSize}, func(x interface{}) error {
+	b := batcher.New(reflect.TypeOf(int(0)), &batcher.Options{MaxHandlers: maxHandlers, MaxBatchSize: maxBatchSize}, func(x any) error {
 		items := x.([]int)
 		mu.Lock()
 		outstanding++
@@ -240,7 +240,7 @@ func TestShutdown(t *testing.T) {
 	ctx := context.Background()
 	var nHandlers int64 // atomic
 	c := make(chan int, 10)
-	b := batcher.New(reflect.TypeOf(int(0)), &batcher.Options{MaxHandlers: cap(c)}, func(x interface{}) error {
+	b := batcher.New(reflect.TypeOf(int(0)), &batcher.Options{MaxHandlers: cap(c)}, func(x any) error {
 		for range x.([]int) {
 			c <- 0
 		}
@@ -274,7 +274,7 @@ func TestShutdown(t *testing.T) {
 func TestItemCanBeInterface(t *testing.T) {
 	readerType := reflect.TypeOf([]io.Reader{}).Elem()
 	called := false
-	b := batcher.New(readerType, nil, func(items interface{}) error {
+	b := batcher.New(readerType, nil, func(items any) error {
 		called = true
 		_, ok := items.([]io.Reader)
 		if !ok {

--- a/pubsub/driver/driver.go
+++ b/pubsub/driver/driver.go
@@ -24,7 +24,7 @@ import (
 )
 
 // AckID is the identifier of a message for purposes of acknowledgement.
-type AckID interface{}
+type AckID any
 
 // AckInfo represents an action on an AckID.
 type AckInfo struct {
@@ -56,7 +56,7 @@ type Message struct {
 	// AsFunc allows drivers to expose driver-specific types;
 	// see Topic.As for more details.
 	// AsFunc must be populated on messages returned from ReceiveBatch.
-	AsFunc func(interface{}) bool
+	AsFunc func(any) bool
 
 	// BeforeSend is a callback used when sending a message. It should remain
 	// nil on messages returned from ReceiveBatch.
@@ -65,7 +65,7 @@ type Message struct {
 	//
 	// asFunc converts its argument to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	BeforeSend func(asFunc func(interface{}) bool) error
+	BeforeSend func(asFunc func(any) bool) error
 
 	// AfterSend is a callback used when sending a message. It should remain
 	// nil on messages returned from ReceiveBatch.
@@ -75,7 +75,7 @@ type Message struct {
 	//
 	// asFunc converts its argument to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	AfterSend func(asFunc func(interface{}) bool) error
+	AfterSend func(asFunc func(any) bool) error
 }
 
 // ByteSize estimates the size in bytes of the message for the purpose of restricting batch sizes.
@@ -117,11 +117,11 @@ type Topic interface {
 
 	// As allows drivers to expose driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	As(i interface{}) bool
+	As(i any) bool
 
 	// ErrorAs allows drivers to expose driver-specific types for errors.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	ErrorAs(error, interface{}) bool
+	ErrorAs(error, any) bool
 
 	// ErrorCode should return a code that describes the error, which was returned by
 	// one of the other methods in this interface.
@@ -204,11 +204,11 @@ type Subscription interface {
 
 	// As converts i to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	As(i interface{}) bool
+	As(i any) bool
 
 	// ErrorAs allows drivers to expose driver-specific types for errors.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	ErrorAs(error, interface{}) bool
+	ErrorAs(error, any) bool
 
 	// ErrorCode should return a code that describes the error, which was returned by
 	// one of the other methods in this interface.

--- a/pubsub/drivertest/drivertest.go
+++ b/pubsub/drivertest/drivertest.go
@@ -106,10 +106,10 @@ type AsTest interface {
 	MessageCheck(m *pubsub.Message) error
 	// BeforeSend will be used as Message.BeforeSend as part of sending a test
 	// message.
-	BeforeSend(as func(interface{}) bool) error
+	BeforeSend(as func(any) bool) error
 	// AfterSend will be used as Message.AfterSend as part of sending a test
 	// message.
-	AfterSend(as func(interface{}) bool) error
+	AfterSend(as func(any) bool) error
 }
 
 // Many tests set the maximum batch size to 1 to make record/replay stable.
@@ -162,14 +162,14 @@ func (verifyAsFailsOnNil) MessageCheck(m *pubsub.Message) error {
 	return nil
 }
 
-func (verifyAsFailsOnNil) BeforeSend(as func(interface{}) bool) error {
+func (verifyAsFailsOnNil) BeforeSend(as func(any) bool) error {
 	if as(nil) {
 		return errors.New("want Message.BeforeSend's As function to return false when passed nil")
 	}
 	return nil
 }
 
-func (verifyAsFailsOnNil) AfterSend(as func(interface{}) bool) error {
+func (verifyAsFailsOnNil) AfterSend(as func(any) bool) error {
 	if as(nil) {
 		return errors.New("want Message.AfterSend's As function to return false when passed nil")
 	}

--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -374,7 +374,7 @@ func (t *topic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 	for _, dm := range dms {
 		psm := &pb.PubsubMessage{Data: dm.Body, Attributes: dm.Metadata}
 		if dm.BeforeSend != nil {
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				if p, ok := i.(**pb.PubsubMessage); ok {
 					*p = psm
 					return true
@@ -395,7 +395,7 @@ func (t *topic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 	if len(pr.MessageIds) == len(dms) {
 		for n, dm := range dms {
 			if dm.AfterSend != nil {
-				asFunc := func(i interface{}) bool {
+				asFunc := func(i any) bool {
 					if p, ok := i.(*string); ok {
 						*p = pr.MessageIds[n]
 						return true
@@ -418,7 +418,7 @@ func (t *topic) IsRetryable(error) bool {
 }
 
 // As implements driver.Topic.As.
-func (t *topic) As(i interface{}) bool {
+func (t *topic) As(i any) bool {
 	c, ok := i.(**raw.PublisherClient)
 	if !ok {
 		return false
@@ -428,11 +428,11 @@ func (t *topic) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Topic.ErrorAs
-func (*topic) ErrorAs(err error, i interface{}) bool {
+func (*topic) ErrorAs(err error, i any) bool {
 	return errorAs(err, i)
 }
 
-func errorAs(err error, i interface{}) bool {
+func errorAs(err error, i any) bool {
 	s, ok := status.FromError(err)
 	if !ok {
 		return false
@@ -566,8 +566,8 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 	return ms, nil
 }
 
-func messageAsFunc(pm *pb.PubsubMessage, rm *pb.ReceivedMessage) func(interface{}) bool {
-	return func(i interface{}) bool {
+func messageAsFunc(pm *pb.PubsubMessage, rm *pb.ReceivedMessage) func(any) bool {
+	return func(i any) bool {
 		ip, ok := i.(**pb.PubsubMessage)
 		if ok {
 			*ip = pm
@@ -618,7 +618,7 @@ func (s *subscription) IsRetryable(err error) bool {
 }
 
 // As implements driver.Subscription.As.
-func (s *subscription) As(i interface{}) bool {
+func (s *subscription) As(i any) bool {
 	c, ok := i.(**raw.SubscriberClient)
 	if !ok {
 		return false
@@ -628,7 +628,7 @@ func (s *subscription) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Subscription.ErrorAs
-func (*subscription) ErrorAs(err error, i interface{}) bool {
+func (*subscription) ErrorAs(err error, i any) bool {
 	return errorAs(err, i)
 }
 

--- a/pubsub/gcppubsub/gcppubsub_test.go
+++ b/pubsub/gcppubsub/gcppubsub_test.go
@@ -264,7 +264,7 @@ func (gcpAsTest) MessageCheck(m *pubsub.Message) error {
 	return nil
 }
 
-func (gcpAsTest) BeforeSend(as func(interface{}) bool) error {
+func (gcpAsTest) BeforeSend(as func(any) bool) error {
 	var ppm *pubsubpb.PubsubMessage
 	if !as(&ppm) {
 		return fmt.Errorf("cast failed for %T", &ppm)
@@ -272,7 +272,7 @@ func (gcpAsTest) BeforeSend(as func(interface{}) bool) error {
 	return nil
 }
 
-func (gcpAsTest) AfterSend(as func(interface{}) bool) error {
+func (gcpAsTest) AfterSend(as func(any) bool) error {
 	var msgId string
 	if !as(&msgId) {
 		return fmt.Errorf("cast failed for %T", &msgId)

--- a/pubsub/kafkapubsub/kafka.go
+++ b/pubsub/kafkapubsub/kafka.go
@@ -286,7 +286,7 @@ func (t *topic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 			Headers: headers,
 		}
 		if dm.BeforeSend != nil {
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				if p, ok := i.(**sarama.ProducerMessage); ok {
 					*p = pm
 					return true
@@ -306,7 +306,7 @@ func (t *topic) SendBatch(ctx context.Context, dms []*driver.Message) error {
 	}
 	for _, dm := range dms {
 		if dm.AfterSend != nil {
-			asFunc := func(i interface{}) bool { return false }
+			asFunc := func(i any) bool { return false }
 			if err := dm.AfterSend(asFunc); err != nil {
 				return err
 			}
@@ -326,7 +326,7 @@ func (t *topic) IsRetryable(error) bool {
 }
 
 // As implements driver.Topic.As.
-func (t *topic) As(i interface{}) bool {
+func (t *topic) As(i any) bool {
 	if p, ok := i.(*sarama.SyncProducer); ok {
 		*p = t.producer
 		return true
@@ -335,7 +335,7 @@ func (t *topic) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Topic.ErrorAs.
-func (t *topic) ErrorAs(err error, i interface{}) bool {
+func (t *topic) ErrorAs(err error, i any) bool {
 	return errorAs(err, i)
 }
 
@@ -581,7 +581,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 			Body:       msg.Value,
 			Metadata:   md,
 			AckID:      ack,
-			AsFunc: func(i interface{}) bool {
+			AsFunc: func(i any) bool {
 				if p, ok := i.(**sarama.ConsumerMessage); ok {
 					*p = msg
 					return true
@@ -646,7 +646,7 @@ func (*subscription) IsRetryable(error) bool {
 }
 
 // As implements driver.Subscription.As.
-func (s *subscription) As(i interface{}) bool {
+func (s *subscription) As(i any) bool {
 	if p, ok := i.(*sarama.ConsumerGroup); ok {
 		*p = s.consumerGroup
 		return true
@@ -661,7 +661,7 @@ func (s *subscription) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Subscription.ErrorAs.
-func (s *subscription) ErrorAs(err error, i interface{}) bool {
+func (s *subscription) ErrorAs(err error, i any) bool {
 	return errorAs(err, i)
 }
 
@@ -670,7 +670,7 @@ func (*subscription) ErrorCode(err error) gcerrors.ErrorCode {
 	return errorCode(err)
 }
 
-func errorAs(err error, i interface{}) bool {
+func errorAs(err error, i any) bool {
 	switch terr := err.(type) {
 	case sarama.ConsumerError:
 		if p, ok := i.(*sarama.ConsumerError); ok {

--- a/pubsub/kafkapubsub/kafka_test.go
+++ b/pubsub/kafkapubsub/kafka_test.go
@@ -173,7 +173,7 @@ func (asTest) MessageCheck(m *pubsub.Message) error {
 	return nil
 }
 
-func (asTest) BeforeSend(as func(interface{}) bool) error {
+func (asTest) BeforeSend(as func(any) bool) error {
 	var pm *sarama.ProducerMessage
 	if !as(&pm) {
 		return fmt.Errorf("cast failed for %T", &pm)
@@ -181,7 +181,7 @@ func (asTest) BeforeSend(as func(interface{}) bool) error {
 	return nil
 }
 
-func (asTest) AfterSend(as func(interface{}) bool) error {
+func (asTest) AfterSend(as func(any) bool) error {
 	return nil
 }
 
@@ -232,7 +232,7 @@ func TestKafkaKey(t *testing.T) {
 			keyName: keyValue,
 		},
 		Body: []byte("hello world"),
-		BeforeSend: func(as func(interface{}) bool) error {
+		BeforeSend: func(as func(any) bool) error {
 			// Verify that the Key field was set correctly on the outgoing Kafka
 			// message.
 			var pm *sarama.ProducerMessage

--- a/pubsub/mempubsub/mem.go
+++ b/pubsub/mempubsub/mem.go
@@ -174,15 +174,15 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 	for i, m := range ms {
 		m.AckID = t.nextAckID + i
 		m.LoggableID = fmt.Sprintf("msg #%d", m.AckID)
-		m.AsFunc = func(interface{}) bool { return false }
+		m.AsFunc = func(any) bool { return false }
 
 		if m.BeforeSend != nil {
-			if err := m.BeforeSend(func(interface{}) bool { return false }); err != nil {
+			if err := m.BeforeSend(func(any) bool { return false }); err != nil {
 				return err
 			}
 		}
 		if m.AfterSend != nil {
-			if err := m.AfterSend(func(interface{}) bool { return false }); err != nil {
+			if err := m.AfterSend(func(any) bool { return false }); err != nil {
 				return err
 			}
 		}
@@ -201,7 +201,7 @@ func (*topic) IsRetryable(error) bool { return false }
 // It supports *topic so that NewSubscription can recover a *topic
 // from the portable type (see below). External users won't be able
 // to use As because topic isn't exported.
-func (t *topic) As(i interface{}) bool {
+func (t *topic) As(i any) bool {
 	x, ok := i.(**topic)
 	if !ok {
 		return false
@@ -211,7 +211,7 @@ func (t *topic) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Topic.ErrorAs
-func (*topic) ErrorAs(error, interface{}) bool {
+func (*topic) ErrorAs(error, any) bool {
 	return false
 }
 
@@ -390,10 +390,10 @@ func (s *subscription) SendNacks(ctx context.Context, ackIDs []driver.AckID) err
 func (*subscription) IsRetryable(error) bool { return false }
 
 // As implements driver.Subscription.As.
-func (s *subscription) As(i interface{}) bool { return false }
+func (s *subscription) As(i any) bool { return false }
 
 // ErrorAs implements driver.Subscription.ErrorAs
-func (*subscription) ErrorAs(error, interface{}) bool {
+func (*subscription) ErrorAs(error, any) bool {
 	return false
 }
 

--- a/pubsub/natspubsub/nats.go
+++ b/pubsub/natspubsub/nats.go
@@ -361,7 +361,7 @@ func (t *topic) sendMessage(m *driver.Message) error {
 		return err
 	}
 	if m.BeforeSend != nil {
-		asFunc := func(i interface{}) bool { return false }
+		asFunc := func(i any) bool { return false }
 		if err := m.BeforeSend(asFunc); err != nil {
 			return err
 		}
@@ -370,7 +370,7 @@ func (t *topic) sendMessage(m *driver.Message) error {
 		return err
 	}
 	if m.AfterSend != nil {
-		asFunc := func(i interface{}) bool { return false }
+		asFunc := func(i any) bool { return false }
 		if err := m.AfterSend(asFunc); err != nil {
 			return err
 		}
@@ -381,7 +381,7 @@ func (t *topic) sendMessage(m *driver.Message) error {
 func (t *topic) sendMessageV2(m *driver.Message) error {
 	msg := encodeMessageV2(m, t.subj)
 	if m.BeforeSend != nil {
-		asFunc := func(i interface{}) bool {
+		asFunc := func(i any) bool {
 			if nm, ok := i.(**nats.Msg); ok {
 				*nm = msg
 				return true
@@ -398,7 +398,7 @@ func (t *topic) sendMessageV2(m *driver.Message) error {
 	}
 
 	if m.AfterSend != nil {
-		asFunc := func(i interface{}) bool { return false }
+		asFunc := func(i any) bool { return false }
 		if err := m.AfterSend(asFunc); err != nil {
 			return err
 		}
@@ -410,7 +410,7 @@ func (t *topic) sendMessageV2(m *driver.Message) error {
 func (*topic) IsRetryable(error) bool { return false }
 
 // As implements driver.Topic.As.
-func (t *topic) As(i interface{}) bool {
+func (t *topic) As(i any) bool {
 	c, ok := i.(**nats.Conn)
 	if !ok {
 		return false
@@ -420,7 +420,7 @@ func (t *topic) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Topic.ErrorAs
-func (*topic) ErrorAs(error, interface{}) bool {
+func (*topic) ErrorAs(error, any) bool {
 	return false
 }
 
@@ -535,7 +535,7 @@ func decode(msg *nats.Msg) (*driver.Message, error) {
 	return &dm, nil
 }
 
-func messageAsFunc(msg *nats.Msg) func(interface{}) bool {
+func messageAsFunc(msg *nats.Msg) func(any) bool {
 	return func(i any) bool {
 		p, ok := i.(**nats.Msg)
 		if !ok {
@@ -565,7 +565,7 @@ func (s *subscription) SendNacks(ctx context.Context, ids []driver.AckID) error 
 func (s *subscription) IsRetryable(error) bool { return false }
 
 // As implements driver.Subscription.As.
-func (s *subscription) As(i interface{}) bool {
+func (s *subscription) As(i any) bool {
 	c, ok := i.(**nats.Subscription)
 	if !ok {
 		return false
@@ -575,7 +575,7 @@ func (s *subscription) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Subscription.ErrorAs
-func (*subscription) ErrorAs(error, interface{}) bool {
+func (*subscription) ErrorAs(error, any) bool {
 	return false
 }
 

--- a/pubsub/natspubsub/nats_test.go
+++ b/pubsub/natspubsub/nats_test.go
@@ -180,7 +180,7 @@ func (natsAsTest) MessageCheck(m *pubsub.Message) error {
 	return nil
 }
 
-func (n natsAsTest) BeforeSend(as func(interface{}) bool) error {
+func (n natsAsTest) BeforeSend(as func(any) bool) error {
 	if !n.useV2 {
 		return nil
 	}
@@ -196,7 +196,7 @@ func (n natsAsTest) BeforeSend(as func(interface{}) bool) error {
 	return nil
 }
 
-func (natsAsTest) AfterSend(as func(interface{}) bool) error {
+func (natsAsTest) AfterSend(as func(any) bool) error {
 	return nil
 }
 
@@ -601,7 +601,7 @@ func TestCodec(t *testing.T) {
 		{Metadata: map[string]string{"a": "1"}, Body: []byte("hello")},
 		{
 			Metadata: map[string]string{"a": "1"}, Body: []byte("hello"),
-			AckID: "foo", AsFunc: func(interface{}) bool { return true },
+			AckID: "foo", AsFunc: func(any) bool { return true },
 		},
 	} {
 		t.Run("V1", func(t *testing.T) {

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -115,7 +115,7 @@ type Message struct {
 	//
 	// asFunc converts its argument to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	BeforeSend func(asFunc func(interface{}) bool) error
+	BeforeSend func(asFunc func(any) bool) error
 
 	// AfterSend is a callback used when sending a message. It will always be
 	// set to nil for received messages.
@@ -125,10 +125,10 @@ type Message struct {
 	//
 	// asFunc converts its argument to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	AfterSend func(asFunc func(interface{}) bool) error
+	AfterSend func(asFunc func(any) bool) error
 
 	// asFunc invokes driver.Message.AsFunc.
-	asFunc func(interface{}) bool
+	asFunc func(any) bool
 
 	// ack is a closure that queues this message for the action (ack or nack).
 	ack func(isAck bool)
@@ -207,7 +207,7 @@ func (m *Message) Nack() {
 // examples in this package for examples, and the driver package
 // documentation for the specific types supported for that driver.
 // As panics unless it is called on a message obtained from Subscription.Receive.
-func (m *Message) As(i interface{}) bool {
+func (m *Message) As(i any) bool {
 	if m.asFunc == nil {
 		panic("As called on a Message that was not obtained from Receive")
 	}
@@ -298,7 +298,7 @@ func (t *Topic) Shutdown(ctx context.Context) (err error) {
 // See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the driver package
 // documentation for the specific types supported for that driver.
-func (t *Topic) As(i interface{}) bool {
+func (t *Topic) As(i any) bool {
 	return t.driver.As(i)
 }
 
@@ -306,7 +306,7 @@ func (t *Topic) As(i interface{}) bool {
 // ErrorAs panics if i is nil or not a pointer.
 // ErrorAs returns false if err == nil.
 // See https://gocloud.dev/concepts/as/ for background information.
-func (t *Topic) ErrorAs(err error, i interface{}) bool {
+func (t *Topic) ErrorAs(err error, i any) bool {
 	return gcerr.ErrorAs(err, i, t.driver.ErrorAs)
 }
 
@@ -315,7 +315,7 @@ var NewTopic = newTopic
 
 // newSendBatcher creates a batcher for topics, for use with NewTopic.
 func newSendBatcher(ctx context.Context, t *Topic, dt driver.Topic, opts *batcher.Options) *batcher.Batcher {
-	handler := func(items interface{}) error {
+	handler := func(items any) error {
 		dms := items.([]*driver.Message)
 		err := retry.Call(ctx, gax.Backoff{}, dt.IsRetryable, func() (err error) {
 			ctx2 := t.tracer.Start(ctx, "driver.Topic.SendBatch")
@@ -355,7 +355,7 @@ var (
 	OpenCensusViews = oc.Views(pkgName, latencyMeasure)
 )
 
-func newTracer(driver interface{}) *oc.Tracer {
+func newTracer(driver any) *oc.Tracer {
 	return &oc.Tracer{
 		Package:        pkgName,
 		Provider:       oc.ProviderName(driver),
@@ -729,7 +729,7 @@ func (s *Subscription) Shutdown(ctx context.Context) (err error) {
 // See https://gocloud.dev/concepts/as/ for background information, the "As"
 // examples in this package for examples, and the driver package
 // documentation for the specific types supported for that driver.
-func (s *Subscription) As(i interface{}) bool {
+func (s *Subscription) As(i any) bool {
 	return s.driver.As(i)
 }
 
@@ -737,7 +737,7 @@ func (s *Subscription) As(i interface{}) bool {
 // ErrorAs panics if i is nil or not a pointer.
 // ErrorAs returns false if err == nil.
 // See Topic.As for more details.
-func (s *Subscription) ErrorAs(err error, i interface{}) bool {
+func (s *Subscription) ErrorAs(err error, i any) bool {
 	return gcerr.ErrorAs(err, i, s.driver.ErrorAs)
 }
 
@@ -769,7 +769,7 @@ func newSubscription(ds driver.Subscription, recvBatchOpts, ackBatcherOpts *batc
 }
 
 func newAckBatcher(ctx context.Context, s *Subscription, ds driver.Subscription, opts *batcher.Options) *batcher.Batcher {
-	handler := func(items interface{}) error {
+	handler := func(items any) error {
 		var acks, nacks []driver.AckID
 		for _, a := range items.([]*driver.AckInfo) {
 			if a.IsAck {

--- a/pubsub/rabbitpubsub/fake_test.go
+++ b/pubsub/rabbitpubsub/fake_test.go
@@ -103,7 +103,7 @@ func (ch *fakeChannel) getExchange(name string) (*exchange, error) {
 // errorf returns an amqp.Error and closes the channel. (In the AMQP protocol, any channel error
 // closes the channel and makes it unusable.)
 // It must be called with ch.conn.mu held.
-func (ch *fakeChannel) errorf(code int, reasonFormat string, args ...interface{}) error {
+func (ch *fakeChannel) errorf(code int, reasonFormat string, args ...any) error {
 	_ = ch.Close()
 	return &amqp.Error{Code: code, Reason: fmt.Sprintf(reasonFormat, args...)}
 }

--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -301,7 +301,7 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 	for _, m := range ms {
 		routingKey, pub := toRoutingKeyAndAMQPPublishing(m, t.opts)
 		if m.BeforeSend != nil {
-			asFunc := func(i interface{}) bool {
+			asFunc := func(i any) bool {
 				if p, ok := i.(**amqp.Publishing); ok {
 					*p = &pub
 					return true
@@ -317,7 +317,7 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 			break
 		}
 		if m.AfterSend != nil {
-			asFunc := func(i interface{}) bool { return false }
+			asFunc := func(i any) bool { return false }
 			if err := m.AfterSend(asFunc); err != nil {
 				return err
 			}
@@ -522,7 +522,7 @@ func isRetryable(err error) bool {
 }
 
 // As implements driver.Topic.As.
-func (t *topic) As(i interface{}) bool {
+func (t *topic) As(i any) bool {
 	c, ok := i.(**amqp.Connection)
 	if !ok {
 		return false
@@ -536,11 +536,11 @@ func (t *topic) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Topic.ErrorAs
-func (*topic) ErrorAs(err error, i interface{}) bool {
+func (*topic) ErrorAs(err error, i any) bool {
 	return errorAs(err, i)
 }
 
-func errorAs(err error, i interface{}) bool {
+func errorAs(err error, i any) bool {
 	var aerr *amqp.Error
 	if errors.As(err, &aerr) {
 		if p, ok := i.(**amqp.Error); ok {
@@ -721,7 +721,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 
 // toDriverMessage converts an amqp.Delivery (a received message) to a driver.Message.
 func toDriverMessage(d amqp.Delivery, opts *SubscriptionOptions) *driver.Message {
-	// Delivery.Headers is a map[string]interface{}, so we have to
+	// Delivery.Headers is a map[string]any, so we have to
 	// convert each value to a string.
 	md := map[string]string{}
 	for k, v := range d.Headers {
@@ -743,7 +743,7 @@ func toDriverMessage(d amqp.Delivery, opts *SubscriptionOptions) *driver.Message
 		Body:       d.Body,
 		AckID:      d.DeliveryTag,
 		Metadata:   md,
-		AsFunc: func(i interface{}) bool {
+		AsFunc: func(i any) bool {
 			p, ok := i.(*amqp.Delivery)
 			if !ok {
 				return false
@@ -808,7 +808,7 @@ func (*subscription) ErrorCode(err error) gcerrors.ErrorCode {
 }
 
 // As implements driver.Subscription.As.
-func (s *subscription) As(i interface{}) bool {
+func (s *subscription) As(i any) bool {
 	c, ok := i.(**amqp.Connection)
 	if !ok {
 		return false
@@ -822,7 +822,7 @@ func (s *subscription) As(i interface{}) bool {
 }
 
 // ErrorAs implements driver.Subscription.ErrorAs
-func (*subscription) ErrorAs(err error, i interface{}) bool {
+func (*subscription) ErrorAs(err error, i any) bool {
 	return errorAs(err, i)
 }
 

--- a/pubsub/rabbitpubsub/rabbit_test.go
+++ b/pubsub/rabbitpubsub/rabbit_test.go
@@ -373,7 +373,7 @@ func (r rabbitAsTest) MessageCheck(m *pubsub.Message) error {
 	return nil
 }
 
-func (rabbitAsTest) BeforeSend(as func(interface{}) bool) error {
+func (rabbitAsTest) BeforeSend(as func(any) bool) error {
 	var pub *amqp.Publishing
 	if !as(&pub) {
 		return fmt.Errorf("cast failed for %T", &pub)
@@ -381,7 +381,7 @@ func (rabbitAsTest) BeforeSend(as func(interface{}) bool) error {
 	return nil
 }
 
-func (rabbitAsTest) AfterSend(as func(interface{}) bool) error {
+func (rabbitAsTest) AfterSend(as func(any) bool) error {
 	return nil
 }
 

--- a/runtimevar/awsparamstore/awsparamstore.go
+++ b/runtimevar/awsparamstore/awsparamstore.go
@@ -210,7 +210,7 @@ func newWatcher(useV2 bool, sess client.ConfigProvider, clientV2 *ssmv2.Client, 
 
 // state implements driver.State.
 type state struct {
-	val        interface{}
+	val        any
 	rawGetV1   *ssm.GetParameterOutput
 	rawGetV2   *ssmv2.GetParameterOutput
 	updateTime time.Time
@@ -219,7 +219,7 @@ type state struct {
 }
 
 // Value implements driver.State.Value.
-func (s *state) Value() (interface{}, error) {
+func (s *state) Value() (any, error) {
 	return s.val, s.err
 }
 
@@ -229,7 +229,7 @@ func (s *state) UpdateTime() time.Time {
 }
 
 // As implements driver.State.As.
-func (s *state) As(i interface{}) bool {
+func (s *state) As(i any) bool {
 	switch p := i.(type) {
 	case **ssm.GetParameterOutput:
 		*p = s.rawGetV1
@@ -375,7 +375,7 @@ func (w *watcher) Close() error {
 }
 
 // ErrorAs implements driver.ErrorAs.
-func (w *watcher) ErrorAs(err error, i interface{}) bool {
+func (w *watcher) ErrorAs(err error, i any) bool {
 	if w.useV2 {
 		return errors.As(err, i)
 	}

--- a/runtimevar/awssecretsmanager/awssecretsmanager.go
+++ b/runtimevar/awssecretsmanager/awssecretsmanager.go
@@ -200,7 +200,7 @@ func OpenVariableV2(client *secretsmanagerv2.Client, name string, decoder *runti
 
 // state implements driver.State.
 type state struct {
-	val        interface{}
+	val        any
 	rawGetV1   *secretsmanager.GetSecretValueOutput
 	rawGetV2   *secretsmanagerv2.GetSecretValueOutput
 	rawDescV1  *secretsmanager.DescribeSecretOutput
@@ -211,7 +211,7 @@ type state struct {
 }
 
 // Value implements driver.State.Value.
-func (s *state) Value() (interface{}, error) {
+func (s *state) Value() (any, error) {
 	return s.val, s.err
 }
 
@@ -221,7 +221,7 @@ func (s *state) UpdateTime() time.Time {
 }
 
 // As implements driver.State.As.
-func (s *state) As(i interface{}) bool {
+func (s *state) As(i any) bool {
 	switch p := i.(type) {
 	case **secretsmanager.GetSecretValueOutput:
 		*p = s.rawGetV1
@@ -426,7 +426,7 @@ func (w *watcher) Close() error {
 }
 
 // ErrorAs implements driver.ErrorAs.
-func (w *watcher) ErrorAs(err error, i interface{}) bool {
+func (w *watcher) ErrorAs(err error, i any) bool {
 	if w.useV2 {
 		return errors.As(err, i)
 	}

--- a/runtimevar/blobvar/blobvar.go
+++ b/runtimevar/blobvar/blobvar.go
@@ -162,14 +162,14 @@ func newWatcher(bucket *blob.Bucket, key string, decoder *runtimevar.Decoder, op
 
 // state implements driver.State.
 type state struct {
-	val        interface{}
+	val        any
 	updateTime time.Time
 	rawBytes   []byte
 	err        error
 }
 
 // Value implements driver.State.Value.
-func (s *state) Value() (interface{}, error) {
+func (s *state) Value() (any, error) {
 	return s.val, s.err
 }
 
@@ -179,7 +179,7 @@ func (s *state) UpdateTime() time.Time {
 }
 
 // As implements driver.State.As.
-func (s *state) As(i interface{}) bool {
+func (s *state) As(i any) bool {
 	return false
 }
 
@@ -241,7 +241,7 @@ func (w *watcher) Close() error {
 // ErrorAs implements driver.ErrorAs.
 // Since blobvar uses the blob package, ErrorAs delegates
 // to the bucket's ErrorAs method.
-func (w *watcher) ErrorAs(err error, i interface{}) bool {
+func (w *watcher) ErrorAs(err error, i any) bool {
 	return w.bucket.ErrorAs(err, i)
 }
 

--- a/runtimevar/blobvar/blobvar_test.go
+++ b/runtimevar/blobvar/blobvar_test.go
@@ -117,7 +117,7 @@ func TestOpenVariable(t *testing.T) {
 		URL          string
 		WantErr      bool
 		WantWatchErr bool
-		Want         interface{}
+		Want         any
 	}{
 		// myvar does not exist.
 		{"mem://", "blob://myvar", false, true, nil},
@@ -138,7 +138,7 @@ func TestOpenVariable(t *testing.T) {
 		// Working example with string decoder.
 		{bucketURL, "blob://myvar.txt?decoder=string", false, false, "hello world!"},
 		// Working example with JSON decoder.
-		{bucketURL, "blob://myvar.json?decoder=jsonmap", false, false, &map[string]interface{}{"Foo": "Bar"}},
+		{bucketURL, "blob://myvar.json?decoder=jsonmap", false, false, &map[string]any{"Foo": "Bar"}},
 		// Setting wait.
 		{bucketURL, "blob://myvar.txt?wait=2m", false, false, []byte("hello world!")},
 		// Invalid wait.

--- a/runtimevar/constantvar/constantvar.go
+++ b/runtimevar/constantvar/constantvar.go
@@ -104,7 +104,7 @@ func (o *URLOpener) OpenVariableURL(ctx context.Context, u *url.URL) (*runtimeva
 var errNotExist = errors.New("variable does not exist")
 
 // New constructs a *runtimevar.Variable holding value.
-func New(value interface{}) *runtimevar.Variable {
+func New(value any) *runtimevar.Variable {
 	return runtimevar.New(&watcher{value: value, t: time.Now()})
 }
 
@@ -144,13 +144,13 @@ func NewError(err error) *runtimevar.Variable {
 
 // watcher implements driver.Watcher and driver.State.
 type watcher struct {
-	value interface{}
+	value any
 	err   error
 	t     time.Time
 }
 
 // Value implements driver.State.Value.
-func (w *watcher) Value() (interface{}, error) {
+func (w *watcher) Value() (any, error) {
 	return w.value, w.err
 }
 
@@ -160,7 +160,7 @@ func (w *watcher) UpdateTime() time.Time {
 }
 
 // As implements driver.State.As.
-func (w *watcher) As(i interface{}) bool {
+func (w *watcher) As(i any) bool {
 	return false
 }
 
@@ -180,7 +180,7 @@ func (w *watcher) WatchVariable(ctx context.Context, prev driver.State) (driver.
 func (*watcher) Close() error { return nil }
 
 // ErrorAs implements driver.ErrorAs.
-func (*watcher) ErrorAs(err error, i interface{}) bool { return false }
+func (*watcher) ErrorAs(err error, i any) bool { return false }
 
 // ErrorCode implements driver.ErrorCode
 func (*watcher) ErrorCode(err error) gcerrors.ErrorCode {

--- a/runtimevar/constantvar/constantvar_test.go
+++ b/runtimevar/constantvar/constantvar_test.go
@@ -181,7 +181,7 @@ func TestOpenVariable(t *testing.T) {
 		URL          string
 		WantErr      bool
 		WantWatchErr bool
-		Want         interface{}
+		Want         any
 	}{
 		// Empty URL results in empty byte slice.
 		{"constant://", false, false, []byte("")},
@@ -190,7 +190,7 @@ func TestOpenVariable(t *testing.T) {
 		// String value.
 		{"constant://?val=hello+world&decoder=string", false, false, "hello world"},
 		// JSON value; val parameter is {"Foo": "Bar"}, URL-encoded.
-		{"constant://?val=%7B%22Foo%22%3A%22Bar%22%7d&decoder=jsonmap", false, false, &map[string]interface{}{"Foo": "Bar"}},
+		{"constant://?val=%7B%22Foo%22%3A%22Bar%22%7d&decoder=jsonmap", false, false, &map[string]any{"Foo": "Bar"}},
 		// Environment variable value.
 		{"constant://?envvar=RUNTIMEVAR_CONST_TEST&decoder=string", false, false, "hello world"},
 		// Error.

--- a/runtimevar/driver/driver.go
+++ b/runtimevar/driver/driver.go
@@ -38,13 +38,13 @@ func WaitDuration(d time.Duration) time.Duration {
 // State represents the current state of a variable.
 type State interface {
 	// Value returns the current variable value.
-	Value() (interface{}, error)
+	Value() (any, error)
 	// UpdateTime returns the update time for the variable.
 	UpdateTime() time.Time
 
 	// As converts i to driver-specific types.
 	// See https://gocloud.dev/concepts/as/ for background information.
-	As(interface{}) bool
+	As(any) bool
 }
 
 // Watcher watches for updates on a variable and returns an updated Variable object if
@@ -91,7 +91,7 @@ type Watcher interface {
 
 	// ErrorAs allows drivers to expose driver-specific types for returned
 	// errors; see State.As for more details.
-	ErrorAs(error, interface{}) bool
+	ErrorAs(error, any) bool
 
 	// ErrorCode should return a code that describes the error, which was returned by
 	// one of the other methods in this interface.

--- a/runtimevar/etcdvar/etcdvar.go
+++ b/runtimevar/etcdvar/etcdvar.go
@@ -155,7 +155,7 @@ var errNotExist = errors.New("variable does not exist")
 
 // state implements driver.State.
 type state struct {
-	val        interface{}
+	val        any
 	raw        *clientv3.GetResponse
 	updateTime time.Time
 	version    int64
@@ -163,7 +163,7 @@ type state struct {
 }
 
 // Value implements driver.State.Value.
-func (s *state) Value() (interface{}, error) {
+func (s *state) Value() (any, error) {
 	return s.val, s.err
 }
 
@@ -173,7 +173,7 @@ func (s *state) UpdateTime() time.Time {
 }
 
 // As implements driver.State.As.
-func (s *state) As(i interface{}) bool {
+func (s *state) As(i any) bool {
 	if s.raw == nil {
 		return false
 	}
@@ -305,7 +305,7 @@ func (w *watcher) Close() error {
 }
 
 // ErrorAs implements driver.ErrorAs.
-func (w *watcher) ErrorAs(err error, i interface{}) bool {
+func (w *watcher) ErrorAs(err error, i any) bool {
 	switch v := err.(type) {
 	case rpctypes.EtcdError:
 		if p, ok := i.(*rpctypes.EtcdError); ok {

--- a/runtimevar/etcdvar/etcdvar_test.go
+++ b/runtimevar/etcdvar/etcdvar_test.go
@@ -163,7 +163,7 @@ func TestOpenVariable(t *testing.T) {
 		URL          string
 		WantErr      bool
 		WantWatchErr bool
-		Want         interface{}
+		Want         any
 	}{
 		// Nonexistentvar does not exist, so we get an error from Watch.
 		{"etcd://nonexistentvar", false, true, nil},
@@ -176,7 +176,7 @@ func TestOpenVariable(t *testing.T) {
 		// Working example with default decoder.
 		{"etcd://string-var", false, false, []byte("hello world")},
 		// Working example with JSON decoder.
-		{"etcd://json-var?decoder=jsonmap", false, false, &map[string]interface{}{"Foo": "Bar"}},
+		{"etcd://json-var?decoder=jsonmap", false, false, &map[string]any{"Foo": "Bar"}},
 	}
 
 	for _, test := range tests {

--- a/runtimevar/filevar/filevar.go
+++ b/runtimevar/filevar/filevar.go
@@ -184,13 +184,13 @@ func (e *errNotExist) Error() string {
 
 // state implements driver.State.
 type state struct {
-	val        interface{}
+	val        any
 	updateTime time.Time
 	raw        []byte
 	err        error
 }
 
-func (s *state) Value() (interface{}, error) {
+func (s *state) Value() (any, error) {
 	return s.val, s.err
 }
 
@@ -198,7 +198,7 @@ func (s *state) UpdateTime() time.Time {
 	return s.updateTime
 }
 
-func (s *state) As(i interface{}) bool {
+func (s *state) As(i any) bool {
 	return false
 }
 
@@ -333,7 +333,7 @@ func (w *watcher) Close() error {
 }
 
 // ErrorAs implements driver.ErrorAs.
-func (w *watcher) ErrorAs(err error, i interface{}) bool { return false }
+func (w *watcher) ErrorAs(err error, i any) bool { return false }
 
 // ErrorCode implements driver.ErrorCode.
 func (*watcher) ErrorCode(err error) gcerrors.ErrorCode {

--- a/runtimevar/filevar/filevar_test.go
+++ b/runtimevar/filevar/filevar_test.go
@@ -217,7 +217,7 @@ func TestOpenVariableURL(t *testing.T) {
 		URL          string
 		WantErr      bool
 		WantWatchErr bool
-		Want         interface{}
+		Want         any
 	}{
 		// Variable construction succeeds, but the file does not exist.
 		{"file://" + nonexistentPath, false, true, nil},
@@ -230,15 +230,15 @@ func TestOpenVariableURL(t *testing.T) {
 		// Working example with string decoder.
 		{"file://" + txtPath + "?decoder=string", false, false, "hello world!"},
 		// Working example with JSON decoder.
-		{"file://" + jsonPath + "?decoder=jsonmap", false, false, &map[string]interface{}{"Foo": "Bar"}},
+		{"file://" + jsonPath + "?decoder=jsonmap", false, false, &map[string]any{"Foo": "Bar"}},
 		// Working example with decrypt (default) decoder.
 		{"file://" + secretsPath + "?decoder=decrypt", false, false, []byte(`{"Foo":"Bar"}`)},
 		// Working example with decrypt+bytes decoder.
 		{"file://" + secretsPath + "?decoder=decrypt+bytes", false, false, []byte(`{"Foo":"Bar"}`)},
 		// Working example with decrypt+json decoder.
-		{"file://" + secretsPath + "?decoder=decrypt+jsonmap", false, false, &map[string]interface{}{"Foo": "Bar"}},
+		{"file://" + secretsPath + "?decoder=decrypt+jsonmap", false, false, &map[string]any{"Foo": "Bar"}},
 		// Working example with escaped decrypt+json decoder
-		{"file://" + secretsPath + "?decoder=" + url.QueryEscape("decrypt+jsonmap"), false, false, &map[string]interface{}{"Foo": "Bar"}},
+		{"file://" + secretsPath + "?decoder=" + url.QueryEscape("decrypt+jsonmap"), false, false, &map[string]any{"Foo": "Bar"}},
 		// Setting wait.
 		{"file://" + txtPath + "?decoder=string&wait=1m", false, false, "hello world!"},
 		// Invalid wait.

--- a/runtimevar/gcpruntimeconfig/gcpruntimeconfig.go
+++ b/runtimevar/gcpruntimeconfig/gcpruntimeconfig.go
@@ -234,7 +234,7 @@ func VariableKey(projectID gcp.ProjectID, configID, variableName string) string 
 
 // state implements driver.State.
 type state struct {
-	val        interface{}
+	val        any
 	raw        *pb.Variable
 	updateTime time.Time
 	rawBytes   []byte
@@ -242,7 +242,7 @@ type state struct {
 }
 
 // Value implements driver.State.Value.
-func (s *state) Value() (interface{}, error) {
+func (s *state) Value() (any, error) {
 	return s.val, s.err
 }
 
@@ -252,7 +252,7 @@ func (s *state) UpdateTime() time.Time {
 }
 
 // As implements driver.State.As.
-func (s *state) As(i interface{}) bool {
+func (s *state) As(i any) bool {
 	if s.raw == nil {
 		return false
 	}
@@ -334,7 +334,7 @@ func (w *watcher) Close() error {
 }
 
 // ErrorAs implements driver.ErrorAs.
-func (w *watcher) ErrorAs(err error, i interface{}) bool {
+func (w *watcher) ErrorAs(err error, i any) bool {
 	// FromError converts err to a *status.Status.
 	s, _ := status.FromError(err)
 	if p, ok := i.(**status.Status); ok {

--- a/runtimevar/gcpsecretmanager/gcpsecretmanager.go
+++ b/runtimevar/gcpsecretmanager/gcpsecretmanager.go
@@ -245,7 +245,7 @@ func SecretKey(projectID gcp.ProjectID, secretID string) string {
 
 // state implements driver.State.
 type state struct {
-	val        interface{}
+	val        any
 	raw        *secretmanagerpb.AccessSecretVersionResponse
 	updateTime time.Time
 	rawBytes   []byte
@@ -253,7 +253,7 @@ type state struct {
 }
 
 // Value implements driver.State.Value.
-func (s *state) Value() (interface{}, error) {
+func (s *state) Value() (any, error) {
 	return s.val, s.err
 }
 
@@ -263,7 +263,7 @@ func (s *state) UpdateTime() time.Time {
 }
 
 // As implements driver.State.As.
-func (s *state) As(i interface{}) bool {
+func (s *state) As(i any) bool {
 	if s.raw == nil {
 		return false
 	}
@@ -359,7 +359,7 @@ func (w *watcher) Close() error {
 }
 
 // ErrorAs implements driver.ErrorAs.
-func (w *watcher) ErrorAs(err error, i interface{}) bool {
+func (w *watcher) ErrorAs(err error, i any) bool {
 	// FromError converts err to a *status.Status.
 	s, _ := status.FromError(err)
 	if p, ok := i.(**status.Status); ok {

--- a/runtimevar/httpvar/httpvar.go
+++ b/runtimevar/httpvar/httpvar.go
@@ -138,7 +138,7 @@ func OpenVariable(client *http.Client, urlStr string, decoder *runtimevar.Decode
 }
 
 type state struct {
-	val        interface{}
+	val        any
 	raw        *http.Response
 	rawBytes   []byte
 	updateTime time.Time
@@ -146,7 +146,7 @@ type state struct {
 }
 
 // Value implements driver.State.Value.
-func (s *state) Value() (interface{}, error) {
+func (s *state) Value() (any, error) {
 	return s.val, s.err
 }
 
@@ -156,7 +156,7 @@ func (s *state) UpdateTime() time.Time {
 }
 
 // As implements driver.State.As.
-func (s *state) As(i interface{}) bool {
+func (s *state) As(i any) bool {
 	if s.raw == nil {
 		return false
 	}
@@ -263,7 +263,7 @@ func (w *watcher) Close() error {
 }
 
 // ErrorAs implements driver.ErrorAs.
-func (w *watcher) ErrorAs(err error, i interface{}) bool {
+func (w *watcher) ErrorAs(err error, i any) bool {
 	switch v := err.(type) {
 	case *url.Error:
 		if p, ok := i.(*url.Error); ok {

--- a/runtimevar/httpvar/httpvar_test.go
+++ b/runtimevar/httpvar/httpvar_test.go
@@ -302,7 +302,7 @@ func TestOpenVariableURL(t *testing.T) {
 		URL          string
 		WantErr      bool
 		WantWatchErr bool
-		Want         interface{}
+		Want         any
 	}{
 		// Nonexistentvar does not exist, so we get an error from Watch.
 		{baseURL + "/nonexistentvar", false, true, nil},
@@ -313,7 +313,7 @@ func TestOpenVariableURL(t *testing.T) {
 		// Working example with default decoder.
 		{baseURL + "/string-var", false, false, []byte("hello world")},
 		// Working example with JSON decoder.
-		{baseURL + "/json-var?decoder=jsonmap", false, false, &map[string]interface{}{"Foo": "Bar"}},
+		{baseURL + "/json-var?decoder=jsonmap", false, false, &map[string]any{"Foo": "Bar"}},
 		// Setting wait.
 		{baseURL + "/string-var?decoder=string&wait=1m", false, false, "hello world"},
 		// Invalid wait.
@@ -347,12 +347,12 @@ func TestOpenVariableURL(t *testing.T) {
 type mockServer struct {
 	baseURL   string
 	close     func()
-	responses map[string]interface{}
+	responses map[string]any
 	authUser  string
 	authPwd   string
 }
 
-func (m *mockServer) SetResponse(name string, response interface{}) {
+func (m *mockServer) SetResponse(name string, response any) {
 	m.responses[name] = response
 }
 
@@ -361,7 +361,7 @@ func (m *mockServer) DeleteResponse(name string) {
 }
 
 func newMockServer() *mockServer {
-	mock := &mockServer{responses: map[string]interface{}{}}
+	mock := &mockServer{responses: map[string]any{}}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/runtimevar/runtimevar_test.go
+++ b/runtimevar/runtimevar_test.go
@@ -46,9 +46,9 @@ type state struct {
 	err        error
 }
 
-func (s *state) Value() (interface{}, error) { return s.val, s.err }
-func (s *state) UpdateTime() time.Time       { return s.updateTime }
-func (s *state) As(i interface{}) bool       { return false }
+func (s *state) Value() (any, error)   { return s.val, s.err }
+func (s *state) UpdateTime() time.Time { return s.updateTime }
+func (s *state) As(i any) bool         { return false }
 
 // fakeWatcher is a fake implementation of driver.Watcher that returns a set *state.
 type fakeWatcher struct {
@@ -535,7 +535,7 @@ func (o *fakeOpener) OpenVariableURL(ctx context.Context, u *url.URL) (*Variable
 func TestDecoder(t *testing.T) {
 	type Struct struct {
 		FieldA string
-		FieldB map[string]interface{}
+		FieldB map[string]any
 	}
 
 	num := 4321
@@ -543,7 +543,7 @@ func TestDecoder(t *testing.T) {
 	str := "boring string"
 	strptr := &str
 
-	inputs := []interface{}{
+	inputs := []any{
 		str,
 		strptr,
 		num,
@@ -551,7 +551,7 @@ func TestDecoder(t *testing.T) {
 		100.1,
 		Struct{
 			FieldA: "hello",
-			FieldB: map[string]interface{}{
+			FieldB: map[string]any{
 				"hello": "world",
 			},
 		},
@@ -561,7 +561,7 @@ func TestDecoder(t *testing.T) {
 		map[string]string{
 			"slice": "pizza",
 		},
-		&map[string]interface{}{},
+		&map[string]any{},
 		[]string{"hello", "world"},
 		&[]int{1, 0, 1},
 		[...]float64{3.1415},
@@ -570,7 +570,7 @@ func TestDecoder(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc     string
-		encodeFn func(interface{}) ([]byte, error)
+		encodeFn func(any) ([]byte, error)
 		decodeFn Decode
 	}{
 		{
@@ -606,7 +606,7 @@ func TestDecoder(t *testing.T) {
 	}
 }
 
-func gobMarshal(v interface{}) ([]byte, error) {
+func gobMarshal(v any) ([]byte, error) {
 	var buf bytes.Buffer
 	if err := gob.NewEncoder(&buf).Encode(v); err != nil {
 		return nil, err
@@ -646,19 +646,19 @@ func TestDecryptDecoder(t *testing.T) {
 
 	tests := []struct {
 		desc      string
-		in        interface{}
-		encodeFn  func(interface{}) ([]byte, error)
+		in        any
+		encodeFn  func(any) ([]byte, error)
 		postDecFn Decode
 	}{
 		{
 			desc:     "Bytes",
 			in:       []byte("hello world"),
-			encodeFn: func(obj interface{}) ([]byte, error) { return obj.([]byte), nil },
+			encodeFn: func(obj any) ([]byte, error) { return obj.([]byte), nil },
 		},
 		{
 			desc:      "String",
 			in:        "hello world",
-			encodeFn:  func(obj interface{}) ([]byte, error) { return []byte(obj.(string)), nil },
+			encodeFn:  func(obj any) ([]byte, error) { return []byte(obj.(string)), nil },
 			postDecFn: StringDecode,
 		},
 		{

--- a/samples/gocdk-blob/main.go
+++ b/samples/gocdk-blob/main.go
@@ -72,7 +72,7 @@ func (*downloadCmd) Usage() string {
 
 func (*downloadCmd) SetFlags(_ *flag.FlagSet) {}
 
-func (*downloadCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (*downloadCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	if f.NArg() != 2 {
 		f.Usage()
 		return subcommands.ExitUsageError
@@ -126,7 +126,7 @@ func (cmd *listCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&cmd.delimiter, "d", "/", "directory delimiter; empty string returns flattened listing")
 }
 
-func (cmd *listCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (cmd *listCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	if f.NArg() != 1 {
 		f.Usage()
 		return subcommands.ExitUsageError
@@ -175,7 +175,7 @@ func (*uploadCmd) Usage() string {
 
 func (*uploadCmd) SetFlags(_ *flag.FlagSet) {}
 
-func (*uploadCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) (status subcommands.ExitStatus) {
+func (*uploadCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) (status subcommands.ExitStatus) {
 	if f.NArg() != 2 {
 		f.Usage()
 		return subcommands.ExitUsageError

--- a/samples/gocdk-docstore/main.go
+++ b/samples/gocdk-docstore/main.go
@@ -62,7 +62,7 @@ type Message struct {
 	ID               string // unique ID of each document
 	Date             string
 	Content          string
-	DocstoreRevision interface{}
+	DocstoreRevision any
 }
 
 func (m Message) String() string {
@@ -88,7 +88,7 @@ func (cmd *listCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&cmd.date, "d", "", "get the messages from this date, in the format YYYY-MM-DD")
 }
 
-func (cmd *listCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (cmd *listCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	if f.NArg() != 1 {
 		f.Usage()
 		return subcommands.ExitUsageError
@@ -145,7 +145,7 @@ func (p *putCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&p.date, "d", "", "date of document")
 }
 
-func (p *putCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (p *putCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	if f.NArg() != 2 {
 		f.Usage()
 		return subcommands.ExitUsageError
@@ -195,7 +195,7 @@ func (*updateCmd) Usage() string {
 
 func (*updateCmd) SetFlags(_ *flag.FlagSet) {}
 
-func (cmd *updateCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (cmd *updateCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	if f.NArg() != 3 {
 		f.Usage()
 		return subcommands.ExitUsageError
@@ -241,7 +241,7 @@ func (cmd *deleteCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&cmd.date, "d", "", "delete the messages from this date, in the format YYYY-MM-DD")
 }
 
-func (cmd *deleteCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (cmd *deleteCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	if f.NArg() != 1 {
 		f.Usage()
 		return subcommands.ExitUsageError

--- a/samples/gocdk-pubsub/main.go
+++ b/samples/gocdk-pubsub/main.go
@@ -73,7 +73,7 @@ func (*pubCmd) Usage() string {
 
 func (*pubCmd) SetFlags(_ *flag.FlagSet) {}
 
-func (*pubCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (*pubCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	if f.NArg() != 1 {
 		f.Usage()
 		return subcommands.ExitUsageError
@@ -129,7 +129,7 @@ func (cmd *subCmd) SetFlags(f *flag.FlagSet) {
 	f.IntVar(&cmd.n, "n", 0, "number of messages to receive, or 0 for unlimited")
 }
 
-func (cmd *subCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (cmd *subCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	if f.NArg() != 1 {
 		f.Usage()
 		return subcommands.ExitUsageError

--- a/samples/gocdk-runtimevar/main.go
+++ b/samples/gocdk-runtimevar/main.go
@@ -73,7 +73,7 @@ func (*catCmd) Usage() string {
 
 func (*catCmd) SetFlags(_ *flag.FlagSet) {}
 
-func (*catCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (*catCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	if f.NArg() != 1 {
 		f.Usage()
 		return subcommands.ExitUsageError
@@ -112,7 +112,7 @@ func (*watchCmd) Usage() string {
 
 func (*watchCmd) SetFlags(_ *flag.FlagSet) {}
 
-func (*watchCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (*watchCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	if f.NArg() != 1 {
 		f.Usage()
 		return subcommands.ExitUsageError

--- a/samples/gocdk-secrets/main.go
+++ b/samples/gocdk-secrets/main.go
@@ -78,7 +78,7 @@ func (cmd *decryptCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&cmd.base64out, "base64out", false, "the resulting plaintext should be base64 encoded before printing it out")
 }
 
-func (cmd *decryptCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (cmd *decryptCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	if f.NArg() != 2 {
 		f.Usage()
 		return subcommands.ExitUsageError
@@ -140,7 +140,7 @@ func (cmd *encryptCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&cmd.base64out, "base64out", true, "the resulting ciphertext should be base64-encoded before printing it out")
 }
 
-func (cmd *encryptCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (cmd *encryptCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	if f.NArg() != 2 {
 		f.Usage()
 		return subcommands.ExitUsageError

--- a/samples/order/common.go
+++ b/samples/order/common.go
@@ -27,7 +27,7 @@ type Order struct {
 	CreateTime       time.Time // time the order was created
 	FinishTime       time.Time // time the order was finished
 	Note             string    // note to the customer from the processor, describing success or error
-	DocstoreRevision interface{}
+	DocstoreRevision any
 }
 
 // OrderRequest is a request for an order. It is the contents of the messages

--- a/samples/order/frontend.go
+++ b/samples/order/frontend.go
@@ -224,7 +224,7 @@ func (f *frontend) newID() string {
 
 // executeTemplate executes t into a buffer using data, and if that succeeds it
 // writes the bytes to w.
-func executeTemplate(t *template.Template, data interface{}, w http.ResponseWriter) error {
+func executeTemplate(t *template.Template, data any, w http.ResponseWriter) error {
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, data); err != nil {
 		return err

--- a/secrets/awskms/kms.go
+++ b/secrets/awskms/kms.go
@@ -309,7 +309,7 @@ func (k *keeper) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) 
 func (k *keeper) Close() error { return nil }
 
 // ErrorAs implements driver.Keeper.ErrorAs.
-func (k *keeper) ErrorAs(err error, i interface{}) bool {
+func (k *keeper) ErrorAs(err error, i any) bool {
 	if k.useV2 {
 		return errors.As(err, i)
 	}

--- a/secrets/azurekeyvault/akv.go
+++ b/secrets/azurekeyvault/akv.go
@@ -244,7 +244,7 @@ func (k *keeper) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error)
 func (k *keeper) Close() error { return nil }
 
 // ErrorAs implements driver.Keeper.ErrorAs.
-func (k *keeper) ErrorAs(err error, i interface{}) bool {
+func (k *keeper) ErrorAs(err error, i any) bool {
 	return errors.As(err, i)
 }
 

--- a/secrets/driver/driver.go
+++ b/secrets/driver/driver.go
@@ -43,7 +43,7 @@ type Keeper interface {
 	// errors.
 	//
 	// See https://gocloud.dev/concepts/as/ for background information.
-	ErrorAs(err error, i interface{}) bool
+	ErrorAs(err error, i any) bool
 
 	// ErrorCode should return a code that describes the error, which was returned
 	// by one of the other methods in this interface.

--- a/secrets/gcpkms/kms.go
+++ b/secrets/gcpkms/kms.go
@@ -180,7 +180,7 @@ func (k *keeper) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) 
 func (k *keeper) Close() error { return nil }
 
 // ErrorAs implements driver.Keeper.ErrorAs.
-func (k *keeper) ErrorAs(err error, i interface{}) bool {
+func (k *keeper) ErrorAs(err error, i any) bool {
 	s, ok := status.FromError(err)
 	if !ok {
 		return false

--- a/secrets/hashivault/vault.go
+++ b/secrets/hashivault/vault.go
@@ -199,7 +199,7 @@ type keeper struct {
 func (k *keeper) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
 	out, err := k.client.Logical().Write(
 		path.Join(k.opts.Engine+"/decrypt", k.keyID),
-		map[string]interface{}{
+		map[string]any{
 			"ciphertext": string(ciphertext),
 		},
 	)
@@ -213,7 +213,7 @@ func (k *keeper) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error)
 func (k *keeper) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
 	secret, err := k.client.Logical().Write(
 		path.Join(k.opts.Engine+"/encrypt", k.keyID),
-		map[string]interface{}{
+		map[string]any{
 			"plaintext": plaintext,
 		},
 	)
@@ -227,7 +227,7 @@ func (k *keeper) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) 
 func (k *keeper) Close() error { return nil }
 
 // ErrorAs implements driver.Keeper.ErrorAs.
-func (k *keeper) ErrorAs(err error, i interface{}) bool {
+func (k *keeper) ErrorAs(err error, i any) bool {
 	return false
 }
 

--- a/secrets/hashivault/vault_test.go
+++ b/secrets/hashivault/vault_test.go
@@ -74,7 +74,7 @@ func newHarness(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
 			t.Fatal(err, "; run secrets/hashivault/localvault.sh to start a dev vault container")
 		}
 		if _, ok := s.Data["transit/"]; !ok {
-			if _, err := c.Logical().Write("sys/mounts/transit", map[string]interface{}{"type": "transit"}); err != nil {
+			if _, err := c.Logical().Write("sys/mounts/transit", map[string]any{"type": "transit"}); err != nil {
 				t.Fatal(err, "; run secrets/hashivault/localvault.sh to start a dev vault container")
 			}
 		}

--- a/secrets/localsecrets/localsecrets.go
+++ b/secrets/localsecrets/localsecrets.go
@@ -169,7 +169,7 @@ func (k *keeper) Decrypt(ctx context.Context, message []byte) ([]byte, error) {
 func (k *keeper) Close() error { return nil }
 
 // ErrorAs implements driver.Keeper.ErrorAs.
-func (k *keeper) ErrorAs(err error, i interface{}) bool {
+func (k *keeper) ErrorAs(err error, i any) bool {
 	return false
 }
 

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -148,7 +148,7 @@ func (k *Keeper) Close() error {
 //
 // ErrorAs panics if i is nil or not a pointer.
 // ErrorAs returns false if err == nil.
-func (k *Keeper) ErrorAs(err error, i interface{}) bool {
+func (k *Keeper) ErrorAs(err error, i any) bool {
 	return gcerr.ErrorAs(err, i, k.k.ErrorAs)
 }
 

--- a/server/requestlog/stackdriver_test.go
+++ b/server/requestlog/stackdriver_test.go
@@ -75,11 +75,11 @@ func TestStackdriverLog(t *testing.T) {
 		t.Fatal("Unmarshal:", err)
 	}
 
-	var r map[string]interface{}
+	var r map[string]any
 	if err := json.Unmarshal(got, &r); err != nil {
 		t.Error("Unmarshal record:", err)
 	} else {
-		rr, _ := r["httpRequest"].(map[string]interface{})
+		rr, _ := r["httpRequest"].(map[string]any)
 		if rr == nil {
 			t.Error("httpRequest does not exist in record or is not a JSON object")
 		}
@@ -110,7 +110,7 @@ func TestStackdriverLog(t *testing.T) {
 		if got, want := jsonString(rr, "latency"), "5.123456789"; parseLatency(got) != want {
 			t.Errorf("httpRequest.latency = %q; want %q", got, want+"s")
 		}
-		ts, _ := r["timestamp"].(map[string]interface{})
+		ts, _ := r["timestamp"].(map[string]any)
 		if ts == nil {
 			t.Error("timestamp does not exist in record or is not a JSON object")
 		}
@@ -143,12 +143,12 @@ func parseLatency(s string) string {
 	return s
 }
 
-func jsonString(obj map[string]interface{}, k string) string {
+func jsonString(obj map[string]any, k string) string {
 	v, _ := obj[k].(string)
 	return v
 }
 
-func jsonNumber(obj map[string]interface{}, k string) float64 {
+func jsonNumber(obj map[string]any, k string) float64 {
 	v, _ := obj[k].(float64)
 	return v
 }


### PR DESCRIPTION
All modules are on a Go version after 1.18, so we can rename
interface{} to any to modernize the code.

docstore is omitted, because there are PRs in flight that this might
conflict with (#3500, #3508).
