### PR TITLE
remove duplicate imports

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -25,7 +25,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
-	awsv2cfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -180,7 +179,7 @@ func UseV2(q url.Values) bool {
 
 // NewDefaultV2Config returns a aws.Config for AWS SDK v2, using the default options.
 func NewDefaultV2Config(ctx context.Context) (awsv2.Config, error) {
-	return awsv2cfg.LoadDefaultConfig(ctx)
+	return config.LoadDefaultConfig(ctx)
 }
 
 // V2ConfigFromURLParams returns an aws.Config for AWS SDK v2 initialized based on the URL
@@ -208,7 +207,7 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 	var endpoint string
 	var hostnameImmutable bool
 	var rateLimitCapacity int64
-	var opts []func(*awsv2cfg.LoadOptions) error
+	var opts []func(*config.LoadOptions) error
 	for param, values := range q {
 		value := values[0]
 		switch param {
@@ -219,18 +218,18 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 				return awsv2.Config{}, fmt.Errorf("invalid value for hostname_immutable: %w", err)
 			}
 		case "region":
-			opts = append(opts, awsv2cfg.WithRegion(value))
+			opts = append(opts, config.WithRegion(value))
 		case "endpoint":
 			endpoint = value
 		case "profile":
-			opts = append(opts, awsv2cfg.WithSharedConfigProfile(value))
+			opts = append(opts, config.WithSharedConfigProfile(value))
 		case "dualstack":
 			dualStack, err := strconv.ParseBool(value)
 			if err != nil {
 				return awsv2.Config{}, fmt.Errorf("invalid value for dualstack: %w", err)
 			}
 			if dualStack {
-				opts = append(opts, awsv2cfg.WithUseDualStackEndpoint(awsv2.DualStackEndpointStateEnabled))
+				opts = append(opts, config.WithUseDualStackEndpoint(awsv2.DualStackEndpointStateEnabled))
 			}
 		case "fips":
 			fips, err := strconv.ParseBool(value)
@@ -238,7 +237,7 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 				return awsv2.Config{}, fmt.Errorf("invalid value for fips: %w", err)
 			}
 			if fips {
-				opts = append(opts, awsv2cfg.WithUseFIPSEndpoint(awsv2.FIPSEndpointStateEnabled))
+				opts = append(opts, config.WithUseFIPSEndpoint(awsv2.FIPSEndpointStateEnabled))
 			}
 		case "rate_limiter_capacity":
 			var err error
@@ -252,7 +251,7 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 				return awsv2.Config{}, fmt.Errorf("invalid value for anonymous: %w", err)
 			}
 			if anon {
-				opts = append(opts, awsv2cfg.WithCredentialsProvider(awsv2.AnonymousCredentials{}))
+				opts = append(opts, config.WithCredentialsProvider(awsv2.AnonymousCredentials{}))
 			}
 		case "awssdk":
 			// ignore, should be handled before this
@@ -270,7 +269,7 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 					HostnameImmutable: hostnameImmutable,
 				}, nil
 			})
-		opts = append(opts, awsv2cfg.WithEndpointResolverWithOptions(customResolver))
+		opts = append(opts, config.WithEndpointResolverWithOptions(customResolver))
 	}
 
 	var rateLimiter retry.RateLimiter
@@ -284,5 +283,5 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (awsv2.Config, err
 		})
 	}))
 
-	return awsv2cfg.LoadDefaultConfig(ctx, opts...)
+	return config.LoadDefaultConfig(ctx, opts...)
 }

--- a/docstore/awsdynamodb/query_test.go
+++ b/docstore/awsdynamodb/query_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	dyn "github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gocloud.dev/docstore/driver"
@@ -583,12 +582,12 @@ func TestCopyTopLevel(t *testing.T) {
 func Test_documentIterator_Next(t *testing.T) {
 	type fields struct {
 		qr     *queryRunner
-		items  []map[string]*dyn.AttributeValue
+		items  []map[string]*dynamodb.AttributeValue
 		curr   int
 		offset int
 		limit  int
 		count  int
-		last   map[string]*dyn.AttributeValue
+		last   map[string]*dynamodb.AttributeValue
 		asFunc func(i interface{}) bool
 	}
 	type args struct {
@@ -605,14 +604,14 @@ func Test_documentIterator_Next(t *testing.T) {
 			name: "nextWithNoDecodeError",
 			fields: fields{
 				qr: &queryRunner{},
-				items: []map[string]*dyn.AttributeValue{
-					{"key": {M: map[string]*dyn.AttributeValue{"key": {S: aws.String("value")}}}},
+				items: []map[string]*dynamodb.AttributeValue{
+					{"key": {M: map[string]*dynamodb.AttributeValue{"key": {S: aws.String("value")}}}},
 				},
 				curr:   0,
 				offset: 0,
 				limit:  0,
 				count:  0,
-				last:   map[string]*dyn.AttributeValue{},
+				last:   map[string]*dynamodb.AttributeValue{},
 			},
 			args: args{
 				ctx: context.Background(),
@@ -624,14 +623,14 @@ func Test_documentIterator_Next(t *testing.T) {
 			name: "nextWithDecodeError",
 			fields: fields{
 				qr: &queryRunner{},
-				items: []map[string]*dyn.AttributeValue{
+				items: []map[string]*dynamodb.AttributeValue{
 					{"key": {M: nil}}, // set M to nil to trigger decode error
 				},
 				curr:   0,
 				offset: 0,
 				limit:  0,
 				count:  0,
-				last:   map[string]*dyn.AttributeValue{},
+				last:   map[string]*dynamodb.AttributeValue{},
 			},
 			args: args{
 				ctx: context.Background(),
@@ -643,16 +642,16 @@ func Test_documentIterator_Next(t *testing.T) {
 			name: "nextWhereCurrIsGreaterThanOrEqualToItemsAndLastIsNotNil",
 			fields: fields{
 				qr: &queryRunner{
-					scanIn: &dyn.ScanInput{},
+					scanIn: &dynamodb.ScanInput{},
 					// hack to return error from run
 					beforeRun: func(asFunc func(i interface{}) bool) error { return errors.New("invalid") },
 				},
-				items:  []map[string]*dyn.AttributeValue{{"key": {M: map[string]*dyn.AttributeValue{"key": {S: aws.String("value"), M: nil}}}}},
+				items:  []map[string]*dynamodb.AttributeValue{{"key": {M: map[string]*dynamodb.AttributeValue{"key": {S: aws.String("value"), M: nil}}}}},
 				curr:   1,
 				offset: 0,
 				limit:  0,
 				count:  0,
-				last:   map[string]*dyn.AttributeValue{"key": {S: aws.String("value")}},
+				last:   map[string]*dynamodb.AttributeValue{"key": {S: aws.String("value")}},
 			},
 			args: args{
 				ctx: context.Background(),


### PR DESCRIPTION
[aws/aws.go:28](https://github.com/google/go-cloud/blob/9e81e8d4f2a83fc70eb74643da0485273ab2480d/aws/aws.go#L28): remove duplicate import statements, the `github.com/aws/aws-sdk-go-v2/config` is imported twice,

[docstore/awsdynamodb/query_test.go:27](https://github.com/google/go-cloud/blob/9e81e8d4f2a83fc70eb74643da0485273ab2480d/docstore/awsdynamodb/query_test.go#L27): remove duplicate import statements, the `github.com/aws/aws-sdk-go/service/dynamodb` is imported twice.