### PR TITLE
docstore: Support unwrapping action list errors

### DIFF
--- a/docstore/docstore.go
+++ b/docstore/docstore.go
@@ -299,13 +299,12 @@ func (e ActionListError) Error() string {
 // Unwrap returns the error in e, if there is exactly one. If there is more than one
 // error, Unwrap returns nil, since there is no way to determine which should be
 // returned.
-func (e ActionListError) Unwrap() error {
-	if len(e) == 1 {
-		return e[0].Err
+func (e ActionListError) Unwrap() []error {
+	errs := []error{}
+	for _, err := range e {
+		errs = append(errs, err.Err)
 	}
-	// Return nil when e is nil, or has more than one error.
-	// When there are multiple errors, it doesn't make sense to return any of them.
-	return nil
+	return errs
 }
 
 // BeforeDo takes a callback function that will be called before the ActionList is
@@ -558,55 +557,37 @@ func (a *Action) String() string {
 // Create is a convenience for building and running a single-element action list.
 // See ActionList.Create.
 func (c *Collection) Create(ctx context.Context, doc Document) error {
-	if err := c.Actions().Create(doc).Do(ctx); err != nil {
-		return err.(ActionListError).Unwrap()
-	}
-	return nil
+	return c.Actions().Create(doc).Do(ctx)
 }
 
 // Replace is a convenience for building and running a single-element action list.
 // See ActionList.Replace.
 func (c *Collection) Replace(ctx context.Context, doc Document) error {
-	if err := c.Actions().Replace(doc).Do(ctx); err != nil {
-		return err.(ActionListError).Unwrap()
-	}
-	return nil
+	return c.Actions().Replace(doc).Do(ctx)
 }
 
 // Put is a convenience for building and running a single-element action list.
 // See ActionList.Put.
 func (c *Collection) Put(ctx context.Context, doc Document) error {
-	if err := c.Actions().Put(doc).Do(ctx); err != nil {
-		return err.(ActionListError).Unwrap()
-	}
-	return nil
+	return c.Actions().Put(doc).Do(ctx)
 }
 
 // Delete is a convenience for building and running a single-element action list.
 // See ActionList.Delete.
 func (c *Collection) Delete(ctx context.Context, doc Document) error {
-	if err := c.Actions().Delete(doc).Do(ctx); err != nil {
-		return err.(ActionListError).Unwrap()
-	}
-	return nil
+	return c.Actions().Delete(doc).Do(ctx)
 }
 
 // Get is a convenience for building and running a single-element action list.
 // See ActionList.Get.
 func (c *Collection) Get(ctx context.Context, doc Document, fps ...FieldPath) error {
-	if err := c.Actions().Get(doc, fps...).Do(ctx); err != nil {
-		return err.(ActionListError).Unwrap()
-	}
-	return nil
+	return c.Actions().Get(doc, fps...).Do(ctx)
 }
 
 // Update is a convenience for building and running a single-element action list.
 // See ActionList.Update.
 func (c *Collection) Update(ctx context.Context, doc Document, mods Mods) error {
-	if err := c.Actions().Update(doc, mods).Do(ctx); err != nil {
-		return err.(ActionListError).Unwrap()
-	}
-	return nil
+	return c.Actions().Update(doc, mods).Do(ctx)
 }
 
 func parseFieldPath(fp FieldPath) ([]string, error) {
@@ -698,9 +679,9 @@ func wrapError(c driver.Collection, err error) error {
 		return err
 	}
 	if _, ok := err.(*gcerr.Error); ok {
-		return err
+		return gcerrors.Wrap(err)
 	}
-	return gcerr.New(c.ErrorCode(err), err, 2, "docstore")
+	return gcerrors.Wrap(gcerr.New(c.ErrorCode(err), err, 2, "docstore"))
 }
 
 // ErrorAs converts i to driver-specific types. See

--- a/docstore/docstore.go
+++ b/docstore/docstore.go
@@ -296,9 +296,7 @@ func (e ActionListError) Error() string {
 	return strings.Join(s, "; ")
 }
 
-// Unwrap returns the error in e, if there is exactly one. If there is more than one
-// error, Unwrap returns nil, since there is no way to determine which should be
-// returned.
+// Unwrap returns all underlying errors from e.
 func (e ActionListError) Unwrap() []error {
 	errs := []error{}
 	for _, err := range e {
@@ -679,9 +677,9 @@ func wrapError(c driver.Collection, err error) error {
 		return err
 	}
 	if _, ok := err.(*gcerr.Error); ok {
-		return gcerrors.Wrap(err)
+		return err
 	}
-	return gcerrors.Wrap(gcerr.New(c.ErrorCode(err), err, 2, "docstore"))
+	return gcerr.New(c.ErrorCode(err), err, 2, "docstore")
 }
 
 // ErrorAs converts i to driver-specific types. See

--- a/docstore/docstore_test.go
+++ b/docstore/docstore_test.go
@@ -16,6 +16,7 @@ package docstore
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -118,10 +119,7 @@ func TestClosedErrors(t *testing.T) {
 
 	check := func(err error) {
 		t.Helper()
-		if alerr, ok := err.(ActionListError); ok {
-			err = alerr.Unwrap()
-		}
-		if err != errClosed {
+		if !errors.Is(err, errClosed) {
 			t.Errorf("got %v, want errClosed", err)
 		}
 	}

--- a/gcerrors/errors.go
+++ b/gcerrors/errors.go
@@ -68,33 +68,6 @@ const (
 	DeadlineExceeded ErrorCode = gcerr.DeadlineExceeded
 )
 
-// TODO: just as an example, hypothetically this would be implemented for all errors
-type AlreadyExistsError struct {
-	err error
-}
-
-func (a *AlreadyExistsError) Error() string {
-	return a.err.Error()
-}
-
-func (a *AlreadyExistsError) Unwrap() error {
-	return a.err
-}
-
-// Wrap returns the Error struct that corresponds to the ErrorCode of the underlying error.
-// If err is not a go-cloud error it just returns the error.
-func Wrap(err error) error {
-	var e *gcerr.Error
-	if !errors.As(err, &e) {
-		return err
-	}
-	switch e.Code {
-	case gcerr.AlreadyExists:
-		return &AlreadyExistsError{err: err}
-	}
-	return err
-}
-
 // Code returns the ErrorCode of err if it, or some error it wraps, is an *Error.
 // If err is context.Canceled or context.DeadlineExceeded, or wraps one of those errors,
 // it returns the Canceled or DeadlineExceeded codes, respectively.

--- a/gcerrors/errors.go
+++ b/gcerrors/errors.go
@@ -68,6 +68,33 @@ const (
 	DeadlineExceeded ErrorCode = gcerr.DeadlineExceeded
 )
 
+// TODO: just as an example, hypothetically this would be implemented for all errors
+type AlreadyExistsError struct {
+	err error
+}
+
+func (a *AlreadyExistsError) Error() string {
+	return a.err.Error()
+}
+
+func (a *AlreadyExistsError) Unwrap() error {
+	return a.err
+}
+
+// Wrap returns the Error struct that corresponds to the ErrorCode of the underlying error.
+// If err is not a go-cloud error it just returns the error.
+func Wrap(err error) error {
+	var e *gcerr.Error
+	if !errors.As(err, &e) {
+		return err
+	}
+	switch e.Code {
+	case gcerr.AlreadyExists:
+		return &AlreadyExistsError{err: err}
+	}
+	return err
+}
+
 // Code returns the ErrorCode of err if it, or some error it wraps, is an *Error.
 // If err is context.Canceled or context.DeadlineExceeded, or wraps one of those errors,
 // it returns the Canceled or DeadlineExceeded codes, respectively.


### PR DESCRIPTION
Example changes to use struct error types (see #3702 ).

While creating this PR I realized that there is already a concrete infrastructure for unwrapping driver specific errors (e.g. `docstore.ErrorAs()`). Besides, I also realized that rewriting this part is currently not very simple because it would inflict breaking changes in the driver<->interface API.

Therefore, I as initial step I added a new Wrap() function which simply wraps a gcerrs.Error into a code-specific struct (currently only implemented AlreadyExistsError).

The idea behind such an approach would be to slowly migrate to struct errors like this:

1. Slowly deprecate `gcerror.ErrorAs()` as it would now be possible to extract driver specific errors by simply using `errors.As()`.
2. Instead of wrapping error codes, change the driver API to convert driver-errors to struct error wrappers (this step would break the API between driver<->sdk interface).
3. Remove legacy error helpers and deprecate error codes.

As already explained, I do now see that this is a long, complex and especially breaking process, therefore it is up to you to decide if the effort is worth going this way.