### PR TITLE
blob/gcsblob: return Unimplemented for EnforceAbsentContentType in SignedURL

### DIFF
--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -789,6 +789,9 @@ func (b *bucket) SignedURL(ctx context.Context, key string, dopts *driver.Signed
 	if b.opts.GoogleAccessID == "" || numSigners != 1 {
 		return "", gcerr.New(gcerr.Unimplemented, nil, 1, "gcsblob: to use SignedURL, you must call OpenBucket with a valid Options.GoogleAccessID and exactly one of Options.PrivateKey, Options.SignBytes, or Options.MakeSignBytes")
 	}
+	if dopts.EnforceAbsentContentType {
+		return "", gcerr.New(gcerr.Unimplemented, nil, 1, "gcsblob: does not support enforcing an absent Content-Type on PUT")
+	}
 
 	key = escapeKey(key)
 	opts := &storage.SignedURLOptions{


### PR DESCRIPTION
driver.SignedURLOptions documents that a backend which cannot enforce an absent Content-Type on a signed PUT URL must return Unimplemented. s3blob and azureblob both do this. gcsblob had no check at all and silently returned a working signed URL that does not enforce it, since the GCS SDK's SignedURLOptions has no field for forbidding a header's presence.

Added the same check gcsblob's siblings already have, right after the existing signer-validation check in SignedURL.