### PR TITLE
blob/azureblob: handle more precondition errors

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -655,7 +655,11 @@ func (b *bucket) ErrorCode(err error) gcerrors.ErrorCode {
 		switch bloberror.Code(rErr.ErrorCode) {
 		case bloberror.AuthenticationFailed:
 			return gcerrors.PermissionDenied
-		case bloberror.BlobAlreadyExists:
+		case bloberror.BlobAlreadyExists,
+			bloberror.ConditionNotMet,
+			bloberror.TargetConditionNotMet,
+			bloberror.SourceConditionNotMet:
+			// the documented error code is a variation of "ConditionNotMet", but "BlobAlreadyExists" has also been observed
 			return gcerrors.FailedPrecondition
 		case bloberror.BlobNotFound:
 			return gcerrors.NotFound


### PR DESCRIPTION
I noticed that the documentation from microsoft[^1][^2] claims that the error code for precondition errors should be some variation of `ConditionNotMet`, so I think it should be included.

[^1]: https://learn.microsoft.com/en-us/rest/api/storageservices/common-rest-api-error-codes
[^2]: https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-error-codes
