### PR TITLE
blob/fileblob: clean up temp file on BeforeWrite error

### DIFF
--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -758,6 +758,9 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key, contentType string, op
 			*p = f
 			return true
 		}); err != nil {
+			name := f.Name()
+			_ = f.Close()
+			_ = os.Remove(name)
 			return nil, err
 		}
 	}

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -294,6 +294,40 @@ func TestIfNotExistHasNoSideEffects(t *testing.T) {
 	}
 }
 
+func TestBeforeWriteErrorRemovesTempFile(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	beforeWriteErr := errors.New("before write failed")
+
+	b, err := OpenBucket(dir, &Options{NoTempDir: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+
+	var tempName string
+	_, gotErr := b.NewWriter(ctx, "key", &blob.WriterOptions{
+		ContentType: "text/plain",
+		BeforeWrite: func(as func(any) bool) error {
+			var f *os.File
+			if !as(&f) {
+				t.Fatal("BeforeWrite.As failed")
+			}
+			tempName = f.Name()
+			return beforeWriteErr
+		},
+	})
+	if !errors.Is(gotErr, beforeWriteErr) {
+		t.Fatalf("got error %v, want %v", gotErr, beforeWriteErr)
+	}
+	if tempName == "" {
+		t.Fatal("BeforeWrite was not called")
+	}
+	if _, err := os.Stat(tempName); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temp file exists after BeforeWrite error: %v", err)
+	}
+}
+
 func TestSignedURLReturnsUnimplementedWithNoURLSigner(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
Fixes a leak in fileblob's NewTypedWriter when BeforeWrite returns an error. The temp file is created before BeforeWrite runs, so an early callback error left the file open and on disk.

This closes and removes the temp file before returning the callback error, and adds a regression test that captures the temp filename through BeforeWrite and verifies it has been removed.

Tested:
- go test ./blob/fileblob
- go test ./blob/...