### PR TITLE
secrets/localsecrets: add encryption context support via context_ URL parameters

### DIFF
--- a/secrets/localsecrets/localsecrets.go
+++ b/secrets/localsecrets/localsecrets.go
@@ -31,14 +31,18 @@ package localsecrets // import "gocloud.dev/secrets/localsecrets"
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
 	"net/url"
+	"sort"
+	"strings"
 
 	"gocloud.dev/gcerrors"
 	"gocloud.dev/secrets"
+	"golang.org/x/crypto/hkdf"
 	"golang.org/x/crypto/nacl/secretbox"
 )
 
@@ -59,12 +63,31 @@ const (
 // Note that base64.URLEncoding should be used to avoid URL-unsafe character in the hostname.
 // If the URL host is empty (e.g., "base64key://"), a new random key is generated.
 //
-// No query parameters are supported.
-type URLOpener struct{}
+// EncryptionContext key/value pairs can be provided by providing URL parameters prefixed
+// with "context_"; e.g., "...&context_abc=foo&context_def=bar" would result in
+// an EncryptionContext of {abc=foo, def=bar}.
+//
+// A "salt" query parameter can be provided for HKDF domain separation when using
+// EncryptionContext; e.g., "...&salt=myapp". If not set, the default salt
+// "gocloud.dev/secrets/localsecrets" is used.
+type URLOpener struct {
+	// Options specifies the options to pass to OpenKeeper.
+	// EncryptionContext parameters from the URL are merged in.
+	Options KeeperOptions
+}
 
 // OpenKeeperURL opens Keeper URLs.
 func (o *URLOpener) OpenKeeperURL(ctx context.Context, u *url.URL) (*secrets.Keeper, error) {
-	for param := range u.Query() {
+	queryParams := u.Query()
+	opts := o.Options
+	if err := addEncryptionContextFromURLParams(&opts, queryParams); err != nil {
+		return nil, err
+	}
+	if s := queryParams.Get("salt"); s != "" {
+		opts.Salt = []byte(s)
+		queryParams.Del("salt")
+	}
+	for param := range queryParams {
 		return nil, fmt.Errorf("open keeper %v: invalid query parameter %q", u, param)
 	}
 	var sk [32]byte
@@ -77,21 +100,97 @@ func (o *URLOpener) OpenKeeperURL(ctx context.Context, u *url.URL) (*secrets.Kee
 	if err != nil {
 		return nil, fmt.Errorf("open keeper %v: failed to get key: %v", u, err)
 	}
-	return NewKeeper(sk), nil
+	return OpenKeeper(sk, &opts), nil
+}
+
+// addEncryptionContextFromURLParams merges any EncryptionContext URL parameters from
+// u into opts.EncryptionContext.
+// It removes the processed URL parameters from u.
+func addEncryptionContextFromURLParams(opts *KeeperOptions, u url.Values) error {
+	for k, vs := range u {
+		if strings.HasPrefix(k, "context_") {
+			if len(vs) != 1 {
+				return fmt.Errorf("open keeper: EncryptionContext URL parameters %q must have exactly 1 value", k)
+			}
+			u.Del(k)
+			if opts.EncryptionContext == nil {
+				opts.EncryptionContext = map[string]string{}
+			}
+			opts.EncryptionContext[k[8:]] = vs[0]
+		}
+	}
+	return nil
 }
 
 // keeper holds a secret for use in symmetric encryption,
 // and implements driver.Keeper.
 type keeper struct {
 	secretKey [32]byte // secretbox key size
+	opts      KeeperOptions
+}
+
+// OpenKeeper returns a *secrets.Keeper that uses the given symmetric
+// key with the given options.
+func OpenKeeper(sk [32]byte, opts *KeeperOptions) *secrets.Keeper {
+	if opts == nil {
+		opts = &KeeperOptions{}
+	}
+	return secrets.NewKeeper(&keeper{secretKey: sk, opts: *opts})
 }
 
 // NewKeeper returns a *secrets.Keeper that uses the given symmetric
 // key. See the package documentation for an example.
 func NewKeeper(sk [32]byte) *secrets.Keeper {
-	return secrets.NewKeeper(
-		&keeper{secretKey: sk},
-	)
+	return OpenKeeper(sk, nil)
+}
+
+// KeeperOptions controls Keeper behaviors.
+type KeeperOptions struct {
+	// EncryptionContext is a set of key/value pairs that are used during
+	// encryption and decryption. The same EncryptionContext must be provided
+	// for both operations; decryption will fail if the context does not match.
+	// See https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context.
+	EncryptionContext map[string]string
+	// Salt is used as the HKDF salt for key derivation when EncryptionContext
+	// is set. It provides domain separation so that different applications using
+	// the same key and context derive different subkeys.
+	// If nil, defaults to "gocloud.dev/secrets/localsecrets".
+	Salt []byte
+}
+
+var defaultSalt = []byte("gocloud.dev/secrets/localsecrets")
+
+// deriveKey derives a [32]byte key from the base secret key and the encryption context
+// using HKDF (RFC 5869). If no encryption context is set, the base key is returned unchanged.
+func deriveKey(sk [32]byte, opts KeeperOptions) [32]byte {
+	if len(opts.EncryptionContext) == 0 {
+		return sk
+	}
+	// Build deterministic info from sorted context key/value pairs
+	// with null byte separators to prevent ambiguity.
+	keys := make([]string, 0, len(opts.EncryptionContext))
+	for k := range opts.EncryptionContext {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var info []byte
+	for _, k := range keys {
+		info = append(info, k...)
+		info = append(info, 0)
+		info = append(info, opts.EncryptionContext[k]...)
+		info = append(info, 0)
+	}
+	salt := opts.Salt
+	if salt == nil {
+		salt = defaultSalt
+	}
+	r := hkdf.New(sha256.New, sk[:], salt, info)
+	var derived [32]byte
+	if _, err := io.ReadFull(r, derived[:]); err != nil {
+		// sha256-based HKDF will never fail to produce 32 bytes.
+		panic(err)
+	}
+	return derived
 }
 
 // Base64KeyStd takes a secret key as a base64 string and converts it
@@ -146,7 +245,8 @@ func (k *keeper) Encrypt(ctx context.Context, message []byte) ([]byte, error) {
 	// secretbox.Seal appends the encrypted message to its first argument and returns
 	// the result; using a slice on top of the nonce array for this "out" arg allows reading
 	// the nonce out of the first nonceSize bytes when the message is decrypted.
-	return secretbox.Seal(nonce[:], message, &nonce, &k.secretKey), nil
+	key := deriveKey(k.secretKey, k.opts)
+	return secretbox.Seal(nonce[:], message, &nonce, &key), nil
 }
 
 // Decrypt decrypts a message using a nonce that is read out of the first nonceSize bytes
@@ -158,7 +258,8 @@ func (k *keeper) Decrypt(ctx context.Context, message []byte) ([]byte, error) {
 	var decryptNonce [nonceSize]byte
 	copy(decryptNonce[:], message[:nonceSize])
 
-	decrypted, ok := secretbox.Open(nil, message[nonceSize:], &decryptNonce, &k.secretKey)
+	key := deriveKey(k.secretKey, k.opts)
+	decrypted, ok := secretbox.Open(nil, message[nonceSize:], &decryptNonce, &key)
 	if !ok {
 		return nil, errors.New("localsecrets: Decrypt failed")
 	}

--- a/secrets/localsecrets/localsecrets_test.go
+++ b/secrets/localsecrets/localsecrets_test.go
@@ -136,6 +136,12 @@ func TestOpenKeeper(t *testing.T) {
 		{"base64Key://UKcmEoZW7nKl0uPHr8yV__KJm0ANhiFz8PzDN-gYWq8=", false},
 		// Invalid parameter.
 		{"base64key://?param=value", true},
+		// OK with encryption context.
+		{"base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=?context_abc=foo&context_def=bar", false},
+		// OK with encryption context and empty host (random key).
+		{"base64key://?context_tenant=123", false},
+		// Encryption context with multiple values for same key is an error.
+		{"base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=?context_abc=foo&context_abc=bar", true},
 	}
 
 	ctx := context.Background()
@@ -149,5 +155,162 @@ func TestOpenKeeper(t *testing.T) {
 				t.Errorf("%s: got error during close: %v", test.URL, err)
 			}
 		}
+	}
+}
+
+func TestEncryptionContext(t *testing.T) {
+	key, err := NewRandomKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	const plaintext = "hello world"
+
+	// Encrypt with encryption context.
+	keeperWithCtx := OpenKeeper(key, &KeeperOptions{
+		EncryptionContext: map[string]string{"tenant": "abc", "env": "prod"},
+	})
+	defer keeperWithCtx.Close()
+
+	ciphertext, err := keeperWithCtx.Encrypt(ctx, []byte(plaintext))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Decrypt with the same encryption context should succeed.
+	got, err := keeperWithCtx.Decrypt(ctx, ciphertext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != plaintext {
+		t.Errorf("got %q, want %q", string(got), plaintext)
+	}
+
+	// Decrypt without encryption context should fail.
+	keeperNoCtx := NewKeeper(key)
+	defer keeperNoCtx.Close()
+
+	_, err = keeperNoCtx.Decrypt(ctx, ciphertext)
+	if err == nil {
+		t.Error("expected Decrypt to fail without encryption context, but it succeeded")
+	}
+
+	// Decrypt with a different encryption context should fail.
+	keeperDiffCtx := OpenKeeper(key, &KeeperOptions{
+		EncryptionContext: map[string]string{"tenant": "xyz"},
+	})
+	defer keeperDiffCtx.Close()
+
+	_, err = keeperDiffCtx.Decrypt(ctx, ciphertext)
+	if err == nil {
+		t.Error("expected Decrypt to fail with different encryption context, but it succeeded")
+	}
+
+	// Encrypt without context, decrypt with context should fail.
+	ciphertext2, err := keeperNoCtx.Encrypt(ctx, []byte(plaintext))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = keeperWithCtx.Decrypt(ctx, ciphertext2)
+	if err == nil {
+		t.Error("expected Decrypt to fail when ciphertext was encrypted without context, but it succeeded")
+	}
+}
+
+func TestEncryptionContextSalt(t *testing.T) {
+	key, err := NewRandomKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	const plaintext = "hello world"
+	ec := map[string]string{"tenant": "abc"}
+
+	// Encrypt with custom salt.
+	keeperSalt1 := OpenKeeper(key, &KeeperOptions{
+		EncryptionContext: ec,
+		Salt:              []byte("salt1"),
+	})
+	defer keeperSalt1.Close()
+
+	ciphertext, err := keeperSalt1.Encrypt(ctx, []byte(plaintext))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Decrypt with the same salt should succeed.
+	got, err := keeperSalt1.Decrypt(ctx, ciphertext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != plaintext {
+		t.Errorf("got %q, want %q", string(got), plaintext)
+	}
+
+	// Decrypt with a different salt should fail.
+	keeperSalt2 := OpenKeeper(key, &KeeperOptions{
+		EncryptionContext: ec,
+		Salt:              []byte("salt2"),
+	})
+	defer keeperSalt2.Close()
+
+	_, err = keeperSalt2.Decrypt(ctx, ciphertext)
+	if err == nil {
+		t.Error("expected Decrypt to fail with different salt, but it succeeded")
+	}
+
+	// Decrypt with default salt (nil) should also fail.
+	keeperDefaultSalt := OpenKeeper(key, &KeeperOptions{
+		EncryptionContext: ec,
+	})
+	defer keeperDefaultSalt.Close()
+
+	_, err = keeperDefaultSalt.Decrypt(ctx, ciphertext)
+	if err == nil {
+		t.Error("expected Decrypt to fail with default salt vs custom salt, but it succeeded")
+	}
+}
+
+func TestOpenKeeperURLWithSalt(t *testing.T) {
+	ctx := context.Background()
+	const plaintext = "hello world"
+
+	// Open two keepers with same key + context but different salts via URL.
+	k1, err := secrets.OpenKeeper(ctx, "base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=?context_a=1&salt=salt1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer k1.Close()
+
+	ciphertext, err := k1.Encrypt(ctx, []byte(plaintext))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Same key + context + salt via URL should decrypt.
+	k1b, err := secrets.OpenKeeper(ctx, "base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=?context_a=1&salt=salt1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer k1b.Close()
+
+	got, err := k1b.Decrypt(ctx, ciphertext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != plaintext {
+		t.Errorf("got %q, want %q", string(got), plaintext)
+	}
+
+	// Different salt via URL should fail to decrypt.
+	k2, err := secrets.OpenKeeper(ctx, "base64key://smGbjm71Nxd1Ig5FS0wj9SlbzAIrnolCz9bQQ6uAhl4=?context_a=1&salt=salt2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer k2.Close()
+
+	_, err = k2.Decrypt(ctx, ciphertext)
+	if err == nil {
+		t.Error("expected Decrypt to fail with different salt, but it succeeded")
 	}
 }


### PR DESCRIPTION
Add EncryptionContext support to localsecrets, mirroring the awskms interface. Encryption context key/value pairs can be provided via URL parameters prefixed with "context_" (e.g., context_tenant=abc) or programmatically through KeeperOptions.EncryptionContext.

When an encryption context is set, a subkey is derived from the base secret key using HKDF (RFC 5869) with the context as the info parameter. This ensures that ciphertext can only be decrypted with the same encryption context. A configurable salt (via KeeperOptions.Salt or the "salt" URL parameter) provides domain separation, defaulting to "gocloud.dev/secrets/localsecrets".

New public API:
- OpenKeeper(sk [32]byte, opts *KeeperOptions) *secrets.Keeper
- KeeperOptions{EncryptionContext, Salt}

NewKeeper remains unchanged for backwards compatibility.