### PR TITLE
docstore/awsdynamodb: don't panic on in/not-in filter over a key field

### DIFF
--- a/docstore/awsdynamodb/v2/query.go
+++ b/docstore/awsdynamodb/v2/query.go
@@ -419,7 +419,12 @@ func toKeyCondition(f driver.Filter, pkey, skey string) (expression.KeyCondition
 		case ">":
 			return expression.KeyGreaterThan(key, val), true
 		default:
-			panic(fmt.Sprint("invalid filter operation:", f.Op))
+			// Ops such as "in"/"not-in" are valid docstore filters (Where()
+			// accepts them on any field) but cannot form a DynamoDB
+			// KeyConditionExpression. Report "not a key condition" so the
+			// filter is routed to the FilterExpression path instead of
+			// panicking and crashing the process.
+			return expression.KeyConditionBuilder{}, false
 		}
 	}
 	return expression.KeyConditionBuilder{}, false

--- a/docstore/awsdynamodb/v2/query_test.go
+++ b/docstore/awsdynamodb/v2/query_test.go
@@ -704,3 +704,43 @@ func Test_documentIterator_Next(t *testing.T) {
 		})
 	}
 }
+
+// Regression test: docstore's Where() accepts "in"/"not-in" on any field,
+// including a table's key fields. bestQueryable can then pick a Query plan
+// while a key-field filter uses one of those ops, reaching toKeyCondition with
+// an op it cannot express as a KeyCondition. That path must not panic (an
+// unrecovered panic there crashes the calling process); the filter should be
+// handled as a regular FilterExpression instead. Covers the op on both the
+// partition key and the sort key.
+func TestKeyFilterWithInOpDoesNotPanic(t *testing.T) {
+	c := &collection{
+		table:        "T",
+		partitionKey: "pk",
+		sortKey:      "sk",
+		description:  &dyn2Types.TableDescription{},
+		opts:         &Options{AllowScans: true},
+	}
+	for _, op := range []string{"in", "not-in"} {
+		for _, keyField := range []string{"pk", "sk"} {
+			// An "=" on the partition key is always present so bestQueryable
+			// selects a Query plan (reaching toKeyCondition); the in/not-in
+			// filter targets a key field on top of that.
+			q := &driver.Query{
+				Filters: []driver.Filter{
+					{FieldPath: []string{"pk"}, Op: driver.EqualOp, Value: "x"},
+					{FieldPath: []string{keyField}, Op: op, Value: []string{"a", "b"}},
+				},
+			}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("op %q on %q: planQuery panicked: %v", op, keyField, r)
+					}
+				}()
+				// Only assert on the absence of a panic; whether the plan
+				// returns nil or a graceful error is not the contract here.
+				_, _ = c.planQuery(q)
+			}()
+		}
+	}
+}


### PR DESCRIPTION
`toKeyCondition` panics in its default case when a filter on the partition or sort key uses an operator it cannot express as a DynamoDB KeyCondition. docstore's own `Where()` accepts `in`/`not-in` on any field, and `bestQueryable` selects a Query plan using an op-agnostic `hasFilter` check on the sort key, so a valid user query such as `Where("pk", "=", x).Where("sk", "in", vals)` reaches that path. Nothing in the package recovers the panic, so it crashes the calling process during pure-Go query planning, before any network I/O.

This returns `false` from that case instead, routing the filter to the FilterExpression path rather than panicking. Same class as the empty-`in`-slice fix in #3754, different code path (`toKeyCondition` vs `toInCondition`). Added a regression test covering `in` and `not-in` on a key field.