### PR TITLE
blob/azblob: for default URL, get default accountName/protocol from connection string env

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -188,11 +188,31 @@ type ServiceURLOptions struct {
 func NewDefaultServiceURLOptions() *ServiceURLOptions {
 	isCDN, _ := strconv.ParseBool(os.Getenv("AZURE_STORAGE_IS_CDN"))
 	isLocalEmulator, _ := strconv.ParseBool(os.Getenv("AZURE_STORAGE_IS_LOCAL_EMULATOR"))
+	accountName := os.Getenv("AZURE_STORAGE_ACCOUNT")
+	protocol := os.Getenv("AZURE_STORAGE_PROTOCOL")
+	connectionString := os.Getenv("AZURE_STORAGE_CONNECTION_STRING")
+	if connectionString == "" {
+		connectionString = os.Getenv("AZURE_STORAGEBLOB_CONNECTIONSTRING")
+	}
+	if connectionString != "" {
+		// Parse the connection string to get a default account name and protocol.
+		// Format: DefaultEndpointsProtocol=https;AccountName=some-account;AccountKey=very-secure;EndpointSuffix=core.windows.net
+		for _, part := range strings.Split(connectionString, ";") {
+			keyval := strings.Split(part, "=")
+			if len(keyval) == 2 {
+				if accountName == "" && keyval[0] == "AccountName" {
+					accountName = keyval[1]
+				} else if protocol == "" && keyval[0] == "DefaultEndpointsProtocol" {
+					protocol = keyval[1]
+				}
+			}
+		}
+	}
 	return &ServiceURLOptions{
-		AccountName:     os.Getenv("AZURE_STORAGE_ACCOUNT"),
+		AccountName:     accountName,
 		SASToken:        os.Getenv("AZURE_STORAGE_SAS_TOKEN"),
 		StorageDomain:   os.Getenv("AZURE_STORAGE_DOMAIN"),
-		Protocol:        os.Getenv("AZURE_STORAGE_PROTOCOL"),
+		Protocol:        protocol,
 		IsCDN:           isCDN,
 		IsLocalEmulator: isLocalEmulator,
 	}

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -365,6 +365,18 @@ func TestOpenerFromEnv(t *testing.T) {
 			},
 		},
 		{
+			// Connection string provides default protocol and account name.
+			connectionString: "DefaultEndpointsProtocol=https;AccountName=another-account",
+			want: &credInfoT{
+				CredType:         credTypeConnectionString,
+				ConnectionString: "DefaultEndpointsProtocol=https;AccountName=another-account",
+			},
+			wantOpts: &ServiceURLOptions{
+				AccountName: "another-account",
+				Protocol:    "https",
+			},
+		},
+		{
 			// Alternate connection string.
 			accountName:       "myaccount",
 			connectionString2: "a-connection-string",


### PR DESCRIPTION
Fixes #3592