### PR TITLE
pubsub/rabbitpubsub: redact password from default dialer error

### DIFF
--- a/pubsub/rabbitpubsub/rabbit.go
+++ b/pubsub/rabbitpubsub/rabbit.go
@@ -64,7 +64,10 @@ func (o *defaultDialer) defaultConn(ctx context.Context) (*URLOpener, error) {
 	}
 	conn, err := amqp.Dial(serverURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial RABBIT_SERVER_URL %q: %w", serverURL, err)
+		if parsed, perr := url.Parse(serverURL); perr == nil {
+			return nil, fmt.Errorf("failed to dial RABBIT_SERVER_URL %q: %w", parsed.Redacted(), err)
+		}
+		return nil, fmt.Errorf("failed to dial RABBIT_SERVER_URL: %w", err)
 	}
 	o.conn = conn
 	o.opener = &URLOpener{Connection: conn}


### PR DESCRIPTION
Reported via Google OSS VRP, issue 535149884.


## What
\`defaultDialer.defaultConn\` in \`pubsub/rabbitpubsub/rabbit.go\` reads the \`RABBIT_SERVER_URL\` environment variable, an AMQP connection string of the form \`amqp://user:pass@host:port/vhost\`, and dials it lazily. When the dial fails, the error was built directly from the raw connection string:

\`\`\`go
conn, err := amqp.Dial(serverURL)
if err != nil {
    return nil, fmt.Errorf("failed to dial RABBIT_SERVER_URL %q: %w", serverURL, err)
}
\`\`\`

Any dial failure (unreachable broker, wrong vhost, network timeout, etc.) therefore returned an error containing the password verbatim, which typical callers pass straight into their normal logging path.

## Fix
Parse the connection string with \`net/url\` and use the standard library's \`url.URL.Redacted()\` method, which strips userinfo passwords and replaces them with \`xxxxx\`, when building the error message. If parsing itself fails, the connection-string detail is omitted from the error entirely instead of falling back to the raw value.

## Testing
- \`go build ./...\` and \`go vet ./...\` in \`pubsub/rabbitpubsub\` pass.
- \`go test ./...\` in \`pubsub/rabbitpubsub\` behaves the same as before this change (failures are pre-existing tests that require a live RabbitMQ broker and are unrelated to this change).
- Verified locally with an unroutable broker address causing a real dial timeout: before the fix the error contained the plaintext password, after the fix it reads \`amqp://svc-account:xxxxx@10.0.0.9:5672/...\`.