### PR TITLE
internal/testing/setup: close the fake credentials file

### DIFF
--- a/internal/testing/setup/setup.go
+++ b/internal/testing/setup/setup.go
@@ -251,6 +251,13 @@ func FakeGCPDefaultCredentials(t *testing.T) func() {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Close the handle before writing to the file by name. On Windows an open
+	// handle blocks deletion, so leaving it open makes t.TempDir's cleanup fail
+	// with "The process cannot access the file because it is being used by
+	// another process".
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(f.Name(), jsonCred, 0o666); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
`FakeGCPDefaultCredentials` creates the file with `os.CreateTemp` and never closes the returned handle. On Windows an open handle blocks deletion, so `t.TempDir`'s cleanup fails and the test reports:

```
TempDir RemoveAll cleanup: unlinkat ...\fake-gcp-creds...:
The process cannot access the file because it is being used by another process.
```

That is enough to fail a package on Windows even when the test itself passes. On stock `master`:

```
$ go test ./gcp/ -run Credentials
--- FAIL: TestDefaultCredentialsWithParams
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat ...: The process
    cannot access the file because it is being used by another process.
FAIL
```

and with this change:

```
$ go test ./gcp/ -run Credentials
ok      gocloud.dev/gcp
```

The handle is now closed before the file is written to by name. Nine other packages call `FakeGCPDefaultCredentials` and are affected the same way.

Verified with `go build ./...`, `gofmt -s`, `go vet`, and `golangci-lint run` (0 issues).
