### PR TITLE
mysql: don't enable cleartext passwords on unverified connections

### DIFF
--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -79,7 +79,13 @@ func ConfigFromURL(u *url.URL) (cfg *mysql.Config, err error) {
 	cfg.Passwd, _ = u.User.Password()
 	cfg.DBName = dbName
 	if _, ok := u.Query()["allowCleartextPasswords"]; !ok {
-		cfg.AllowCleartextPasswords = true
+		// The cleartext auth plugin hands the password to whatever answers on
+		// the database address, so it is only safe once the server's identity
+		// has been verified. Enable it by default only when the connection is
+		// TLS-protected with certificate verification and no plaintext
+		// fallback; otherwise applications must opt in explicitly with
+		// "allowCleartextPasswords=true".
+		cfg.AllowCleartextPasswords = cfg.TLS != nil && !cfg.TLS.InsecureSkipVerify && !cfg.AllowFallbackToPlaintext
 	}
 	cfg.AllowNativePasswords = true
 	return cfg, nil

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -99,9 +99,24 @@ func TestConfigFromURLCleartextPasswords(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "default",
+			name: "default, no TLS",
 			url:  "mysql://user:password@localhost/db",
+			want: false,
+		},
+		{
+			name: "default, TLS with verification",
+			url:  "mysql://user:password@localhost/db?tls=true",
 			want: true,
+		},
+		{
+			name: "default, TLS without verification",
+			url:  "mysql://user:password@localhost/db?tls=skip-verify",
+			want: false,
+		},
+		{
+			name: "default, TLS with plaintext fallback",
+			url:  "mysql://user:password@localhost/db?tls=preferred",
+			want: false,
 		},
 		{
 			name: "explicit false",
@@ -111,6 +126,11 @@ func TestConfigFromURLCleartextPasswords(t *testing.T) {
 		{
 			name: "explicit true",
 			url:  "mysql://user:password@localhost/db?allowCleartextPasswords=true",
+			want: true,
+		},
+		{
+			name: "explicit true without TLS",
+			url:  "mysql://user:password@localhost/db?allowCleartextPasswords=true&tls=false",
 			want: true,
 		},
 	} {

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -104,6 +104,11 @@ func TestConfigFromURLCleartextPasswords(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "default, no TLS, other query params present",
+			url:  "mysql://user:password@localhost/db?timeout=5s",
+			want: false,
+		},
+		{
 			name: "default, TLS with verification",
 			url:  "mysql://user:password@localhost/db?tls=true",
 			want: true,


### PR DESCRIPTION
`ConfigFromURL` turns on `AllowCleartextPasswords` for every `mysql://` URL and configures no TLS, so a plain `mysql://user:pw@host/db` connects in the clear with the cleartext auth plugin permitted. Anything that can answer on the database address (a MITM, DNS/ARP spoofing, a rogue pod, a compromised server) can reply to the handshake with an auth switch to `mysql_clear_password` and read the password straight off the wire; with the plugin refused, the password is only ever sent as a challenge-response scramble or RSA-encrypted.

This enables the plugin by default only when the connection is TLS-protected with certificate verification and no plaintext fallback, so `tls=skip-verify` and `tls=preferred` don't qualify. The `allowCleartextPasswords` parameter added in #3738 still forces it on for servers that require PAM/LDAP auth, and awsmysql sets the field itself after calling `ConfigFromURL`, so IAM auth is unaffected.

Verified against a local server that sends the auth switch: before, it receives the password verbatim; after, the driver refuses with "this user requires clear text authentication".