### PR TITLE
blob/s3blob: remove disableSSL from docs

### DIFF
--- a/internal/website/content/howto/blob/_index.md
+++ b/internal/website/content/howto/blob/_index.md
@@ -242,7 +242,7 @@ parameters like so:
 ```go
 bucket, err := blob.OpenBucket("s3://mybucket?" +
     "endpoint=my.minio.local:8080&" +
-    "disableSSL=true&" +
+    "disable_https=true&" +
     "s3ForcePathStyle=true")
 ```
 


### PR DESCRIPTION
That option does not exist. This replaces it with what seems to be the correct option, `disable_https`.