### PR TITLE
security: remove hardcoded Codecov token from .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,11 @@
 codecov:
-  token: 47dfd1fc-dc72-4d25-b608-eca6508efd05
-
+  # Removed hardcoded token for security reasons.
+  # The token should be set via CI/CD secrets instead.
+  # Example for GitHub Actions:
+  #   - name: Upload coverage to Codecov
+  #     run: codecov -t ${{ secrets.CODECOV_TOKEN }}
+  #
+  # See: https://docs.codecov.com/docs/adding-the-codecov-token
 coverage:
   status:
     project:


### PR DESCRIPTION
### Summary
This PR removes a hardcoded Codecov upload token from `.codecov.yml` and replaces it with documentation advising the use of CI-provided secrets.

### Rationale
Storing tokens in version control exposes them to anyone with read access to the repository, which can allow unauthorized uploads to the project's Codecov dashboard. This could be abused to:

- Upload forged coverage reports.
- Inflate/deflate project coverage metrics.
- Pollute project history and reduce trust in CI/CD data.

### Security Benefits
- Prevents unauthorized manipulation of coverage data.
- Aligns the project with best practices for secret management.
- Reduces the risk of future supply-chain or CI/CD integrity issues.

### References
- [Codecov: Adding the Codecov Token](https://docs.codecov.com/docs/adding-the-codecov-token)

Signed-off-by: Mustafa Adam ibnqamar10@gmail.com