### PR TITLE
secrets/hashivault: reject keyIDs that escape the engine/operation path

### DIFF
--- a/secrets/hashivault/vault.go
+++ b/secrets/hashivault/vault.go
@@ -38,6 +38,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/vault/api"
@@ -197,12 +198,13 @@ type keeper struct {
 
 // Decrypt decrypts the ciphertext into a plaintext.
 func (k *keeper) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
-	out, err := k.client.Logical().Write(
-		path.Join(k.opts.Engine+"/decrypt", k.keyID),
-		map[string]any{
-			"ciphertext": string(ciphertext),
-		},
-	)
+	p, err := vaultPath(k.opts.Engine+"/decrypt", k.keyID)
+	if err != nil {
+		return nil, err
+	}
+	out, err := k.client.Logical().Write(p, map[string]any{
+		"ciphertext": string(ciphertext),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -211,16 +213,32 @@ func (k *keeper) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error)
 
 // Encrypt encrypts a plaintext into a ciphertext.
 func (k *keeper) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
-	secret, err := k.client.Logical().Write(
-		path.Join(k.opts.Engine+"/encrypt", k.keyID),
-		map[string]any{
-			"plaintext": plaintext,
-		},
-	)
+	p, err := vaultPath(k.opts.Engine+"/encrypt", k.keyID)
+	if err != nil {
+		return nil, err
+	}
+	secret, err := k.client.Logical().Write(p, map[string]any{
+		"plaintext": plaintext,
+	})
 	if err != nil {
 		return nil, err
 	}
 	return []byte(secret.Data["ciphertext"].(string)), nil
+}
+
+// vaultPath joins prefix and keyID into a Vault API path, and verifies that
+// the result is actually inside prefix. path.Join cleans ".." segments, so a
+// keyID such as "../../sys/health" would otherwise silently make the request
+// escape the intended secrets engine and operation (decrypt vs. encrypt) --
+// something Vault's own path-prefix-scoped ACL policies can't defend against,
+// since as far as Vault is concerned it's simply the path the client asked
+// for.
+func vaultPath(prefix, keyID string) (string, error) {
+	p := path.Join(prefix, keyID)
+	if p != prefix && !strings.HasPrefix(p, prefix+"/") {
+		return "", fmt.Errorf("hashivault: keyID %q escapes the %q path", keyID, prefix)
+	}
+	return p, nil
 }
 
 // Close implements driver.Keeper.Close.

--- a/secrets/hashivault/vault_test.go
+++ b/secrets/hashivault/vault_test.go
@@ -17,6 +17,9 @@ package hashivault
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -214,4 +217,67 @@ func TestGetVaultConnectionDetails(t *testing.T) {
 			t.Errorf("export '': got %q", vaultToken)
 		}
 	})
