### PR TITLE
remove unnecessary nil check

### DIFF
--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -562,7 +562,7 @@ func (s *Subscription) Receive(ctx context.Context) (_ *Message, err error) {
 				}
 				resultChannel := s.getNextBatch(batchSize)
 				for msgsOrError := range resultChannel {
-					if msgsOrError.msgs != nil && len(msgsOrError.msgs) > 0 {
+					if len(msgsOrError.msgs) > 0 {
 						// messages received from channel
 						s.mu.Lock()
 						s.q = append(s.q, msgsOrError.msgs...)


### PR DESCRIPTION
[pubsub/pubsub.go:565](https://github.com/google/go-cloud/blob/9e81e8d4f2a83fc70eb74643da0485273ab2480d/pubsub/pubsub.go#L565): remove unnecessay nil check.

```
var slice []byte
if slice != nil && len(slice) > 0 {}
// is the same as
if len(slice) > 0 {}
```
because `len(slice)` where slice == nil is always equal to 0,

`staticcheck` will highlight this optimization with the following message:
```
pubsub/pubsub.go:565:9: should omit nil check; len() for []*gocloud.dev/pubsub/driver.Message is defined as zero (S1009)
```

for reference: [staticcheck S1009](https://staticcheck.dev/docs/checks#S1009)