### PR TITLE
blob/memblob: fix Upload not hashing content for MD5 attribute

### DIFF
--- a/blob/memblob/memblob.go
+++ b/blob/memblob/memblob.go
@@ -348,6 +348,9 @@ func (w *writer) Write(p []byte) (n int, err error) {
 }
 
 func (w *writer) Upload(r io.Reader) error {
+	if w.md5hash != nil {
+		r = io.TeeReader(r, w.md5hash)
+	}
 	_, err := w.buf.ReadFrom(r)
 	return err
 }

--- a/blob/memblob/memblob_test.go
+++ b/blob/memblob/memblob_test.go
@@ -15,7 +15,9 @@
 package memblob
 
 import (
+	"bytes"
 	"context"
+	"crypto/md5"
 	"net/http"
 	"testing"
 
@@ -74,6 +76,35 @@ func TestConformanceWithPrefix(t *testing.T) {
 
 func BenchmarkMemblob(b *testing.B) {
 	drivertest.RunBenchmarks(b, OpenBucket(nil))
+}
+
+// TestUploadMD5 verifies that blobs written via the Upload fast-path store the
+// correct MD5 attribute. Previously, writer.Upload wrote only to the buffer and
+// skipped feeding data through the md5 hasher, so the stored MD5 was always
+// the hash of an empty input rather than the actual content hash.
+func TestUploadMD5(t *testing.T) {
+	ctx := context.Background()
+	b := OpenBucket(nil)
+	defer b.Close()
+
+	content := []byte("hello memblob upload md5")
+
+	// blob.Bucket.Upload uses the driver's Upload method when available.
+	if err := b.Upload(ctx, "testkey", bytes.NewReader(content), &blob.WriterOptions{
+		ContentType: "text/plain",
+	}); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+
+	attrs, err := b.Attributes(ctx, "testkey")
+	if err != nil {
+		t.Fatalf("Attributes: %v", err)
+	}
+
+	want := md5.Sum(content)
+	if !bytes.Equal(attrs.MD5, want[:]) {
+		t.Errorf("MD5 after Upload = %x, want %x", attrs.MD5, want)
+	}
 }
 
 func TestOpenBucketFromURL(t *testing.T) {


### PR DESCRIPTION
The writer.Upload method wrote bytes directly into the buffer but never
passed them through the md5 hasher. When a blob is written via the Upload
fast-path (which the portable blob.Bucket.Upload uses whenever ContentMD5
is not set), the resulting Attributes.MD5 was always the MD5 of an empty
input (d41d8cd98f00b204e9800998ecf8427e) rather than the actual content.

writer.Write does this correctly by writing to both w.md5hash and w.buf.
writer.Upload only wrote to w.buf.

The fix wraps the incoming reader with io.TeeReader so every byte that
ReadFrom pulls into the buffer also flows through the md5 hasher, keeping
the two write paths consistent.

Added TestUploadMD5 which exercises the Upload path and checks that the
stored MD5 matches crypto/md5.Sum of the written content. The test failed
before this change and passes after.