### PR TITLE
mysql: revert TLSConfig change

### DIFF
--- a/mysql/awsmysql/awsmysql_test.go
+++ b/mysql/awsmysql/awsmysql_test.go
@@ -76,9 +76,7 @@ func TestOpenIAM(t *testing.T) {
 		t.Fatalf("Missing one or more required Terraform outputs; got endpoint=%q iam_db_username=%q database=%q", endpoint, username, databaseName)
 	}
 	ctx := context.Background()
-	// You must trust the RDS CA cert (on local machine) for IAM authentication.
-	// or use tls=preferred&allowCleartextPasswords=true
-	urlstr := fmt.Sprintf("awsmysql://%s@%s/%s?tls=true&aws_role_arn=%s",
+	urlstr := fmt.Sprintf("awsmysql://%s@%s/%s?aws_role_arn=%s",
 		username, endpoint, databaseName, roleARN)
 	t.Log("Connecting to:", urlstr)
 	db, err := mysql.Open(ctx, urlstr)


### PR DESCRIPTION
See: https://github.com/google/go-cloud/pull/3348

In the old PR, I was make mistake when changed the config object to use TLS directly.  This TLS setting should use directly with `mysql.NewConnector()`, if we encoding the config again with `FormatDSN()`, the TLS will have no effect.

In summary, the old PR https://github.com/google/go-cloud/pull/3348 disabled TLS config for both AWS/Azure in 2 years.

The issue only found when adding IAM authenticate, which require TLS config.

I'm apologize for my mistake.