### PR TITLE
postgres/gcppostgres: redact password from connection errors

### DIFF
--- a/postgres/gcppostgres/gcppostgres.go
+++ b/postgres/gcppostgres/gcppostgres.go
@@ -80,7 +80,7 @@ func (o *lazyCredsOpener) OpenPostgresURL(ctx context.Context, u *url.URL) (*sql
 		o.opener = &URLOpener{CertSource: certSource}
 	})
 	if o.err != nil {
-		return nil, fmt.Errorf("gcppostgres open %v: %v", u, o.err)
+		return nil, fmt.Errorf("gcppostgres open %v: %v", u.Redacted(), o.err)
 	}
 	return o.opener.OpenPostgresURL(ctx, u)
 }
@@ -103,7 +103,7 @@ func (uo *URLOpener) OpenPostgresURL(ctx context.Context, u *url.URL) (*sql.DB, 
 	}
 	instance, dbName, err := instanceFromURL(u)
 	if err != nil {
-		return nil, fmt.Errorf("gcppostgres: open %v: %v", u, err)
+		return nil, fmt.Errorf("gcppostgres: open %v: %v", u.Redacted(), err)
 	}
 
 	query := u.Query()

--- a/postgres/gcppostgres/gcppostgres_test.go
+++ b/postgres/gcppostgres/gcppostgres_test.go
@@ -16,8 +16,11 @@ package gcppostgres
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 
 	"gocloud.dev/internal/testing/terraform"
@@ -87,6 +90,36 @@ func TestURLOpener(t *testing.T) {
 				t.Error("Close:", err)
 			}
 		})
+	}
+}
+
+// stubCertSource is a minimal proxy.CertSource used only to reach
+// URLOpener.OpenPostgresURL's error paths without needing real GCP
+// credentials or network access.
+type stubCertSource struct{}
+
+func (stubCertSource) Local(instance string) (tls.Certificate, error) {
+	return tls.Certificate{}, fmt.Errorf("stub: not implemented")
+}
+
+func (stubCertSource) Remote(instance string) (cert *x509.Certificate, addr, name, version string, err error) {
+	return nil, "", "", "", fmt.Errorf("stub: not implemented")
+}
+
+func TestOpenPostgresURLDoesNotLeakPassword(t *testing.T) {
+	const password = "S3cr3tDBPassw0rd"
+	// Missing the dbname path segment, which fails instanceFromURL.
+	u, err := url.Parse(fmt.Sprintf("gcppostgres://dbuser:%s@myproject/us-central1/mydb", password))
+	if err != nil {
+		t.Fatalf("failed to parse URL: %v", err)
+	}
+	opener := &URLOpener{CertSource: stubCertSource{}}
+	_, err = opener.OpenPostgresURL(context.Background(), u)
+	if err == nil {
+		t.Fatal("OpenPostgresURL: got nil error, want error for malformed URL")
+	}
+	if strings.Contains(err.Error(), password) {
+		t.Errorf("OpenPostgresURL error contains the raw password: %q", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
OSS VRP Issue 541240334

Both error paths in gcppostgres.go format the raw *url.URL with %v:

- lazyCredsOpener.OpenPostgresURL, when Application Default Credentials fail to load
- URLOpener.OpenPostgresURL, when the instance path fails to parse

Since url.URL's default String() method includes the userinfo password in plain text, any password supplied in the gcppostgres:// URL ends up in the returned error in both cases.

This switches both call sites to url.URL.Redacted(), which masks the password with "xxxxx" while keeping the rest of the URL for debugging. Added a test covering the malformed-path case.

go test ./postgres/... passes.