### PR TITLE
mysql/gcpmysql: redact password from connection error

### DIFF
--- a/mysql/gcpmysql/gcpmysql.go
+++ b/mysql/gcpmysql/gcpmysql.go
@@ -77,7 +77,7 @@ func (o *lazyCredsOpener) OpenMySQLURL(ctx context.Context, u *url.URL) (*sql.DB
 		o.opener = &URLOpener{CertSource: certSource}
 	})
 	if o.err != nil {
-		return nil, fmt.Errorf("gcpmysql open %v: %v", u, o.err)
+		return nil, fmt.Errorf("gcpmysql open %v: %v", u.Redacted(), o.err)
 	}
 	return o.opener.OpenMySQLURL(ctx, u)
 }

--- a/mysql/gcpmysql/gcpmysql_test.go
+++ b/mysql/gcpmysql/gcpmysql_test.go
@@ -19,12 +19,29 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	drvr "github.com/go-sql-driver/mysql"
 	"gocloud.dev/internal/testing/terraform"
 	"gocloud.dev/mysql"
 )
+
+func TestOpenMySQLURLDoesNotLeakPasswordOnCredentialsFailure(t *testing.T) {
+	const password = "S3cr3tDBPassw0rd"
+	u, err := url.Parse(fmt.Sprintf("gcpmysql://dbuser:%s@myproject/us-central1/myinstance/mydb", password))
+	if err != nil {
+		t.Fatalf("failed to parse URL: %v", err)
+	}
+	o := new(lazyCredsOpener)
+	_, err = o.OpenMySQLURL(context.Background(), u)
+	if err == nil {
+		t.Skip("Application Default Credentials are available in this environment; skipping negative-path test")
+	}
+	if strings.Contains(err.Error(), password) {
+		t.Errorf("OpenMySQLURL error contains the raw password: %q", err.Error())
+	}
+}
 
 func TestOpen(t *testing.T) {
 	// This test will be skipped unless the project is set up with Terraform.


### PR DESCRIPTION
lazyCredsOpener.OpenMySQLURL formats the raw *url.URL with %v when Application Default Credentials fail to load:

https://github.com/google/go-cloud/blob/master/mysql/gcpmysql/gcpmysql.go#L80

url.URL's default String() method includes the userinfo password in plain text, so any password supplied in the gcpmysql:// URL ends up in the returned error.

This switches the call site to url.URL.Redacted(), which masks the password with "xxxxx" while keeping the rest of the URL for debugging. Same fix as the companion PR for postgres/gcppostgres (#3752). Added a test for the negative-credentials path.

go test ./mysql/... passes.