### PR TITLE
blob/gcsblob: derive universe domain from credentials

### DIFF
--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -177,6 +177,13 @@ func (o *lazyCredsOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.
 			// Populate default values from credentials files, where available.
 			opts.GoogleAccessID, opts.PrivateKey = readDefaultCredentials(creds.JSON)
 
+			ud, err := creds.GetUniverseDomain()
+			if err != nil {
+				fmt.Printf("Warning: unable to load GCP Universe Domain: %v", err)
+			} else if ud != "" {
+				opts.ClientOptions = append(opts.ClientOptions, option.WithUniverseDomain(ud))
+			}
+
 			// ... else, on GCE, at least get the instance's main service account.
 			if opts.GoogleAccessID == "" && metadata.OnGCE() {
 				mc := metadata.NewClient(nil)
@@ -276,9 +283,6 @@ func (o *URLOpener) forParams(ctx context.Context, q url.Values) (*Options, *gcp
 		// The private key might have expired, or falling back to SignBytes/MakeSignBytes
 		// is intentional such as for tests or involving a key stored in a HSM/TPM.
 		opts.PrivateKey = nil
-	}
-	if universeDomain := q.Get("universe_domain"); universeDomain != "" {
-		opts.ClientOptions = append(opts.ClientOptions, option.WithUniverseDomain(universeDomain))
 	}
 	return opts, client, nil
 }

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -37,7 +37,6 @@ import (
 	"gocloud.dev/gcp"
 	"gocloud.dev/internal/testing/setup"
 	"google.golang.org/api/googleapi"
-	"google.golang.org/api/option"
 )
 
 const (
@@ -631,28 +630,6 @@ func TestURLOpenerForParams(t *testing.T) {
 				"access_id": {"bar"},
 			},
 			wantOpts: Options{GoogleAccessID: "bar"},
-		},
-		{
-			name: "UniverseDomain",
-			query: url.Values{
-				"universe_domain": {"example.com"},
-			},
-			wantOpts: Options{ClientOptions: []option.ClientOption{option.WithUniverseDomain("example.com")}},
-		},
-		{
-			name:     "UniverseDomain with existing options",
-			currOpts: Options{GoogleAccessID: "foo"},
-			query: url.Values{
-				"universe_domain": {"example.com"},
-			},
-			wantOpts: Options{GoogleAccessID: "foo", ClientOptions: []option.ClientOption{option.WithUniverseDomain("example.com")}},
-		},
-		{
-			name: "UniverseDomain empty value ignored",
-			query: url.Values{
-				"universe_domain": {""},
-			},
-			wantOpts: Options{},
 		},
 	}
 


### PR DESCRIPTION
Previously if a `universe_domain` were specified, it would be set in the request for credentials and the storage client options. However, we can automatically derive this value from the credentials themselves. This makes it possible to use Google Application Default credentials without any explicit `universe_domain` configuration because the universe domain is returned automatically.

This has been tested with a Google Cloud Dedicated preview instance.