### PR TITLE
blob/gcsblob: Support universe domain configuration

### DIFF
--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -37,6 +37,7 @@ import (
 	"gocloud.dev/gcp"
 	"gocloud.dev/internal/testing/setup"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 )
 
 const (
@@ -631,6 +632,28 @@ func TestURLOpenerForParams(t *testing.T) {
 			},
 			wantOpts: Options{GoogleAccessID: "bar"},
 		},
+		{
+			name: "UniverseDomain",
+			query: url.Values{
+				"universe_domain": {"example.com"},
+			},
+			wantOpts: Options{ClientOptions: []option.ClientOption{option.WithUniverseDomain("example.com")}},
+		},
+		{
+			name:     "UniverseDomain with existing options",
+			currOpts: Options{GoogleAccessID: "foo"},
+			query: url.Values{
+				"universe_domain": {"example.com"},
+			},
+			wantOpts: Options{GoogleAccessID: "foo", ClientOptions: []option.ClientOption{option.WithUniverseDomain("example.com")}},
+		},
+		{
+			name: "UniverseDomain empty value ignored",
+			query: url.Values{
+				"universe_domain": {""},
+			},
+			wantOpts: Options{},
+		},
 	}
 
 	for _, test := range tests {
@@ -678,6 +701,10 @@ func TestOpenBucketFromURL(t *testing.T) {
 		{"gs://mybucket?private_key_path=" + pkFile.Name(), false},
 		// OK, clearing any pre-existing private key.
 		{"gs://mybucket?private_key_path=", false},
+		// OK, setting universe_domain.
+		{"gs://mybucket?universe_domain=example.com", false},
+		// OK, universe_domain with empty value.
+		{"gs://mybucket?universe_domain=", false},
 		// Invalid private_key_path.
 		{"gs://mybucket?private_key_path=invalid-path", true},
 		// Invalid parameter.

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -84,6 +84,20 @@ func DefaultCredentials(ctx context.Context) (*google.Credentials, error) {
 	return adc, nil
 }
 
+// DefaultCredentialsWithParams obtains the default GCP credentials with the
+// specified parameters. The Scopes field in params will be overridden with
+// Cloud Platform scope if not set.
+func DefaultCredentialsWithParams(ctx context.Context, params google.CredentialsParams) (*google.Credentials, error) {
+	if len(params.Scopes) == 0 {
+		params.Scopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
+	}
+	adc, err := google.FindDefaultCredentialsWithParams(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return adc, nil
+}
+
 // CredentialsTokenSource extracts the token source from GCP credentials.
 func CredentialsTokenSource(creds *google.Credentials) TokenSource {
 	if creds == nil {


### PR DESCRIPTION
In https://github.com/googleapis/google-api-go-client/pull/2335, Google added support for configuring a universe domain to support different Google Cloud domains. This commit adds a `universe_domain` query parameter to retrieve credentials and access Google Cloud Storage with a different domain.

