### PR TITLE
docstore/mongodocstore: redact password from default dialer error

### DIFF
--- a/docstore/mongodocstore/urls.go
+++ b/docstore/mongodocstore/urls.go
@@ -54,7 +54,11 @@ func (o *defaultDialer) OpenCollectionURL(ctx context.Context, u *url.URL) (*doc
 	if currentEnv != o.mongoServerURL {
 		client, err := Dial(ctx, currentEnv)
 		if err != nil {
-			o.err = fmt.Errorf("failed to dial default Mongo server at %q: %v", currentEnv, err)
+			if parsed, perr := url.Parse(currentEnv); perr == nil {
+				o.err = fmt.Errorf("failed to dial default Mongo server at %q: %v", parsed.Redacted(), err)
+			} else {
+				o.err = fmt.Errorf("failed to dial default Mongo server: %v", err)
+			}
 			return nil, fmt.Errorf("open collection %s: %v", u, o.err)
 		}
 		o.mongoServerURL = currentEnv


### PR DESCRIPTION
Reported via OSS VRP: Issue 535147791

## What
\`defaultDialer.OpenCollectionURL\` in \`docstore/mongodocstore/urls.go\` reads the \`MONGO_SERVER_URL\` environment variable, which is a MongoDB connection string of the form \`mongodb://user:pass@host/...\`, and dials it lazily on first use (and again whenever the env var value changes). When the dial fails, the error path built the returned error directly from the raw connection string:

\`\`\`go
client, err := Dial(ctx, currentEnv)
if err != nil {
    o.err = fmt.Errorf("failed to dial default Mongo server at %q: %v", currentEnv, err)
    ...
}
\`\`\`

Any dial failure (unreachable host, auth failure, a malformed query parameter such as an invalid \`readPreference\`, etc.) therefore returned an error containing the password verbatim. Since this error is what typical callers pass straight into their normal logging path, a transient connection problem or misconfiguration results in the database credential being written to application logs.

## Fix
Parse the connection string with \`net/url\` and use the standard library's \`url.URL.Redacted()\` method, which strips userinfo passwords and replaces them with \`xxxxx\`, when building the error message. If parsing itself fails, the connection-string detail is omitted from the error entirely instead of falling back to the raw value.

## Testing
- \`go build ./...\` and \`go vet ./...\` in \`docstore/mongodocstore\` pass.
- \`go test ./...\` in \`docstore/mongodocstore\` behaves the same as before this change (failures are pre-existing conformance tests that require a live MongoDB instance and are unrelated to this change).
- Verified locally with a synchronous dial failure (malformed \`readPreference\` query parameter, no network needed): before the fix the error contained the plaintext password, after the fix it reads \`mongodb://admin:xxxxx@10.0.0.5:27017/...\`.