### PR TITLE
blob/azureblob:  handle precondition error

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -665,6 +665,9 @@ func (b *bucket) ErrorCode(err error) gcerrors.ErrorCode {
 		if code == bloberror.AuthenticationFailed {
 			return gcerrors.PermissionDenied
 		}
+		if code == bloberror.BlobAlreadyExists {
+			return gcerrors.FailedPrecondition
+		}
 	}
 	if strings.Contains(err.Error(), "no such host") {
 		// This happens with an invalid storage account name; the host


### PR DESCRIPTION
Azure returns the following error when a request fails due to a conflicting precondition
```xml
<?xml version="1.0" encoding="utf-8"?>
<Error>
    <Code>BlobAlreadyExists</Code>
    <Message>The specified blob already exists.
        RequestId:xyz-123
        Time:2025-11-05T08:28:21.2817469Z</Message>
</Error>
```

This needs to be converted to the generic `FailedPrecondition` error so it can be handled properly.