+}
+
+func TestVaultPath(t *testing.T) {
+	tests := []struct {
+		prefix, keyID, want string
+		wantErr             bool
+	}{
+		{"transit/decrypt", "mykey", "transit/decrypt/mykey", false},
+		{"transit/decrypt", "tenant-a/subkey", "transit/decrypt/tenant-a/subkey", false},
+		{"transit/decrypt", "tenant-a/../tenant-b", "transit/decrypt/tenant-b", false},
+		{"transit/decrypt", "../../sys/health", "", true},
+		{"transit/decrypt", "a/../../../auth/token/create", "", true},
+		{"transit/decrypt", "..", "", true},
+		{"transit/decrypt", "../decrypt-sibling", "", true},
+	}
+	for _, tc := range tests {
+		got, err := vaultPath(tc.prefix, tc.keyID)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("vaultPath(%q, %q) error = %v, wantErr %v", tc.prefix, tc.keyID, err, tc.wantErr)
+			continue
+		}
+		if err == nil && got != tc.want {
+			t.Errorf("vaultPath(%q, %q) = %q, want %q", tc.prefix, tc.keyID, got, tc.want)
+		}
+	}
+}
+
+func TestDecryptRejectsKeyIDThatEscapesEnginePrefix(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"data":{"plaintext":"aGVsbG8="}}`)
+	}))
+	defer srv.Close()
+
+	client, err := api.NewClient(&api.Config{Address: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A legitimate keyID reaches the expected path.
+	gotPath = ""
+	k := newKeeper(client, "tenant-a-key", nil)
+	if _, err := k.Decrypt(context.Background(), []byte("Y2lwaGVydGV4dA==")); err != nil {
+		t.Fatalf("Decrypt with a normal keyID: %v", err)
+	}
+	if want := "/v1/transit/decrypt/tenant-a-key"; gotPath != want {
+		t.Errorf("request path = %q, want %q", gotPath, want)
+	}
+
+	// A keyID crafted to escape the transit/decrypt prefix must be rejected
+	// before any request is sent, not merely fail server-side.
+	for _, keyID := range []string{"../../sys/health", "a/../../../auth/token/create"} {
+		gotPath = ""
+		k := newKeeper(client, keyID, nil)
+		if _, err := k.Decrypt(context.Background(), []byte("Y2lwaGVydGV4dA==")); err == nil {
+			t.Errorf("Decrypt with keyID %q: got no error, want rejection", keyID)
+		}
+		if gotPath != "" {
+			t.Errorf("Decrypt with keyID %q: request reached the server at path %q; want no request sent", keyID, gotPath)
+		}
+	}
 }

--- a/secrets/hashivault/vault_test.go
+++ b/secrets/hashivault/vault_test.go
@@ -281,3 +281,71 @@ func TestDecryptRejectsKeyIDThatEscapesEnginePrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestEncryptRejectsKeyIDThatEscapesEnginePrefix(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"data":{"ciphertext":"vault:v1:abc"}}`)
+	}))
+	defer srv.Close()
+
+	client, err := api.NewClient(&api.Config{Address: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A legitimate keyID reaches the expected path.
+	gotPath = ""
+	k := newKeeper(client, "tenant-a-key", nil)
+	if _, err := k.Encrypt(context.Background(), []byte("hello")); err != nil {
+		t.Fatalf("Encrypt with a normal keyID: %v", err)
+	}
+	if want := "/v1/transit/encrypt/tenant-a-key"; gotPath != want {
+		t.Errorf("request path = %q, want %q", gotPath, want)
+	}
+
+	// A keyID crafted to escape the transit/encrypt prefix must be rejected
+	// before any request is sent, not merely fail server-side.
+	for _, keyID := range []string{"../../sys/health", "a/../../../auth/token/create"} {
+		gotPath = ""
+		k := newKeeper(client, keyID, nil)
+		if _, err := k.Encrypt(context.Background(), []byte("hello")); err == nil {
+			t.Errorf("Encrypt with keyID %q: got no error, want rejection", keyID)
+		}
+		if gotPath != "" {
+			t.Errorf("Encrypt with keyID %q: request reached the server at path %q; want no request sent", keyID, gotPath)
+		}
+	}
+}
+
+func TestOpenKeeperRejectsKeyIDThatEscapesEnginePrefix(t *testing.T) {
+	// End-to-end through secrets.OpenKeeper and the URL opener, not just the
+	// driver.Keeper methods directly, to confirm a URL-supplied keyID is
+	// covered too (e.g. "hashivault://../../sys/health").
+	t.Setenv("VAULT_SERVER_URL", "http://myvaultserver")
+	t.Setenv("VAULT_SERVER_TOKEN", "faketoken")
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"data":{"plaintext":"aGVsbG8="}}`)
+	}))
+	defer srv.Close()
+
+	client, err := api.NewClient(&api.Config{Address: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keeper := OpenKeeper(client, "../../sys/health", nil)
+	defer keeper.Close()
+	if _, err := keeper.Decrypt(context.Background(), []byte("Y2lwaGVydGV4dA==")); err == nil {
+		t.Error("Decrypt via a keyID that escapes the engine prefix: got no error, want rejection")
+	}
+	if gotPath != "" {
+		t.Errorf("request reached the server at path %q; want no request sent", gotPath)
+	}
+}


### PR DESCRIPTION
`keeper.Decrypt`/`keeper.Encrypt` (`secrets/hashivault/vault.go`) build the literal Vault API request path with `path.Join(opts.Engine+"/decrypt", keyID)` / `.../encrypt`. `path.Join` cleans `..` segments, so a `keyID` such as `"../../sys/health"` makes the actual HTTP request escape the intended engine and operation entirely — confirmed against a fake Vault server, where `keyID = "a/../../../auth/token/create"` produced a request to `/v1/auth/token/create` instead of `/v1/transit/decrypt/...`.

This is the only secrets driver in this module that builds a raw path this way: `awskms`/`gcpkms` pass their key identifier as a structured field on the cloud SDK's request type (server-side authorization decides what's valid), and `azurekeyvault` validates `keyID` with a strict regex before use. `hashivault`'s `keyID` is exactly the parameter `OpenKeeper(client, keyID, opts)` is documented to take directly, and Vault's own authorization model is commonly path-prefix ACLs (e.g. a policy scoped to `transit/decrypt/tenant-a-*` for a specific tenant/key namespace) — so a caller that only controls the key name, not the Vault client's credentials, can reach paths the deploying application never intended to expose.

Adds `vaultPath`, which joins the prefix and `keyID` and then verifies the result is still inside that prefix, returning an error instead of sending the request otherwise. `tenant-a/../tenant-b` (relative navigation that stays within `<engine>/<op>/`) still works; only escapes past that boundary are rejected.