### PR TITLE
runtimevar/filevar: Support relative paths in URL openers via a host of "."

### DIFF
--- a/runtimevar/filevar/filevar.go
+++ b/runtimevar/filevar/filevar.go
@@ -109,7 +109,9 @@ func (o *URLOpener) OpenVariableURL(ctx context.Context, u *url.URL) (*runtimeva
 		return nil, fmt.Errorf("open variable %v: invalid query parameter %q", u, param)
 	}
 	path := u.Path
-	if os.PathSeparator != '/' {
+	// Hostname == "." means a relative path, so drop the leading "/".
+	// Also drop the leading "/" on Windows.
+	if u.Host == "." || os.PathSeparator != '/' {
 		path = strings.TrimPrefix(path, "/")
 	}
 	return OpenVariable(filepath.FromSlash(path), decoder, &opts)

--- a/runtimevar/filevar/filevar_test.go
+++ b/runtimevar/filevar/filevar_test.go
@@ -243,6 +243,8 @@ func TestOpenVariableURL(t *testing.T) {
 		{"file://" + txtPath + "?decoder=string&wait=1m", false, false, "hello world!"},
 		// Invalid wait.
 		{"file://" + txtPath + "?decoder=string&wait=xx", true, false, nil},
+		// Relative path using host="."; bucket is created but error at read time.
+		{"file://./../.." + nonexistentPath, false, true, nil},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The runtimevar version of https://github.com/google/go-cloud/pull/2796

This enables referencing test files without requiring absolute pathing.
