### PR TITLE
blob/azureblob: eliminate Azure Autorest dependency and replace usage

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -110,7 +110,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/wire"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/driver"
@@ -126,6 +125,14 @@ const (
 	defaultUploadBuffers   = 5               // configure the number of rotating buffers that are used when uploading (for degree of parallelism)
 	defaultUploadBlockSize = 8 * 1024 * 1024 // configure the upload buffer size
 )
+
+// ptrVal returns the value pointed to by p, or the zero value if p is nil.
+func ptrVal[T any](p *T) (v T) {
+	if p != nil {
+		v = *p
+	}
+	return
+}
 
 func init() {
 	blob.DefaultURLMux().RegisterBucket(Scheme, new(lazyOpener))
@@ -590,8 +597,8 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 		return nil, err
 	}
 	attrs := driver.ReaderAttributes{
-		ContentType: to.String(blobDownloadResponse.ContentType),
-		Size:        getSize(blobDownloadResponse.ContentLength, to.String(blobDownloadResponse.ContentRange)),
+		ContentType: ptrVal(blobDownloadResponse.ContentType),
+		Size:        getSize(blobDownloadResponse.ContentLength, ptrVal(blobDownloadResponse.ContentRange)),
 		ModTime:     *blobDownloadResponse.LastModified,
 	}
 	var body io.ReadCloser
@@ -700,12 +707,12 @@ func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes
 		eTag = string(*blobPropertiesResponse.ETag)
 	}
 	return &driver.Attributes{
-		CacheControl:       to.String(blobPropertiesResponse.CacheControl),
-		ContentDisposition: to.String(blobPropertiesResponse.ContentDisposition),
-		ContentEncoding:    to.String(blobPropertiesResponse.ContentEncoding),
-		ContentLanguage:    to.String(blobPropertiesResponse.ContentLanguage),
-		ContentType:        to.String(blobPropertiesResponse.ContentType),
-		Size:               to.Int64(blobPropertiesResponse.ContentLength),
+		CacheControl:       ptrVal(blobPropertiesResponse.CacheControl),
+		ContentDisposition: ptrVal(blobPropertiesResponse.ContentDisposition),
+		ContentEncoding:    ptrVal(blobPropertiesResponse.ContentEncoding),
+		ContentLanguage:    ptrVal(blobPropertiesResponse.ContentLanguage),
+		ContentType:        ptrVal(blobPropertiesResponse.ContentType),
+		Size:               ptrVal(blobPropertiesResponse.ContentLength),
 		CreateTime:         *blobPropertiesResponse.CreationTime,
 		ModTime:            *blobPropertiesResponse.LastModified,
 		MD5:                blobPropertiesResponse.ContentMD5,
@@ -765,7 +772,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 	segment := resp.ListBlobsHierarchySegmentResponse.Segment
 	for _, blobPrefix := range segment.BlobPrefixes {
 		page.Objects = append(page.Objects, &driver.ListObject{
-			Key:   unescapeKey(to.String(blobPrefix.Name)),
+			Key:   unescapeKey(ptrVal(blobPrefix.Name)),
 			Size:  0,
 			IsDir: true,
 			AsFunc: func(i any) bool {
@@ -779,7 +786,7 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 	}
 	for _, blobInfo := range segment.BlobItems {
 		page.Objects = append(page.Objects, &driver.ListObject{
-			Key:     unescapeKey(to.String(blobInfo.Name)),
+			Key:     unescapeKey(ptrVal(blobInfo.Name)),
 			ModTime: *blobInfo.Properties.LastModified,
 			Size:    *blobInfo.Properties.ContentLength,
 			MD5:     blobInfo.Properties.ContentMD5,

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.10.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3
 	github.com/Azure/go-amqp v1.5.0
-	github.com/Azure/go-autorest/autorest/to v0.4.1
 	github.com/GoogleCloudPlatform/cloudsql-proxy v1.37.10
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.30.0
@@ -98,7 +97,6 @@ require (
 	filippo.io/edwards25519 v1.1.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
-	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,14 +94,11 @@ github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3/go.mod h1:URuDvhmATV
 github.com/Azure/go-amqp v0.17.0/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
 github.com/Azure/go-amqp v1.5.0 h1:GRiQK1VhrNFbyx5VlmI6BsA1FCp27W5rb9kxOZScnTo=
 github.com/Azure/go-amqp v1.5.0/go.mod h1:vZAogwdrkbyK3Mla8m/CxSc/aKdnTZ4IbPxl51Y5WZE=
-github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.18/go.mod h1:dSiJPy22c3u0OtOKDNttNgqpNFY/GeWa7GH/Pz56QRA=
 github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
-github.com/Azure/go-autorest/autorest/to v0.4.1 h1:CxNHBqdzTr7rLtdrtb5CMjJcDut+WNGCVv7OmS5+lTc=
-github.com/Azure/go-autorest/autorest/to v0.4.1/go.mod h1:EtaofgU4zmtvn1zT2ARsjRFdq9vXx0YWtmElwL+GZ9M=
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=

--- a/internal/testing/alldeps
+++ b/internal/testing/alldeps
@@ -23,7 +23,6 @@ github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal
 github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
 github.com/Azure/go-amqp
-github.com/Azure/go-autorest/autorest/to
 github.com/AzureAD/microsoft-authentication-library-for-go
 github.com/GoogleCloudPlatform/cloudsql-proxy
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp

--- a/samples/go.mod
+++ b/samples/go.mod
@@ -74,8 +74,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.10.0 // indirect
 	github.com/Azure/go-amqp v1.5.0 // indirect
-	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
-	github.com/Azure/go-autorest/autorest/to v0.4.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/GoogleCloudPlatform/cloudsql-proxy v1.37.10 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect

--- a/samples/go.sum
+++ b/samples/go.sum
@@ -92,14 +92,11 @@ github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3/go.mod h1:URuDvhmATV
 github.com/Azure/go-amqp v0.17.0/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
 github.com/Azure/go-amqp v1.5.0 h1:GRiQK1VhrNFbyx5VlmI6BsA1FCp27W5rb9kxOZScnTo=
 github.com/Azure/go-amqp v1.5.0/go.mod h1:vZAogwdrkbyK3Mla8m/CxSc/aKdnTZ4IbPxl51Y5WZE=
-github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.18/go.mod h1:dSiJPy22c3u0OtOKDNttNgqpNFY/GeWa7GH/Pz56QRA=
 github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
-github.com/Azure/go-autorest/autorest/to v0.4.1 h1:CxNHBqdzTr7rLtdrtb5CMjJcDut+WNGCVv7OmS5+lTc=
-github.com/Azure/go-autorest/autorest/to v0.4.1/go.mod h1:EtaofgU4zmtvn1zT2ARsjRFdq9vXx0YWtmElwL+GZ9M=
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=


### PR DESCRIPTION
Fixes #3671 

github.com/Azure/go-autorest was archived in Feb 2025 with support ended since Mar 2023. The only sub-package used was autorest/to, which provided nil-safe pointer dereference helpers.

Replace it with a local generic ptrVal function that provides the same behavior for all pointer types using Go generics.

Why not azcore/to ?
The modern Azure SDK's azcore/to package only provides Ptr (value → pointer) and SliceOfPtrs. It does not include a reverse helper (pointer → value), so a local function is necessary.
