### PR TITLE
blob/s3blob: map S3 403 errors PermissionDenied code

### DIFF
--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -419,6 +419,8 @@ func (b *bucket) ErrorCode(err error) gcerrors.ErrorCode {
 		return gcerrors.NotFound
 	case code == "PreconditionFailed":
 		return gcerrors.FailedPrecondition
+	case code == "AccessDenied" || code == "Forbidden":
+		return gcerrors.PermissionDenied
 	default:
 		return gcerrors.Unknown
 	}


### PR DESCRIPTION
If the S3 credentials used to access a bucket doesn't have the `s3:ListBucket` credentials, previously the error code would return as `Unknown`. This commit changes this to PermissionDenied.