### PR TITLE
 build: add top-level permissions restriction to tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@
 
 name: tests
 on: [push, pull_request]
+permissions: read-all
 jobs:
   build:
     strategy:


### PR DESCRIPTION
 Add explicit `permissions: read-all` to restrict the default GITHUB_TOKEN
  permissions. Without this, workflows get the repository's default permissions
  which may include write access.

  This follows the principle of least privilege for CI workflows.

  Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-the-minimum-permissions-for-the-github_token