### PR TITLE
blob/fileblob: parse dir_file_mode as octal

### DIFF
--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -112,7 +112,9 @@ const Scheme = "file"
 //     if it does not already exist.
 //   - dir_file_mode: any directories that are created (the base directory when create_dir
 //     is true, or subdirectories for keys) are created using this os.FileMode, parsed
-//     using os.Parseuint. Defaults to 0777.
+//     using strconv.ParseUint with base 0. A leading "0" or "0o" is interpreted as
+//     octal (e.g. "0777"), matching the conventional notation for file modes.
+//     Defaults to 0777.
 //   - no_tmp_dir: (any non-empty value) temporary files are created next to the final
 //     path instead of in os.TempDir.
 //   - base_url: the base URL to use to construct signed URLs; see URLSignerHMAC
@@ -203,7 +205,11 @@ func (o *URLOpener) forParams(ctx context.Context, q url.Values) (*Options, erro
 		opts.CreateDir = true
 	}
 	if fms := q.Get("dir_file_mode"); fms != "" {
-		fm, err := strconv.ParseUint(fms, 10, 32)
+		// Use base 0 so that the value is interpreted according to its prefix:
+		// a leading "0" or "0o" means octal, which is how file modes are
+		// conventionally written (e.g. "0777"). Without this, "0777" would be
+		// parsed as decimal 777, yielding unexpected permission bits.
+		fm, err := strconv.ParseUint(fms, 0, 32)
 		if err != nil {
 			return nil, fmt.Errorf("fileblob.OpenBucket: invalid dir_file_mode %q: %v", fms, err)
 		}

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -457,6 +457,39 @@ func TestOpenBucketFromURL(t *testing.T) {
 	}
 }
 
+func TestDirFileModeFromURL(t *testing.T) {
+	ctx := context.Background()
+	o := &URLOpener{}
+	tests := []struct {
+		query string
+		want  os.FileMode
+	}{
+		// Octal notation with a leading "0" is the conventional way to write a
+		// file mode, and is what the documented default (0777) looks like.
+		{"dir_file_mode=0777", os.FileMode(0o777)},
+		{"dir_file_mode=0755", os.FileMode(0o755)},
+		{"dir_file_mode=0700", os.FileMode(0o700)},
+		// "0o" prefix is also octal.
+		{"dir_file_mode=0o644", os.FileMode(0o644)},
+		// No prefix is decimal, preserving the previous behavior.
+		{"dir_file_mode=511", os.FileMode(511)},
+	}
+	for _, test := range tests {
+		q, err := url.ParseQuery(test.query)
+		if err != nil {
+			t.Fatalf("%s: %v", test.query, err)
+		}
+		opts, err := o.forParams(ctx, q)
+		if err != nil {
+			t.Errorf("%s: got error %v, want nil", test.query, err)
+			continue
+		}
+		if opts.DirFileMode != test.want {
+			t.Errorf("%s: got DirFileMode %v (%#o), want %v (%#o)", test.query, opts.DirFileMode, opts.DirFileMode, test.want, test.want)
+		}
+	}
+}
+
 func TestEscapeBucketRoot(t *testing.T) {
 	ctx := context.Background()
 	tdir := t.TempDir()


### PR DESCRIPTION
The fileblob URL opener accepts a dir_file_mode query parameter that sets the os.FileMode used when creating directories. It was parsed with strconv.ParseUint using base 10:

    fm, err := strconv.ParseUint(fms, 10, 32)

File modes are conventionally written in octal, and the doc comment for this parameter gives the default as 0777. A user who follows that convention and passes dir_file_mode=0777 ends up with decimal 777, which is os.FileMode 01411 (-r----x--x), not the intended -rwxrwxrwx. The leading zero is also silently dropped, so the value never round-trips the way it reads.

This changes the parse to base 0 so the value is interpreted by its prefix: a leading 0 or 0o means octal (the usual file-mode notation), while a plain decimal value keeps working exactly as before. The existing valid case in the tests uses dir_file_mode=666 with no prefix, so it is unaffected.

The doc comment is updated to describe the actual parsing (it previously referred to a nonexistent "os.Parseuint").

A new test, TestDirFileModeFromURL, drives the opener's parameter parsing and asserts the resulting DirFileMode for octal, 0o-prefixed, and decimal inputs. Before the change it fails:

    dir_file_mode=0777: got DirFileMode -r----x--x (01411), want -rwxrwxrwx (0777)

After the change the full blob/fileblob package passes, with gofmt and go vet clean.
