### PR TITLE
pubsub/azuresb: redact shared access key from connection string error

### DIFF
--- a/pubsub/azuresb/azuresb.go
+++ b/pubsub/azuresb/azuresb.go
@@ -173,6 +173,22 @@ type URLOpener struct {
 	SubscriptionOptions SubscriptionOptions
 }
 
+// redactSharedAccessKey returns connString with the value of any
+// "SharedAccessKey=..." segment replaced by "xxxxx", so that it's safe to
+// include in error messages and logs.
+func redactSharedAccessKey(connString string) string {
+	const key = "SharedAccessKey="
+	idx := strings.Index(connString, key)
+	if idx == -1 {
+		return connString
+	}
+	rest := connString[idx+len(key):]
+	if end := strings.IndexByte(rest, ';'); end != -1 {
+		return connString[:idx] + key + "xxxxx" + rest[end:]
+	}
+	return connString[:idx] + key + "xxxxx"
+}
+
 func (o *URLOpener) sbClient(kind string, u *url.URL) (*servicebus.Client, error) {
 	if o.ConnectionString == "" && o.ServiceBusHostname == "" {
 		return nil, fmt.Errorf("open %s %v: one of ConnectionString or ServiceBusHostname is required", kind, u)
@@ -182,7 +198,7 @@ func (o *URLOpener) sbClient(kind string, u *url.URL) (*servicebus.Client, error
 	if o.ConnectionString != "" {
 		client, err := NewClientFromConnectionString(o.ConnectionString, o.ServiceBusClientOptions)
 		if err != nil {
-			return nil, fmt.Errorf("open %s %v: invalid connection string %q: %v", kind, u, o.ConnectionString, err)
+			return nil, fmt.Errorf("open %s %v: invalid connection string %q: %v", kind, u, redactSharedAccessKey(o.ConnectionString), err)
 		}
 		return client, nil
 	}


### PR DESCRIPTION
## Reported via Google OSS VRP, issue 535156364.

## What
\`URLOpener.sbClient\` in \`pubsub/azuresb/azuresb.go\` reads the \`SERVICEBUS_CONNECTION_STRING\` environment variable, an Azure Service Bus connection string containing a \`SharedAccessKey=...\` component. When parsing the connection string failed, the error was built directly from the raw string:

\`\`\`go
client, err := NewClientFromConnectionString(o.ConnectionString, o.ServiceBusClientOptions)
if err != nil {
    return nil, fmt.Errorf("open %s %v: invalid connection string %q: %v", kind, u, o.ConnectionString, err)
}
\`\`\`

Any parse failure (a malformed segment, a stray character introduced during manual editing or partial rotation, etc.) therefore returned an error containing the shared access key verbatim, which typical callers pass straight into their normal logging path.

## Fix
Add a small \`redactSharedAccessKey\` helper that replaces the value of a \`SharedAccessKey=...\` segment with \`xxxxx\`, up to the next \`;\` or the end of the string, and use its output in the error message instead of the raw connection string. The connection string is a semicolon-separated \`Key=Value\` format rather than a \`net/url.URL\`, so \`url.Redacted()\` doesn't apply directly here.

## Testing
- \`go build ./pubsub/azuresb/...\` and \`go vet ./pubsub/azuresb/...\` pass.
- \`go test ./pubsub/azuresb/...\` passes, same as before this change.
- Verified locally with a connection string that has one malformed segment (a stray flag missing \`=\`), causing a synchronous parse failure: before the fix the error contained the plaintext shared access key, after the fix it reads \`SharedAccessKey=xxxxx\`.