### PR TITLE
internal/escape: make HexEscape injective against pre-existing escape sequences

### DIFF
--- a/internal/escape/escape.go
+++ b/internal/escape/escape.go
@@ -58,7 +58,19 @@ func HexEscape(s string, shouldEscape func(s []rune, i int) bool) string {
 	runes := []rune(s)
 	var toEscape []int
 	for i := range runes {
-		if shouldEscape(runes, i) {
+		// In addition to whatever the caller wants escaped, always escape
+		// the start of any substring that HexUnescape would itself parse as
+		// an escape sequence (i.e., that looks like "__0x<hex>__"). Without
+		// this, a string need not contain any character the caller wants
+		// escaped to still produce output identical to some other,
+		// different string that does: e.g., a literal "__0x2f__" in the
+		// input is indistinguishable, after escaping, from a "/" that some
+		// other input had escaped into that same text. Two different
+		// preimages mapping to the same escaped string is a real
+		// correctness and security problem for callers that use the
+		// escaped string as a storage key or path, since it lets one
+		// caller-chosen key collide with another's.
+		if shouldEscape(runes, i) || isEscapeSequence(runes, i) {
 			toEscape = append(toEscape, i)
 		}
 	}
@@ -85,6 +97,14 @@ func HexEscape(s string, shouldEscape func(s []rune, i int) bool) string {
 		}
 	}
 	return string(escaped[0:j])
+}
+
+// isEscapeSequence reports whether the rune sequence starting at r[i] would
+// be parsed by HexUnescape as an escape sequence, regardless of whether it
+// was actually produced by a previous call to HexEscape.
+func isEscapeSequence(r []rune, i int) bool {
+	ok, _, _ := unescape(r, i)
+	return ok
 }
 
 // unescape tries to unescape starting at r[i].

--- a/internal/escape/escape_test.go
+++ b/internal/escape/escape_test.go
@@ -67,6 +67,42 @@ func TestHexEscape(t *testing.T) {
 	}
 }
 
+// TestHexEscapeInjective verifies that two different inputs never escape to
+// the same output for a given shouldEscape function, and that every escaped
+// string still unescapes back to its original input. Regression test: a
+// caller-supplied string that already contains the literal text of an
+// escape sequence (e.g. "__0x2f__") used to be indistinguishable, after
+// escaping, from a different string whose escaped rune produced that same
+// text (e.g. a "/" that shouldEscape flagged). Two callers choosing
+// different keys could therefore end up addressing the same escaped
+// storage key.
+func TestHexEscapeInjective(t *testing.T) {
+	// Mirrors the "escape a '/' right after '..'" rule used by
+	// blob/fileblob, blob/gcsblob, blob/s3blob, and blob/azureblob.
+	dotDotSlash := func(r []rune, i int) bool {
+		return i > 1 && r[i] == '/' && r[i-1] == '.' && r[i-2] == '.'
+	}
+
+	pairs := [][2]string{
+		{"a/../b", "a/..__0x2f__b"},
+		{"x/../y", "x/..__0x2f__y"},
+		{"../z", "..__0x2f__z"},
+	}
+	for _, p := range pairs {
+		e0 := HexEscape(p[0], dotDotSlash)
+		e1 := HexEscape(p[1], dotDotSlash)
+		if e0 == e1 {
+			t.Errorf("collision: HexEscape(%q) == HexEscape(%q) == %q", p[0], p[1], e0)
+		}
+		if got := HexUnescape(e0); got != p[0] {
+			t.Errorf("HexUnescape(HexEscape(%q)) = %q, want %q", p[0], got, p[0])
+		}
+		if got := HexUnescape(e1); got != p[1] {
+			t.Errorf("HexUnescape(HexEscape(%q)) = %q, want %q", p[1], got, p[1])
+		}
+	}
+}
+
 func TestHexEscapeUnescapeWeirdStrings(t *testing.T) {
 	for name, s := range WeirdStrings {
 		escaped := HexEscape(s, func(r []rune, i int) bool { return !IsASCIIAlphanumeric(r[i]) })


### PR DESCRIPTION
HexEscape only escaped the runes its shouldEscape callback flagged. A caller-supplied string that already contains the literal text of an escape sequence (for example `__0x2f__`) was indistinguishable, after escaping, from a different string whose escaped rune produced that same text (for example a `/` that shouldEscape flagged). Two different inputs could therefore map to the same escaped output.

This is reachable in blob/fileblob, blob/gcsblob, blob/s3blob, and blob/azureblob, all of which use HexEscape with a rule that escapes the `/` immediately after `..` into the literal text `__0x2f__` to stop path traversal. A key such as `a/..__0x2f__b` (no slash, no `..`, just an ordinary string) escapes to the exact same output as `a/../b`, so two different keys chosen by different callers address the same underlying object.

HexEscape now also escapes any position where the input already parses as a valid escape sequence, in addition to whatever the caller's shouldEscape flags. This keeps existing behavior unchanged for every input that does not itself contain what looks like an escape sequence, and makes HexEscape/HexUnescape injective for the rest.

Added `TestHexEscapeInjective` covering the case above.

Tests:
- `go test ./internal/escape/... -count=1`
- `go test ./blob/... -count=1`