### PR TITLE
aws: ensure role assumption is done after other options are parsed

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -94,6 +94,7 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (aws.Config, error
 	var endpoint string
 	var hostnameImmutable bool
 	var rateLimitCapacity int64
+	var roleARN string
 	var opts []func(*config.LoadOptions) error
 	for param, values := range q {
 		value := values[0]
@@ -144,18 +145,7 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (aws.Config, error
 			if !strings.HasPrefix(value, "arn:") {
 				return aws.Config{}, fmt.Errorf("invalid value for role: must be a valid ARN (starts with 'arn:'): %s", value)
 			}
-			baseConfig, err := config.LoadDefaultConfig(ctx, opts...)
-			if err != nil {
-				return aws.Config{}, fmt.Errorf("failed to load default AWS config: %w", err)
-			}
-			stsClient := sts.NewFromConfig(baseConfig)
-			provider := stscreds.NewAssumeRoleProvider(stsClient, value)
-			opts = []func(*config.LoadOptions) error{
-				config.WithCredentialsProvider(provider),
-			}
-			if baseConfig.Region != "" {
-				opts = append(opts, config.WithRegion(baseConfig.Region))
-			}
+			roleARN = value
 		case requestChecksumCalculationParamKey:
 			value, err := parseRequestChecksumCalculation(value)
 			if err != nil {
@@ -175,6 +165,21 @@ func V2ConfigFromURLParams(ctx context.Context, q url.Values) (aws.Config, error
 		default:
 			return aws.Config{}, fmt.Errorf("unknown query parameter %q", param)
 		}
+	}
+	if roleARN != "" {
+		baseConfig, err := config.LoadDefaultConfig(ctx, opts...)
+		if err != nil {
+			return aws.Config{}, fmt.Errorf("failed to load default AWS config: %w", err)
+		}
+		stsClient := sts.NewFromConfig(baseConfig)
+		provider := stscreds.NewAssumeRoleProvider(stsClient, roleARN)
+		opts = []func(*config.LoadOptions) error{
+			config.WithCredentialsProvider(provider),
+		}
+		if baseConfig.Region == "" {
+			return aws.Config{}, fmt.Errorf("STS client created with empty region: all other parameters must be collected before assuming role")
+		}
+		opts = append(opts, config.WithRegion(baseConfig.Region))
 	}
 	if endpoint != "" {
 		customResolver := aws.EndpointResolverWithOptionsFunc(


### PR DESCRIPTION
This fixes an issue introduced with the new feature in #3716 . Without this change, the options map is iterated over in a random order, which will cause issues if another parameter (e.g. region) is provided and needed.

Current tests don't catch this, but this part of the PR:

```
			if baseConfig.Region == "" {
				return aws.Config{}, fmt.Errorf("STS client created with empty region: all other parameters must be collected before assuming role")
			}
```

does exercise the tests -- if that same check was added to the current code, the current tests will fail sporadically.