### PR TITLE
pubsub/awssnssqs: verify SNS envelope shape before trusting it

### DIFF
--- a/pubsub/awssnssqs/awssnssqs.go
+++ b/pubsub/awssnssqs/awssnssqs.go
@@ -198,6 +198,8 @@ const SQSScheme = "awssqs"
 //
 //   - raw (for "awssqs" Subscriptions only): sets SubscriberOptions.Raw. The
 //     value must be parseable by `strconv.ParseBool`.
+//   - snstopicarn (for "awssqs" Subscriptions only): sets
+//     SubscriberOptions.SNSTopicARN.
 //   - nacklazy (for "awssqs" Subscriptions only): sets SubscriberOptions.NackLazy. The
 //     value must be parseable by `strconv.ParseBool`.
 //   - waittime: sets SubscriberOptions.WaitTime, in time.ParseDuration formats.
@@ -241,6 +243,10 @@ func (o *URLOpener) OpenSubscriptionURL(ctx context.Context, u *url.URL) (*pubsu
 			return nil, fmt.Errorf("invalid value %q for raw: %v", rawStr, err)
 		}
 		q.Del("raw")
+	}
+	if arn := q.Get("snstopicarn"); arn != "" {
+		opts.SNSTopicARN = arn
+		q.Del("snstopicarn")
 	}
 	if nackLazyStr := q.Get("nacklazy"); nackLazyStr != "" {
 		var err error
@@ -746,8 +752,21 @@ type SubscriptionOptions struct {
 	// identify whether message bodies are raw or SNS JSON; this may be
 	// inefficient for raw messages.
 	//
+	// Note that nothing in an SQS message proves that it was delivered by SNS,
+	// so when this is false a sender that can only choose the message body can
+	// also choose the Metadata the Subscription reports, by making the body
+	// look like an SNS notification. Set this to true, or set SNSTopicARN, if
+	// Metadata is used for anything security-relevant.
+	//
 	// See https://aws.amazon.com/sns/faqs/#Raw_message_delivery.
 	Raw bool
+
+	// SNSTopicARN is the ARN of the SNS topic this subscription is subscribed
+	// to. It is only used when Raw is false: a body that looks like an SNS
+	// notification is only unwrapped if it claims to come from this topic.
+	//
+	// Leaving it empty accepts a claimed ARN from any topic.
+	SNSTopicARN string
 
 	// NackLazy determines what Nack does.
 	//
@@ -818,7 +837,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 		for k, v := range m.MessageAttributes {
 			rawAttrs[k] = aws.ToString(v.StringValue)
 		}
-		bodyStr, rawAttrs = extractBody(bodyStr, rawAttrs, s.opts.Raw)
+		bodyStr, rawAttrs = extractBody(bodyStr, rawAttrs, s.opts.Raw, s.opts.SNSTopicARN)
 
 		decodeIt := false
 		attrs := map[string]string{}
@@ -870,7 +889,7 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 	return ms, nil
 }
 
-func extractBody(bodyStr string, rawAttrs map[string]string, raw bool) (body string, attributes map[string]string) {
+func extractBody(bodyStr string, rawAttrs map[string]string, raw bool, snsTopicARN string) (body string, attributes map[string]string) {
 	// If the user told us that message bodies are raw, or if there are
 	// top-level MessageAttributes, then it's raw.
 	// (SNS JSON message can have attributes, but they are encoded in
@@ -884,13 +903,22 @@ func extractBody(bodyStr string, rawAttrs map[string]string, raw bool) (body str
 
 	// It might be SNS JSON; try to parse the raw body as such.
 	// https://aws.amazon.com/sns/faqs/#Raw_message_delivery
-	// If it parses as JSON and has a TopicArn field, assume it's SNS JSON.
+	// Require the shape of an SNS notification: SNS always sets Type,
+	// MessageId, TopicArn and Timestamp. A body that merely happens to have a
+	// TopicArn field isn't enough, because unwrapping hides the bytes the
+	// sender actually sent and promotes body content to Message.Metadata.
 	var bodyJSON struct {
+		Type              string
+		MessageId         string
 		TopicArn          string
+		Timestamp         string
 		Message           string
 		MessageAttributes map[string]struct{ Value string }
 	}
-	if err := json.Unmarshal([]byte(bodyStr), &bodyJSON); err == nil && bodyJSON.TopicArn != "" {
+	if err := json.Unmarshal([]byte(bodyStr), &bodyJSON); err == nil &&
+		bodyJSON.Type == "Notification" && bodyJSON.MessageId != "" &&
+		bodyJSON.Timestamp != "" && bodyJSON.TopicArn != "" &&
+		(snsTopicARN == "" || bodyJSON.TopicArn == snsTopicARN) {
 		// It looks like SNS JSON. Get attributes from the decoded struct,
 		// and update the body to be the JSON Message field.
 		for k, v := range bodyJSON.MessageAttributes {
@@ -898,9 +926,9 @@ func extractBody(bodyStr string, rawAttrs map[string]string, raw bool) (body str
 		}
 		return bodyJSON.Message, rawAttrs
 	}
-	// It doesn't look like SNS JSON, either because it
-	// isn't JSON or because the JSON doesn't have a TopicArn
-	// field. Treat it as raw.
+	// It doesn't look like SNS JSON, either because it isn't JSON, because it
+	// doesn't have the fields of an SNS notification, or because it claims a
+	// topic other than SNSTopicARN. Treat it as raw.
 	//
 	// As above in the other "raw" case, we leave bodyStr
 	// alone. There can't be any top-level attributes (because

--- a/pubsub/awssnssqs/awssnssqs_test.go
+++ b/pubsub/awssnssqs/awssnssqs_test.go
@@ -687,3 +687,86 @@ func testFIFOTopic(t *testing.T, kind topicKind) {
 		})
 	}
 }
+
+func TestExtractBody(t *testing.T) {
+	const snsARN = "arn:aws:sns:us-east-2:456752665576:mytopic"
+	snsJSON := func(arn string) string {
+		return fmt.Sprintf(`{"Type":"Notification","MessageId":"abc","TopicArn":%q,"Timestamp":"2026-07-30T00:00:00.000Z","Message":"hello","MessageAttributes":{"a":{"Type":"String","Value":"1"}}}`, arn)
+	}
+	for _, tc := range []struct {
+		name        string
+		body        string
+		rawAttrs    map[string]string
+		raw         bool
+		snsTopicARN string
+		wantBody    string
+		wantAttrs   map[string]string
+	}{
+		{
+			name:      "SNS notification is unwrapped",
+			body:      snsJSON(snsARN),
+			wantBody:  "hello",
+			wantAttrs: map[string]string{"a": "1"},
+		},
+		{
+			name:        "SNS notification from the expected topic is unwrapped",
+			body:        snsJSON(snsARN),
+			snsTopicARN: snsARN,
+			wantBody:    "hello",
+			wantAttrs:   map[string]string{"a": "1"},
+		},
+		{
+			name:        "SNS notification from another topic is left alone",
+			body:        snsJSON("arn:aws:sns:us-east-2:456752665576:othertopic"),
+			snsTopicARN: snsARN,
+			wantBody:    snsJSON("arn:aws:sns:us-east-2:456752665576:othertopic"),
+			wantAttrs:   map[string]string{},
+		},
+		{
+			name:      "raw body with only a TopicArn field is left alone",
+			body:      `{"TopicArn":"user-supplied","order_id":42}`,
+			wantBody:  `{"TopicArn":"user-supplied","order_id":42}`,
+			wantAttrs: map[string]string{},
+		},
+		{
+			name:      "forged envelope missing SNS fields cannot inject metadata",
+			body:      `{"TopicArn":"any","Message":"x","MessageAttributes":{"role":{"Value":"admin"}}}`,
+			wantBody:  `{"TopicArn":"any","Message":"x","MessageAttributes":{"role":{"Value":"admin"}}}`,
+			wantAttrs: map[string]string{},
+		},
+		{
+			name:      "non-JSON body is left alone",
+			body:      "hello world",
+			wantBody:  "hello world",
+			wantAttrs: map[string]string{},
+		},
+		{
+			name:      "Raw skips unwrapping entirely",
+			body:      snsJSON(snsARN),
+			raw:       true,
+			wantBody:  snsJSON(snsARN),
+			wantAttrs: map[string]string{},
+		},
+		{
+			name:      "top-level attributes mean the message is raw",
+			body:      snsJSON(snsARN),
+			rawAttrs:  map[string]string{"b": "2"},
+			wantBody:  snsJSON(snsARN),
+			wantAttrs: map[string]string{"b": "2"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			attrs := tc.rawAttrs
+			if attrs == nil {
+				attrs = map[string]string{}
+			}
+			gotBody, gotAttrs := extractBody(tc.body, attrs, tc.raw, tc.snsTopicARN)
+			if gotBody != tc.wantBody {
+				t.Errorf("body = %q; want %q", gotBody, tc.wantBody)
+			}
+			if diff := cmp.Diff(gotAttrs, tc.wantAttrs); diff != "" {
+				t.Errorf("attributes: -got, +want: %s", diff)
+			}
+		})
+	}
+}

--- a/pubsub/awssnssqs/awssnssqs_test.go
+++ b/pubsub/awssnssqs/awssnssqs_test.go
@@ -735,6 +735,27 @@ func TestExtractBody(t *testing.T) {
 			wantAttrs: map[string]string{},
 		},
 		{
+			// Boundary case: an envelope missing exactly one of the four
+			// required fields (here, MessageId) must still be rejected, to
+			// confirm all four are actually required rather than any subset.
+			name:      "envelope missing only MessageId is not unwrapped",
+			body:      `{"Type":"Notification","TopicArn":"any","Timestamp":"2026-07-30T00:00:00.000Z","Message":"x","MessageAttributes":{"role":{"Value":"admin"}}}`,
+			wantBody:  `{"Type":"Notification","TopicArn":"any","Timestamp":"2026-07-30T00:00:00.000Z","Message":"x","MessageAttributes":{"role":{"Value":"admin"}}}`,
+			wantAttrs: map[string]string{},
+		},
+		{
+			name:      "envelope missing only Timestamp is not unwrapped",
+			body:      `{"Type":"Notification","MessageId":"abc","TopicArn":"any","Message":"x","MessageAttributes":{"role":{"Value":"admin"}}}`,
+			wantBody:  `{"Type":"Notification","MessageId":"abc","TopicArn":"any","Message":"x","MessageAttributes":{"role":{"Value":"admin"}}}`,
+			wantAttrs: map[string]string{},
+		},
+		{
+			name:      "envelope with wrong Type is not unwrapped",
+			body:      `{"Type":"SubscriptionConfirmation","MessageId":"abc","TopicArn":"any","Timestamp":"2026-07-30T00:00:00.000Z","Message":"x","MessageAttributes":{"role":{"Value":"admin"}}}`,
+			wantBody:  `{"Type":"SubscriptionConfirmation","MessageId":"abc","TopicArn":"any","Timestamp":"2026-07-30T00:00:00.000Z","Message":"x","MessageAttributes":{"role":{"Value":"admin"}}}`,
+			wantAttrs: map[string]string{},
+		},
+		{
 			name:      "non-JSON body is left alone",
 			body:      "hello world",
 			wantBody:  "hello world",


### PR DESCRIPTION
`extractBody()` decides a raw SQS message body is an SNS notification by unmarshalling it as JSON and checking for a non-empty `TopicArn` field. If it matches, the envelope's `MessageAttributes` become the delivered message's `Metadata` and the body is replaced by the envelope's `Message` field — nothing about the envelope's origin is checked.

This runs for every `awssqs://` subscription that doesn't set `Raw: true` (the default), including ones that only ever expect SNS-delivered traffic. Since SQS message bodies are attacker-influenced whenever anything upstream forwards user data into the queue (or the attacker simply has `sqs:SendMessage`), a body shaped like `{"TopicArn":"anything","Message":"...","MessageAttributes":{...}}` lets the sender choose the `Metadata` the subscriber sees, or swap out the delivered body for something the real bytes never contained — despite `Metadata` looking like it was authoritatively set by SNS.

This requires the shape an actual SNS notification has (`Type: "Notification"`, `MessageId`, `Timestamp`, `TopicArn`) before unwrapping, and adds `SubscriptionOptions.SNSTopicARN` (settable via the `snstopicarn` URL parameter) so a subscription can additionally pin the topic it expects and ignore envelopes claiming a different one. Existing conformance tests (recorded against real SNS/SQS traffic) still pass unmodified since real notifications already have all four fields.