### PR TITLE
blob/all: add a BeforeDelete hook for conditional deletes

### DIFF
--- a/blob/azureblob/azureblob.go
+++ b/blob/azureblob/azureblob.go
@@ -84,6 +84,7 @@
 //   - Reader.BeforeRead: *azblob.DownloadStreamOptions
 //   - Attributes: azblobblob.GetPropertiesResponse
 //   - CopyOptions.BeforeCopy: *azblobblob.StartCopyFromURLOptions
+//   - DeleteOptions.BeforeDelete: *azblobblob.DeleteOptions
 //   - WriterOptions.BeforeWrite: *azblob.UploadStreamOptions
 //   - SignedURLOptions.BeforeSign: *sas.BlobPermissions
 package azureblob
@@ -570,10 +571,23 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 }
 
 // Delete implements driver.Delete.
-func (b *bucket) Delete(ctx context.Context, key string) error {
+func (b *bucket) Delete(ctx context.Context, key string, opts *driver.DeleteOptions) error {
 	key = escapeKey(key, false)
 	blobClient := b.client.NewBlobClient(key)
-	_, err := blobClient.Delete(ctx, nil)
+	azOpts := &azblobblob.DeleteOptions{}
+	if opts.BeforeDelete != nil {
+		asFunc := func(i any) bool {
+			if p, ok := i.(**azblobblob.DeleteOptions); ok {
+				*p = azOpts
+				return true
+			}
+			return false
+		}
+		if err := opts.BeforeDelete(asFunc); err != nil {
+			return err
+		}
+	}
+	_, err := blobClient.Delete(ctx, azOpts)
 	return err
 }
 

--- a/blob/azureblob/azureblob_test.go
+++ b/blob/azureblob/azureblob_test.go
@@ -213,6 +213,14 @@ func (verifyContentLanguage) BeforeCopy(as func(any) bool) error {
 	return nil
 }
 
+func (verifyContentLanguage) BeforeDelete(as func(any) bool) error {
+	var azOpts *azblobblob.DeleteOptions
+	if !as(&azOpts) {
+		return errors.New("BeforeDelete.As failed")
+	}
+	return nil
+}
+
 func (verifyContentLanguage) BeforeList(as func(any) bool) error {
 	var azOpts *container.ListBlobsHierarchyOptions
 	if !as(&azOpts) {

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -1275,9 +1275,34 @@ func (b *Bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *CopyOpti
 //
 // If the blob does not exist, Delete returns an error for which
 // gcerrors.Code will return gcerrors.NotFound.
-func (b *Bucket) Delete(ctx context.Context, key string) (err error) {
+func (b *Bucket) Delete(ctx context.Context, key string) error {
+	return b.DeleteWithOptions(ctx, key, nil)
+}
+
+// DeleteOptions sets options for DeleteWithOptions.
+type DeleteOptions struct {
+	// BeforeDelete is a callback that will be called before the delete is
+	// initiated. It can be used to apply a driver-specific precondition
+	// (for example a generation or If-Match condition) so the delete is
+	// refused if the blob has changed.
+	//
+	// asFunc converts its argument to driver-specific types.
+	// See https://gocloud.dev/concepts/as/ for background information.
+	BeforeDelete func(asFunc func(any) bool) error
+}
+
+// DeleteWithOptions deletes the blob stored at key, like Delete, with
+// options to configure the delete.
+// A nil DeleteOptions is treated the same as the zero value.
+//
+// If the blob does not exist, DeleteWithOptions returns an error for which
+// gcerrors.Code will return gcerrors.NotFound.
+func (b *Bucket) DeleteWithOptions(ctx context.Context, key string, opts *DeleteOptions) (err error) {
 	if !utf8.ValidString(key) {
 		return gcerr.Newf(gcerr.InvalidArgument, nil, "blob: Delete key must be a valid UTF-8 string: %q", key)
+	}
+	if opts == nil {
+		opts = &DeleteOptions{}
 	}
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -1286,7 +1311,8 @@ func (b *Bucket) Delete(ctx context.Context, key string) (err error) {
 	}
 	ctx, span := b.tracer.Start(ctx, "Delete")
 	defer func() { b.tracer.End(ctx, span, err) }()
-	return wrapError(b.b, b.b.Delete(ctx, key), key)
+	dopts := &driver.DeleteOptions{BeforeDelete: opts.BeforeDelete}
+	return wrapError(b.b, b.b.Delete(ctx, key, dopts), key)
 }
 
 // SignedURL returns a URL that can be used to GET (default), PUT or DELETE

--- a/blob/blob_test.go
+++ b/blob/blob_test.go
@@ -400,7 +400,7 @@ func (b *erroringBucket) Copy(ctx context.Context, dstKey, srcKey string, opts *
 	return errFake
 }
 
-func (b *erroringBucket) Delete(ctx context.Context, key string) error {
+func (b *erroringBucket) Delete(ctx context.Context, key string, opts *driver.DeleteOptions) error {
 	return errFake
 }
 
@@ -488,6 +488,8 @@ func TestErrorsAreWrapped(t *testing.T) {
 
 	err = b.Delete(ctx, "")
 	verifyWrap("Delete", err)
+	err = b.DeleteWithOptions(ctx, "", nil)
+	verifyWrap("DeleteWithOptions", err)
 
 	_, err = b.SignedURL(ctx, "", nil)
 	verifyWrap("SignedURL", err)
@@ -532,6 +534,9 @@ func TestBucketIsClosed(t *testing.T) {
 		t.Error(err)
 	}
 	if err := bucket.Delete(ctx, ""); err != errClosed {
+		t.Error(err)
+	}
+	if err := bucket.DeleteWithOptions(ctx, "", nil); err != errClosed {
 		t.Error(err)
 	}
 	if _, err := bucket.SignedURL(ctx, "", nil); err != errClosed {

--- a/blob/driver/driver.go
+++ b/blob/driver/driver.go
@@ -125,6 +125,18 @@ type CopyOptions struct {
 	BeforeCopy func(asFunc func(any) bool) error
 }
 
+// DeleteOptions controls options for Delete.
+type DeleteOptions struct {
+	// BeforeDelete is a callback that must be called exactly once before
+	// deleting, and may be used to apply a driver-specific precondition to the
+	// delete (for example a generation/version/ETag match, so the delete is
+	// refused if the object changed since it was observed). It is nil if the
+	// caller passed no hook.
+	// asFunc allows drivers to expose driver-specific types;
+	// see Bucket.As for more details.
+	BeforeDelete func(asFunc func(any) bool) error
+}
+
 // ReaderAttributes contains a subset of attributes about a blob that are
 // accessible from Reader.
 type ReaderAttributes struct {
@@ -325,7 +337,8 @@ type Bucket interface {
 	// Delete deletes the object associated with key. If the specified object does
 	// not exist, Delete must return an error for which ErrorCode returns
 	// gcerrors.NotFound.
-	Delete(ctx context.Context, key string) error
+	// opts is guaranteed to be non-nil.
+	Delete(ctx context.Context, key string, opts *DeleteOptions) error
 
 	// SignedURL returns a URL that can be used to GET the blob for the duration
 	// specified in opts.Expiry. opts is guaranteed to be non-nil.
@@ -426,8 +439,8 @@ func (b *prefixedBucket) Copy(ctx context.Context, dstKey, srcKey string, opts *
 	return b.base.Copy(ctx, b.prefix+dstKey, b.prefix+srcKey, opts)
 }
 
-func (b *prefixedBucket) Delete(ctx context.Context, key string) error {
-	return b.base.Delete(ctx, b.prefix+key)
+func (b *prefixedBucket) Delete(ctx context.Context, key string, opts *DeleteOptions) error {
+	return b.base.Delete(ctx, b.prefix+key, opts)
 }
 
 func (b *prefixedBucket) SignedURL(ctx context.Context, key string, opts *SignedURLOptions) (string, error) {
@@ -469,8 +482,8 @@ func (b *singleKeyBucket) Copy(ctx context.Context, dstKey, _ string, opts *Copy
 	return b.base.Copy(ctx, dstKey, b.key, opts)
 }
 
-func (b *singleKeyBucket) Delete(ctx context.Context, _ string) error {
-	return b.base.Delete(ctx, b.key)
+func (b *singleKeyBucket) Delete(ctx context.Context, _ string, opts *DeleteOptions) error {
+	return b.base.Delete(ctx, b.key, opts)
 }
 
 func (b *singleKeyBucket) SignedURL(ctx context.Context, _ string, opts *SignedURLOptions) (string, error) {

--- a/blob/drivertest/drivertest.go
+++ b/blob/drivertest/drivertest.go
@@ -109,6 +109,9 @@ type AsTest interface {
 	// BeforeCopy will be passed directly to CopyOptions as part of copying
 	// the test blob.
 	BeforeCopy(as func(any) bool) error
+	// BeforeDelete will be passed directly to DeleteOptions as part of
+	// deleting the test blob.
+	BeforeDelete(as func(any) bool) error
 	// BeforeList will be passed directly to ListOptions as part of listing the
 	// test blob.
 	BeforeList(as func(any) bool) error
@@ -187,6 +190,13 @@ func (verifyAsFailsOnNil) BeforeWrite(as func(any) bool) error {
 func (verifyAsFailsOnNil) BeforeCopy(as func(any) bool) error {
 	if as(nil) {
 		return errors.New("want BeforeCopy's As to return false when passed nil")
+	}
+	return nil
+}
+
+func (verifyAsFailsOnNil) BeforeDelete(as func(any) bool) error {
+	if as(nil) {
+		return errors.New("want BeforeDelete's As to return false when passed nil")
 	}
 	return nil
 }
@@ -2161,6 +2171,54 @@ func testDelete(t *testing.T, newHarness HarnessMaker) {
 			t.Errorf("got %v want error to include missing key", err)
 		}
 	})
+
+	t.Run("BeforeDelete", func(t *testing.T) {
+		h, err := newHarness(ctx, t)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer h.Close()
+		drv, err := h.MakeDriver(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b := blob.NewBucket(drv)
+		defer closeWithErrorCheck(t, b)
+
+		if err := b.WriteAll(ctx, key, []byte("Hello world"), nil); err != nil {
+			t.Fatal(err)
+		}
+
+		// BeforeDelete must be called exactly once for a successful delete.
+		calls := 0
+		if err := b.DeleteWithOptions(ctx, key, &blob.DeleteOptions{
+			BeforeDelete: func(func(any) bool) error { calls++; return nil },
+		}); err != nil {
+			t.Errorf("DeleteWithOptions got unexpected error: %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("BeforeDelete called %d times, want 1", calls)
+		}
+
+		// An error returned from BeforeDelete aborts the delete and propagates.
+		if err := b.WriteAll(ctx, key, []byte("Hello world"), nil); err != nil {
+			t.Fatal(err)
+		}
+		wantErr := errors.New("BeforeDelete failed")
+		err = b.DeleteWithOptions(ctx, key, &blob.DeleteOptions{
+			BeforeDelete: func(func(any) bool) error { return wantErr },
+		})
+		if !errors.Is(err, wantErr) {
+			t.Errorf("DeleteWithOptions with failing BeforeDelete got %v, want %v", err, wantErr)
+		}
+		// The blob must still exist since the delete was aborted.
+		if exists, err := b.Exists(ctx, key); err != nil {
+			t.Errorf("Exists after aborted delete got error: %v", err)
+		} else if !exists {
+			t.Errorf("blob should still exist after an aborted delete")
+		}
+		deleteWithErrorCheck(ctx, t, b, key)
+	})
 }
 
 // testConcurrentWriteAndRead tests that concurrent writing to multiple blob
@@ -2725,11 +2783,12 @@ func testAs(t *testing.T, newHarness HarnessMaker, st AsTest) {
 		t.Error(err)
 	}
 
-	// Copy the blob, using the provided callback.
+	// Copy the blob, using the provided callback, then delete the copy,
+	// using the provided callback.
 	if err := b.Copy(ctx, copyKey, key, &blob.CopyOptions{BeforeCopy: st.BeforeCopy}); err != nil {
 		t.Error(err)
-	} else {
-		defer deleteWithErrorCheck(ctx, t, b, copyKey)
+	} else if err := b.DeleteWithOptions(ctx, copyKey, &blob.DeleteOptions{BeforeDelete: st.BeforeDelete}); err != nil {
+		t.Error(err)
 	}
 
 	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodDelete} {

--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -960,7 +960,14 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 }
 
 // Delete implements driver.Delete.
-func (b *bucket) Delete(ctx context.Context, key string) error {
+func (b *bucket) Delete(ctx context.Context, key string, opts *driver.DeleteOptions) error {
+	if opts.BeforeDelete != nil {
+		// fileblob exposes no driver-specific delete type; the hook is still
+		// invoked exactly once so portable callers behave consistently.
+		if err := opts.BeforeDelete(func(any) bool { return false }); err != nil {
+			return err
+		}
+	}
 	path, err := b.path(key)
 	if err != nil {
 		return err

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -392,8 +392,9 @@ func (verifyAs) BeforeCopy(as func(any) bool) error {
 	}
 	return nil
 }
-func (verifyAs) BeforeList(as func(any) bool) error { return nil }
-func (verifyAs) BeforeSign(as func(any) bool) error { return nil }
+func (verifyAs) BeforeDelete(as func(any) bool) error { return nil }
+func (verifyAs) BeforeList(as func(any) bool) error   { return nil }
+func (verifyAs) BeforeSign(as func(any) bool) error   { return nil }
 func (verifyAs) AttributesCheck(attrs *blob.Attributes) error {
 	var fi os.FileInfo
 	if !attrs.As(&fi) {

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -51,6 +51,7 @@
 //   - ListOptions.BeforeList: *storage.Query
 //   - Reader: *storage.Reader
 //   - ReaderOptions.BeforeRead: **storage.ObjectHandle, *storage.Reader (if accessing both, must be in that order)
+//   - DeleteOptions.BeforeDelete: **storage.ObjectHandle
 //   - Attributes: storage.ObjectAttrs
 //   - CopyOptions.BeforeCopy: *CopyObjectHandles, *storage.Copier (if accessing both, must be in that order)
 //   - WriterOptions.BeforeWrite: **storage.ObjectHandle, *storage.Writer (if accessing both, must be in that order)
@@ -751,11 +752,27 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 }
 
 // Delete implements driver.Delete.
-func (b *bucket) Delete(ctx context.Context, key string) error {
+func (b *bucket) Delete(ctx context.Context, key string, opts *driver.DeleteOptions) error {
 	key = escapeKey(key)
 	bkt := b.client.Bucket(b.name)
 	obj := bkt.Object(key)
-	return obj.Delete(ctx)
+
+	// Extra level of indirection so BeforeDelete can replace obj if needed;
+	// e.g. ObjectHandle.If returns a new ObjectHandle to apply a precondition.
+	objp := &obj
+	if opts.BeforeDelete != nil {
+		asFunc := func(i any) bool {
+			if p, ok := i.(***storage.ObjectHandle); ok {
+				*p = objp
+				return true
+			}
+			return false
+		}
+		if err := opts.BeforeDelete(asFunc); err != nil {
+			return err
+		}
+	}
+	return (*objp).Delete(ctx)
 }
 
 func (b *bucket) SignedURL(ctx context.Context, key string, dopts *driver.SignedURLOptions) (string, error) {

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -200,6 +200,14 @@ func (verifyContentLanguage) BeforeCopy(as func(any) bool) error {
 	return nil
 }
 
+func (verifyContentLanguage) BeforeDelete(as func(any) bool) error {
+	var objp **storage.ObjectHandle
+	if !as(&objp) {
+		return errors.New("BeforeDelete.As failed to get ObjectHandle")
+	}
+	return nil
+}
+
 func (verifyContentLanguage) BeforeList(as func(any) bool) error {
 	var q *storage.Query
 	if !as(&q) {

--- a/blob/memblob/memblob.go
+++ b/blob/memblob/memblob.go
@@ -428,7 +428,13 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 }
 
 // Delete implements driver.Delete.
-func (b *bucket) Delete(ctx context.Context, key string) error {
+func (b *bucket) Delete(ctx context.Context, key string, opts *driver.DeleteOptions) error {
+	if opts.BeforeDelete != nil {
+		if err := opts.BeforeDelete(func(any) bool { return false }); err != nil {
+			return err
+		}
+	}
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/blob/s3blob/s3blob.go
+++ b/blob/s3blob/s3blob.go
@@ -49,6 +49,7 @@
 //   - ReaderOptions.BeforeRead: *s3.GetObjectInput or *[]func(*s3.Options)
 //   - Attributes: s3.HeadObjectOutput
 //   - CopyOptions.BeforeCopy: s3.CopyObjectInput
+//   - DeleteOptions.BeforeDelete: *s3.DeleteObjectInput
 //   - WriterOptions.BeforeWrite: *transfermanager.UploadObjectInput, *transfermanager.Client
 //   - SignedURLOptions.BeforeSign: *s3.GetObjectInput, when Options.Method == http.MethodGet, or
 //       *s3.PutObjectInput, when Options.Method == http.MethodPut
@@ -861,7 +862,11 @@ func (b *bucket) Copy(ctx context.Context, dstKey, srcKey string, opts *driver.C
 }
 
 // Delete implements driver.Delete.
-func (b *bucket) Delete(ctx context.Context, key string) error {
+func (b *bucket) Delete(ctx context.Context, key string, opts *driver.DeleteOptions) error {
+	// S3 DeleteObject succeeds even if the key doesn't exist, so we check
+	// existence first to return NotFound. This happens before BeforeDelete,
+	// so it always checks the current object, even if the callback sets a
+	// VersionId on the DeleteObjectInput.
 	if _, err := b.Attributes(ctx, key); err != nil {
 		return err
 	}
@@ -869,6 +874,18 @@ func (b *bucket) Delete(ctx context.Context, key string) error {
 	input := &s3.DeleteObjectInput{
 		Bucket: aws.String(b.name),
 		Key:    aws.String(key),
+	}
+	if opts.BeforeDelete != nil {
+		asFunc := func(i any) bool {
+			if p, ok := i.(**s3.DeleteObjectInput); ok {
+				*p = input
+				return true
+			}
+			return false
+		}
+		if err := opts.BeforeDelete(asFunc); err != nil {
+			return err
+		}
 	}
 	_, err := b.client.DeleteObject(ctx, input)
 	return err

--- a/blob/s3blob/s3blob_test.go
+++ b/blob/s3blob/s3blob_test.go
@@ -171,6 +171,14 @@ func (v verifyContentLanguage) BeforeCopy(as func(any) bool) error {
 	return nil
 }
 
+func (v verifyContentLanguage) BeforeDelete(as func(any) bool) error {
+	var in *s3.DeleteObjectInput
+	if !as(&in) {
+		return errors.New("BeforeDelete.As failed")
+	}
+	return nil
+}
+
 func (v verifyContentLanguage) BeforeList(as func(any) bool) error {
 	if v.usingLegacyList {
 		var req *s3.ListObjectsInput


### PR DESCRIPTION
Add a `DeleteOptions.BeforeDelete` callback, mirroring the existing `BeforeRead`/`BeforeCopy` escape hatches, so callers can apply a provider-specific precondition to a delete (e.g. GCS `IfGenerationMatch`, S3 `If-Match`/`versionId`, Azure `If-Match`). This enables race-free "delete only if unchanged" without dropping down to the provider SDK.

Follows the escape-hatch precedent of #1851 (`BeforeRead`) and addresses the conditional-mutation need discussed in #3518.

## API changes

**Portable API (backward compatible):**
- New `blob.DeleteOptions` with a `BeforeDelete func(asFunc func(any) bool) error` field.
- New `Bucket.DeleteWithOptions(ctx, key, opts)`. The existing `Bucket.Delete` is unchanged and now delegates to it (nil options).

**Driver API (breaking for out-of-tree drivers):**
- `driver.Bucket.Delete` now takes a `*driver.DeleteOptions` parameter. External implementations of `driver.Bucket` will need to add the parameter; drivers with nothing useful to expose can ignore it (see fileblob/memblob, which invoke the hook once with a no-op `asFunc`).
- `drivertest.AsTest` has a new `BeforeDelete` method, so external users of the conformance tests will need to implement it.

## Types exposed via As, per driver

| Driver | `BeforeDelete` asFunc type | Example use |
|---|---|---|
| gcsblob | `**storage.ObjectHandle` | swap in the handle returned by `ObjectHandle.If(storage.Conditions{GenerationMatch: ...})` |
| s3blob | `*s3.DeleteObjectInput` | set `IfMatch` / `VersionId` |
| azureblob | `*azblobblob.DeleteOptions` | set `AccessConditions` (e.g. If-Match) |
| fileblob, memblob | none | hook is invoked once; `asFunc` always returns false |

Package doc "As" sections are updated accordingly.

Note on s3blob: `Delete` keeps its existing `Attributes` pre-check (S3 `DeleteObject` succeeds on nonexistent keys, so the check provides the portable NotFound semantics). It runs before `BeforeDelete`, so it always checks the current object even if the callback targets a specific `VersionId`; there's a code comment documenting this.

## Testing

- New drivertest conformance subtest `TestDelete/BeforeDelete`: the hook is called exactly once; an error returned from the hook aborts the delete, propagates through the portable wrapper (`errors.Is`), and the blob survives.
- `AsTest.BeforeDelete` is exercised in `TestAs` (the copied test blob is deleted via `DeleteWithOptions`), so each driver's documented As type is verified, including the nil-safety check in `verifyAsFailsOnNil`.
- `DeleteWithOptions` added to `TestErrorsAreWrapped` and `TestBucketIsClosed` in the portable-type tests.
- Verified locally: `go build`/`go vet ./blob/...` clean; `blob`, `memblob`, `fileblob`, and `azureblob` tests pass. gcsblob/s3blob `TestAs` passes against the **existing** replay recordings (the hook doesn't alter the outgoing request).
- Per CONTRIBUTING.md, this PR is sent without new replay files: the `TestDelete/BeforeDelete` golden files for gcsblob/s3blob need to be regenerated with `-record` against real accounts. The azureblob conformance tests are currently disabled upstream.

Let me also know if you prefer to discuss this through an Issue first.

Disclaimer: The code is generated with the help of Claude Fable & Opus 4.8