### PR TITLE
blob/fileblob: fix nil underlying error in IfNotExist precondition check

### DIFF
--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -849,7 +849,7 @@ func (w *writerWithSidecar) Close() error {
 		defer w.mu.Unlock()
 		_, err = os.Stat(w.path)
 		if err == nil {
-			return gcerr.New(gcerrors.FailedPrecondition, err, 1, "File already exist")
+			return gcerr.New(gcerrors.FailedPrecondition, fmt.Errorf("blob %q already exists", w.path), 1, "fileblob: IfNotExist precondition failed")
 		}
 	}
 	// Write the attributes file.
@@ -903,7 +903,7 @@ func (w *writer) Close() error {
 		defer w.mu.Unlock()
 		_, err = os.Stat(w.path)
 		if err == nil {
-			return gcerr.New(gcerrors.FailedPrecondition, err, 1, "File already exist")
+			return gcerr.New(gcerrors.FailedPrecondition, fmt.Errorf("blob %q already exists", w.path), 1, "fileblob: IfNotExist precondition failed")
 		}
 	}
 


### PR DESCRIPTION
## Bug

In both `writer.Close()` and `writerWithSidecar.Close()`, the `IfNotExist` precondition check has two bugs:

1. **Nil underlying error**: When `os.Stat` succeeds (meaning the file exists), `err` is `nil`. That `nil` is passed directly to `gcerr.New()` as the underlying error, resulting in an error chain with no meaningful cause. `errors.Is` / `errors.As` callers get no wrapped context.

2. **Typo**: The message `"File already exist"` is grammatically incorrect and inconsistent with how `memblob` reports the same condition.

```go
// Before (both writer.Close and writerWithSidecar.Close)
_, err = os.Stat(w.path)
if err == nil {
    return gcerr.New(gcerrors.FailedPrecondition, err, 1, "File already exist")
    //                                            ^^^-- nil!
}
```

## Fix

Replace the `nil` underlying error with a descriptive `fmt.Errorf`, and update the message to be consistent with `memblob`'s phrasing:

```go
// After
_, err = os.Stat(w.path)
if err == nil {
    return gcerr.New(gcerrors.FailedPrecondition, fmt.Errorf("blob %q already exists", w.path), 1, "fileblob: IfNotExist precondition failed")
}
```

This matches the pattern in `memblob` where `IfNotExist` returns:
```go
err := fmt.Errorf("a blob already exists for key %q", w.key)
return gcerr.New(gcerrors.FailedPrecondition, err, 1, "IfNotExist precondition failed")
```

## Testing

The existing `drivertest` conformance suite exercises `IfNotExist` writes; this fix ensures the error returned has a non-nil cause when the precondition triggers.