### PR TITLE
mysql: preserve cleartext password auth setting

### DIFF
--- a/mysql/awsmysql/awsmysql.go
+++ b/mysql/awsmysql/awsmysql.go
@@ -130,6 +130,7 @@ func (uo *URLOpener) OpenMySQLURL(ctx context.Context, u *url.URL) (*sql.DB, err
 	if err != nil {
 		return nil, err
 	}
+	cfg.AllowCleartextPasswords = true
 	c := &connector{
 		cfg:      cfg,
 		iam:      iam,

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -78,7 +78,6 @@ func ConfigFromURL(u *url.URL) (cfg *mysql.Config, err error) {
 	cfg.User = u.User.Username()
 	cfg.Passwd, _ = u.User.Password()
 	cfg.DBName = dbName
-	cfg.AllowCleartextPasswords = true
 	cfg.AllowNativePasswords = true
 	return cfg, nil
 }

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -78,6 +78,9 @@ func ConfigFromURL(u *url.URL) (cfg *mysql.Config, err error) {
 	cfg.User = u.User.Username()
 	cfg.Passwd, _ = u.User.Password()
 	cfg.DBName = dbName
+	if _, ok := u.Query()["allowCleartextPasswords"]; !ok {
+		cfg.AllowCleartextPasswords = true
+	}
 	cfg.AllowNativePasswords = true
 	return cfg, nil
 }

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -101,7 +101,7 @@ func TestConfigFromURLCleartextPasswords(t *testing.T) {
 		{
 			name: "default",
 			url:  "mysql://user:password@localhost/db",
-			want: false,
+			want: true,
 		},
 		{
 			name: "explicit false",

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -91,3 +91,41 @@ func TestConfigFromURL(t *testing.T) {
 		}
 	}
 }
+
+func TestConfigFromURLCleartextPasswords(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{
+			name: "default",
+			url:  "mysql://user:password@localhost/db",
+			want: false,
+		},
+		{
+			name: "explicit false",
+			url:  "mysql://user:password@localhost/db?allowCleartextPasswords=false",
+			want: false,
+		},
+		{
+			name: "explicit true",
+			url:  "mysql://user:password@localhost/db?allowCleartextPasswords=true",
+			want: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := url.Parse(tc.url)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := ConfigFromURL(u)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := cfg.AllowCleartextPasswords; got != tc.want {
+				t.Errorf("AllowCleartextPasswords = %v; want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Changes
- Preserve the existing Go CDK default `AllowCleartextPasswords` behavior for generic `mysql://` URLs when the option is omitted.
- Respect an explicit `allowCleartextPasswords=false` URL setting instead of overwriting it after DSN parsing.
- Continue allowing cleartext password authentication in `awsmysql`, where the connector configures TLS before connecting.
- Add coverage for default, explicit false, and explicit true `allowCleartextPasswords` URL settings.

### Tests
- `go test ./mysql -run TestConfigFromURL -count=1`
- `go test ./mysql ./mysql/awsmysql ./mysql/azuremysql -count=1`
- `go test ./mysql/... -count=1`
- `go test ./... -count=1`
