### PR TITLE
docstore/awsdynamodb: fix panic on empty in/not-in filter value

### DIFF
--- a/docstore/awsdynamodb/v2/query.go
+++ b/docstore/awsdynamodb/v2/query.go
@@ -451,6 +451,14 @@ func toFilter(f driver.Filter) expression.ConditionBuilder {
 func toInCondition(f driver.Filter) expression.ConditionBuilder {
 	name := expression.Name(strings.Join(f.FieldPath, "."))
 	vslice := reflect.ValueOf(f.Value)
+	if vslice.Len() == 0 {
+		// An empty "in" list can never match anything; build an
+		// always-false condition instead of indexing into the empty
+		// slice below. expression.Not of this gives an always-true
+		// condition for "not-in", matching the usual "x IN ()" / "x
+		// NOT IN ()" semantics used elsewhere (e.g., MongoDB's $in/$nin).
+		return expression.Equal(expression.Value(true), expression.Value(false))
+	}
 	right := expression.Value(vslice.Index(0).Interface())
 	other := make([]expression.OperandBuilder, vslice.Len()-1)
 	for i := 1; i < vslice.Len(); i++ {

--- a/docstore/awsdynamodb/v2/query_test.go
+++ b/docstore/awsdynamodb/v2/query_test.go
@@ -413,6 +413,29 @@ func TestQueryNoScans(t *testing.T) {
 	}
 }
 
+// planQuery must not panic on an empty "in"/"not-in" filter value.
+// docstore's own Where() validator (validFilterSlice) accepts an empty
+// slice as valid, so toInCondition must handle a zero-length slice rather
+// than indexing into it unconditionally.
+func TestEmptyInFilterDoesNotPanic(t *testing.T) {
+	c := &collection{
+		table:        "T",
+		partitionKey: "tableP",
+		description:  &dyn2Types.TableDescription{},
+		opts:         &Options{},
+	}
+	for _, op := range []string{"in", "not-in"} {
+		q := &driver.Query{
+			Filters: []driver.Filter{
+				{FieldPath: []string{"category"}, Op: op, Value: []string{}},
+			},
+		}
+		if _, err := c.planQuery(q); err != nil {
+			t.Errorf("op %q: planQuery returned error: %v", op, err)
+		}
+	}
+}
+
 // Make a key schema from the names of the partition and sort keys.
 func keySchema(pkey, skey string) []dyn2Types.KeySchemaElement {
 	return []dyn2Types.KeySchemaElement{


### PR DESCRIPTION
toInCondition unconditionally does vslice.Index(0) on the filter value:

https://github.com/google/go-cloud/blob/master/docstore/awsdynamodb/v2/query.go#L449

docstore's own Where() validator (validFilterSlice, in docstore/query.go) accepts an empty slice as a valid value for the in/not-in operators, since its bounds-check loop never executes for a zero-length slice. A query built with an empty slice, e.g. Where("category", "in", []string{}), reaches toInCondition with a zero-length slice and panics with "reflect: slice index out of range" during query planning, before any network call, with nothing in docstore or this package recovering it.

This handles the zero-length case by building an always-false condition instead of indexing into the empty slice. Not() of that gives an always-true condition for not-in, matching the usual "x IN ()" / "x NOT IN ()" semantics (consistent with how mongodocstore's $in/$nin already treats an empty list).

Added a regression test. go test ./docstore/... passes.