### PR TITLE
secrets/localsecrets: don't leak raw key material in OpenKeeperURL errors

### DIFF
--- a/secrets/localsecrets/localsecrets.go
+++ b/secrets/localsecrets/localsecrets.go
@@ -65,7 +65,9 @@ type URLOpener struct{}
 // OpenKeeperURL opens Keeper URLs.
 func (o *URLOpener) OpenKeeperURL(ctx context.Context, u *url.URL) (*secrets.Keeper, error) {
 	for param := range u.Query() {
-		return nil, fmt.Errorf("open keeper %v: invalid query parameter %q", u, param)
+		// Note: don't include u in this error, since u.Host holds the raw
+		// key material for this scheme and would leak it into logs/errors.
+		return nil, fmt.Errorf("open keeper %s: invalid query parameter %q", u.Scheme, param)
 	}
 	var sk [32]byte
 	var err error
@@ -75,7 +77,9 @@ func (o *URLOpener) OpenKeeperURL(ctx context.Context, u *url.URL) (*secrets.Kee
 		sk, err = Base64Key(u.Host)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("open keeper %v: failed to get key: %v", u, err)
+		// Note: don't include u in this error, since u.Host holds the raw
+		// key material for this scheme and would leak it into logs/errors.
+		return nil, fmt.Errorf("open keeper %s: failed to get key: %v", u.Scheme, err)
 	}
 	return NewKeeper(sk), nil
 }


### PR DESCRIPTION
Summary

The base64key:// scheme in secrets/localsecrets embeds the raw 32-byte symmetric key directly as the URL host. OpenKeeperURL() builds its error messages by formatting the full *url.URL with %v, which (since url.URL implements Stringer) renders the key verbatim into the returned error on any decode failure.

This is the exact pattern in go-cloud's own reference sample, samples/gocdk-secrets/main.go:100-103:

keeper, err := secrets.OpenKeeper(ctx, keeperURL)
if err != nil {
    log.Printf("Failed to open keeper: %v\n", err)
    return subcommands.ExitFailure
}

Any code following this pattern ends up writing the key to whatever log sink it uses whenever the key is misconfigured (wrong base64 alphabet, wrong length, truncated by an env var length limit).

File changed: secrets/localsecrets/localsecrets.go

Fix - stop formatting the full URL in OpenKeeperURL two error paths

BEFORE:

for param := range u.Query() {
    return nil, fmt.Errorf("open keeper %v: invalid query parameter %q", u, param)
}
...
if err != nil {
    return nil, fmt.Errorf("open keeper %v: failed to get key: %v", u, err)
}

u.Host carries the raw key for this scheme, so %v on the full URL puts the key in both error strings.

AFTER:

for param := range u.Query() {
    return nil, fmt.Errorf("open keeper %s: invalid query parameter %q", u.Scheme, param)
}
...
if err != nil {
    return nil, fmt.Errorf("open keeper %s: failed to get key: %v", u.Scheme, err)
}

Formatting only u.Scheme keeps the error useful for debugging (which URL scheme failed to open) without including the host component.

Testing

Verified with two standalone repros: one using a base64.StdEncoding key with a / character, and one using a correctly base64.URLEncoding-encoded key that is simply the wrong length. Before the fix, both included the raw key in the error string. After the fix, neither does. go test ./secrets/localsecrets/... passes unchanged.

Related

#3123 reproduces the same StdEncoding scenario but was scoped to the encoding-choice question, not this error-formatting line, which its fix did not touch.