### PR TITLE
pubsub/natspubsub: redact password from default dialer error

### DIFF
--- a/pubsub/natspubsub/nats.go
+++ b/pubsub/natspubsub/nats.go
@@ -133,7 +133,11 @@ func (o *defaultDialer) defaultConn(ctx context.Context) error {
 		}
 		conn, err := nats.Connect(serverURL)
 		if err != nil {
-			o.err = fmt.Errorf("failed to dial NATS_SERVER_URL %q: %v", serverURL, err)
+			if parsed, perr := url.Parse(serverURL); perr == nil {
+				o.err = fmt.Errorf("failed to dial NATS_SERVER_URL %q: %v", parsed.Redacted(), err)
+			} else {
+				o.err = fmt.Errorf("failed to dial NATS_SERVER_URL: %v", err)
+			}
 			return
 		}
 		o.opener = URLOpener{Connection: conn}


### PR DESCRIPTION
## What

\`defaultDialer.defaultConn\` in \`pubsub/natspubsub/nats.go\` reads the \`NATS_SERVER_URL\` environment variable, a NATS URL that can embed userinfo credentials (\`nats://user:pass@host\`), and dials it lazily. When the dial fails, the error was built directly from the raw connection string:

\`\`\`go
conn, err := nats.Connect(serverURL)
if err != nil {
    o.err = fmt.Errorf("failed to dial NATS_SERVER_URL %q: %v", serverURL, err)
    return
}
\`\`\`

Any dial or parse failure (unreachable server, malformed port, auth failure, etc.) therefore returned an error containing the password verbatim, which typical callers pass straight into their normal logging path.

## Fix

Parse the connection string with \`net/url\` and use the standard library's \`url.URL.Redacted()\` method, which strips userinfo passwords and replaces them with \`xxxxx\`, when building the error message. If parsing itself fails, the connection-string detail is omitted from the error entirely instead of falling back to the raw value.

## Testing

- \`go build ./...\` and \`go vet ./...\` in \`pubsub/natspubsub\` pass.
- \`go test ./...\` in \`pubsub/natspubsub\` passes, same as before this change.
- Verified locally with a malformed \`NATS_SERVER_URL\` causing a synchronous dial failure: before the fix the error contained the plaintext password, after the fix the connection-string detail is omitted from the error (this particular malformed input also fails \`url.Parse\`, so per the fix no connection-string detail is included at all).