### PR TITLE
blob/gcsblob: support the gRPC API and Rapid Storage (zonal) buckets

### DIFF
--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -75,6 +75,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/storage"
+	"cloud.google.com/go/storage/experimental"
 	"github.com/google/wire"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/googleapi"
@@ -155,7 +156,9 @@ func (o *lazyCredsOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.
 	o.init.Do(func() {
 		var opts Options
 		var creds *google.Credentials
-		if os.Getenv("STORAGE_EMULATOR_HOST") != "" {
+		// STORAGE_EMULATOR_HOST_GRPC is the gRPC equivalent; a local emulator
+		// needs separate ports for HTTP and gRPC, so either may be set.
+		if os.Getenv("STORAGE_EMULATOR_HOST") != "" || os.Getenv("STORAGE_EMULATOR_HOST_GRPC") != "" {
 			creds, _ = google.CredentialsFromJSON(ctx, []byte(`{"type": "service_account", "project_id": "my-project-id"}`))
 		} else {
 			var err error
@@ -205,7 +208,9 @@ func (o *lazyCredsOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.
 			o.err = err
 			return
 		}
-		o.opener = &URLOpener{Client: client, Options: opts}
+		// TokenSource is needed for grpc=true and zonal=true URLs, which build a
+		// separate gRPC client that cannot reuse the HTTP one.
+		o.opener = &URLOpener{Client: client, TokenSource: gcp.CredentialsTokenSource(creds), Options: opts}
 	})
 	if o.err != nil {
 		return nil, fmt.Errorf("open bucket %v: %w", u, o.err)
@@ -228,10 +233,24 @@ const Scheme = "gs"
 //     a value of "-" forces the use of an unauthenticated client.
 //   - private_key_path: Path to read for Options.PrivateKey; only used in SignedURL.
 //   - universe_domain: Sets the universe domain for the client.
+//   - grpc: A value of "true" uses the Cloud Storage gRPC API instead of the
+//     JSON/HTTP API. The bucket is opened with a client from DialGRPC.
+//   - zonal: A value of "true" additionally enables the zonal bucket APIs, which
+//     are required for Rapid Storage buckets. Implies grpc=true.
+//
+// gRPC is not automatically faster than JSON/HTTP. For small-object latency
+// against regional, dual-region and multi-region buckets it measured no better,
+// so prefer the default unless you have measured a win for your workload.
 type URLOpener struct {
 	// Client must be set to a non-nil HTTP client authenticated with
 	// Cloud Storage scope or equivalent (unless anonymous=true).
 	Client *gcp.HTTPClient
+
+	// TokenSource is used to authenticate the gRPC client built for URLs with
+	// grpc=true or zonal=true. The gRPC API cannot reuse an HTTP client, so
+	// Client is not enough on its own. It is not needed for URLs that use the
+	// default JSON/HTTP API, nor for anonymous=true.
+	TokenSource gcp.TokenSource
 
 	// Options specifies the default options to pass to OpenBucket.
 	Options Options
@@ -239,36 +258,105 @@ type URLOpener struct {
 
 // OpenBucketURL opens the GCS bucket with the same name as the URL's host.
 func (o *URLOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.Bucket, error) {
-	opts, client, err := o.forParams(ctx, u.Query())
+	opts, client, params, err := o.forParams(ctx, u.Query())
 	if err != nil {
 		return nil, fmt.Errorf("open bucket %v: %w", u, err)
 	}
-	return OpenBucket(ctx, client, u.Host, opts)
+	if !params.useGRPC {
+		return OpenBucket(ctx, client, u.Host, opts)
+	}
+
+	// The gRPC API cannot reuse an HTTP client, so build a dedicated client from
+	// the same credentials. The bucket owns it and closes it, since nothing else
+	// holds a reference.
+	if opts.Client != nil {
+		return nil, fmt.Errorf("open bucket %v: Options.Client cannot be combined with grpc=true or zonal=true", u)
+	}
+	var clientOpts []option.ClientOption
+	if params.useZonal {
+		clientOpts = append(clientOpts, experimental.WithZonalBucketAPIs())
+	}
+	clientOpts = append(clientOpts, opts.ClientOptions...)
+	ts := o.TokenSource
+	if params.anonymous {
+		ts = nil
+	} else if ts == nil {
+		return nil, fmt.Errorf("open bucket %v: URLOpener.TokenSource is required for grpc=true or zonal=true", u)
+	}
+	gc, cleanup, err := DialGRPC(ctx, ts, clientOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("open bucket %v: %w", u, err)
+	}
+	drv, err := openBucketGRPC(gc, u.Host, opts, true)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("open bucket %v: %w", u, err)
+	}
+	return blob.NewBucket(drv), nil
 }
 
-func (o *URLOpener) forParams(ctx context.Context, q url.Values) (*Options, *gcp.HTTPClient, error) {
+// urlParams holds the transport choices parsed out of a bucket URL.
+type urlParams struct {
+	// useGRPC is set by grpc=true, and implied by zonal=true.
+	useGRPC bool
+	// useZonal is set by zonal=true.
+	useZonal bool
+	// anonymous is set when the URL asked for an unauthenticated client, via
+	// anonymous=true or access_id=-.
+	anonymous bool
+}
+
+func (o *URLOpener) forParams(ctx context.Context, q url.Values) (*Options, *gcp.HTTPClient, urlParams, error) {
+	var params urlParams
 	for k := range q {
-		if k != "access_id" && k != "private_key_path" && k != "anonymous" && k != "universe_domain" {
-			return nil, nil, fmt.Errorf("invalid query parameter %q", k)
+		if k != "access_id" && k != "private_key_path" && k != "anonymous" && k != "universe_domain" && k != "grpc" && k != "zonal" {
+			return nil, nil, params, fmt.Errorf("invalid query parameter %q", k)
 		}
 	}
 	opts := new(Options)
 	*opts = o.Options
 	client := o.Client
+	grpcInURL := false
+	if g := q.Get("grpc"); g != "" {
+		useGRPC, err := strconv.ParseBool(g)
+		if err != nil {
+			return nil, nil, params, fmt.Errorf("invalid value %q for query parameter \"grpc\": %w", g, err)
+		}
+		params.useGRPC = useGRPC
+		grpcInURL = true
+	}
+	if z := q.Get("zonal"); z != "" {
+		useZonal, err := strconv.ParseBool(z)
+		if err != nil {
+			return nil, nil, params, fmt.Errorf("invalid value %q for query parameter \"zonal\": %w", z, err)
+		}
+		params.useZonal = useZonal
+	}
+	// The zonal APIs exist only on the gRPC client, so zonal=true implies
+	// grpc=true. Asking for both zonal=true and grpc=false is a contradiction,
+	// so report it instead of picking a winner.
+	if params.useZonal {
+		if grpcInURL && !params.useGRPC {
+			return nil, nil, params, errors.New("query parameter \"zonal=true\" cannot be combined with \"grpc=false\"")
+		}
+		params.useGRPC = true
+	}
 	if anon := q.Get("anonymous"); anon != "" {
 		isAnon, err := strconv.ParseBool(anon)
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid value %q for query parameter \"anonymous\": %w", anon, err)
+			return nil, nil, params, fmt.Errorf("invalid value %q for query parameter \"anonymous\": %w", anon, err)
 		}
 		if isAnon {
 			opts.clear()
 			client = gcp.NewAnonymousHTTPClient(gcp.DefaultTransport())
+			params.anonymous = true
 		}
 	}
 	if accessID := q.Get("access_id"); accessID != "" && accessID != opts.GoogleAccessID {
 		opts.clear()
 		if accessID == "-" {
 			client = gcp.NewAnonymousHTTPClient(gcp.DefaultTransport())
+			params.anonymous = true
 		} else {
 			opts.GoogleAccessID = accessID
 		}
@@ -276,7 +364,7 @@ func (o *URLOpener) forParams(ctx context.Context, q url.Values) (*Options, *gcp
 	if keyPath := q.Get("private_key_path"); keyPath != "" {
 		pk, err := os.ReadFile(keyPath)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, params, err
 		}
 		opts.PrivateKey = pk
 	} else if _, exists := q["private_key_path"]; exists {
@@ -285,7 +373,7 @@ func (o *URLOpener) forParams(ctx context.Context, q url.Values) (*Options, *gcp
 		// is intentional such as for tests or involving a key stored in a HSM/TPM.
 		opts.PrivateKey = nil
 	}
-	return opts, client, nil
+	return opts, client, params, nil
 }
 
 // Options sets options for constructing a *blob.Bucket backed by GCS.
@@ -315,7 +403,9 @@ type Options struct {
 	// Client provides a *storage.Client to use, instead of constructing one based on
 	// the HTTPClient. When set, you must pass nil as the gcp.HTTPClient to OpenBucket.
 	//
-	// For example, this can be used to create a Bucket backed by a gRPC client.
+	// Use this to open a bucket over the Cloud Storage gRPC API, including a
+	// Rapid Storage (zonal) bucket; see DialGRPC. The caller owns the client and
+	// is responsible for closing it.
 	Client *storage.Client
 
 	// ClientOptions are passed when constructing the storage.Client.
@@ -352,16 +442,7 @@ func openBucket(ctx context.Context, client *gcp.HTTPClient, bucketName string, 
 		return nil, errors.New("gcsblob.OpenBucket: client is required")
 	}
 
-	// We wrap the provided http.Client to add a Go CDK User-Agent.
-	clientOpts := []option.ClientOption{option.WithHTTPClient(useragent.HTTPClient(&client.Client, "blob"))}
-	if host := os.Getenv("STORAGE_EMULATOR_HOST"); host != "" {
-		clientOpts = []option.ClientOption{
-			option.WithoutAuthentication(),
-			option.WithEndpoint("http://" + host + "/storage/v1/"),
-			option.WithHTTPClient(http.DefaultClient),
-		}
-	}
-	clientOpts = append(clientOpts, opts.ClientOptions...)
+	clientOpts := append(httpClientOptions(client, os.Getenv("STORAGE_EMULATOR_HOST")), opts.ClientOptions...)
 	c, err := storage.NewClient(ctx, clientOpts...)
 	if err != nil {
 		return nil, err
@@ -369,8 +450,62 @@ func openBucket(ctx context.Context, client *gcp.HTTPClient, bucketName string, 
 	return &bucket{name: bucketName, client: c, opts: opts}, nil
 }
 
-// OpenBucket returns a *blob.Bucket backed by an existing GCS bucket. See the
-// package documentation for an example.
+// httpClientOptions returns the client options for the JSON/HTTP storage API.
+func httpClientOptions(client *gcp.HTTPClient, emulatorHost string) []option.ClientOption {
+	if emulatorHost != "" {
+		return []option.ClientOption{
+			option.WithoutAuthentication(),
+			option.WithEndpoint("http://" + emulatorHost + "/storage/v1/"),
+			option.WithHTTPClient(http.DefaultClient),
+		}
+	}
+	// We wrap the provided http.Client to add a Go CDK User-Agent.
+	return []option.ClientOption{option.WithHTTPClient(useragent.HTTPClient(&client.Client, "blob"))}
+}
+
+// DialGRPC returns a *storage.Client that talks to Cloud Storage over gRPC
+// instead of the default JSON/HTTP API. Pass it as Options.Client, along with a
+// nil gcp.HTTPClient, to open a bucket that uses it:
+//
+//	c, cleanup, err := gcsblob.DialGRPC(ctx, gcp.CredentialsTokenSource(creds))
+//	if err != nil { ... }
+//	defer cleanup()
+//	b, err := gcsblob.OpenBucket(ctx, nil, "my-bucket", &gcsblob.Options{Client: c})
+//
+// Rapid Storage (zonal) buckets accept only appendable object uploads, and
+// reject every other write. They need the zonal bucket APIs:
+//
+//	c, cleanup, err := gcsblob.DialGRPC(ctx, ts, experimental.WithZonalBucketAPIs())
+//
+// Do not pass that option for other bucket types, which reject appendable
+// uploads in turn.
+//
+// A nil ts returns an unauthenticated client. The caller owns the returned
+// client and must call the returned clean-up function when done with it.
+//
+// Emulator support is left to storage.NewGRPCClient, which reads
+// STORAGE_EMULATOR_HOST_GRPC rather than STORAGE_EMULATOR_HOST, since a local
+// emulator needs separate ports for HTTP and gRPC. It also strips the scheme
+// from the host and dials insecurely, neither of which could be done correctly
+// from here.
+func DialGRPC(ctx context.Context, ts gcp.TokenSource, opts ...option.ClientOption) (*storage.Client, func(), error) {
+	clientOpts := []option.ClientOption{useragent.ClientOption("blob")}
+	if ts == nil {
+		clientOpts = append(clientOpts, option.WithoutAuthentication())
+	} else {
+		clientOpts = append(clientOpts, option.WithTokenSource(ts))
+	}
+	clientOpts = append(clientOpts, opts...)
+	c, err := storage.NewGRPCClient(ctx, clientOpts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c, func() { _ = c.Close() }, nil
+}
+
+// OpenBucket returns a *blob.Bucket backed by an existing GCS bucket, using the
+// JSON/HTTP API. For the gRPC API, including Rapid Storage (zonal) buckets, see
+// OpenBucketGRPC. See the package documentation for an example.
 func OpenBucket(ctx context.Context, client *gcp.HTTPClient, bucketName string, opts *Options) (*blob.Bucket, error) {
 	drv, err := openBucket(ctx, client, bucketName, opts)
 	if err != nil {
@@ -379,12 +514,68 @@ func OpenBucket(ctx context.Context, client *gcp.HTTPClient, bucketName string, 
 	return blob.NewBucket(drv), nil
 }
 
+// OpenBucketGRPC returns a *blob.Bucket backed by an existing GCS bucket, using
+// a client that talks to Cloud Storage over gRPC rather than the default
+// JSON/HTTP API. Use DialGRPC to construct client.
+//
+// This is the entry point for Rapid Storage (zonal) buckets, which reject every
+// write over JSON/HTTP:
+//
+//	c, cleanup, err := gcsblob.DialGRPC(ctx, ts, experimental.WithZonalBucketAPIs())
+//	if err != nil { ... }
+//	defer cleanup()
+//	b, err := gcsblob.OpenBucketGRPC(c, "my-rapid-bucket", nil)
+//
+// The caller owns client. Closing the returned bucket does not close it.
+//
+// It is an error to also set Options.Client. Options.ClientOptions is ignored,
+// since those options are applied when client is constructed.
+func OpenBucketGRPC(client *storage.Client, bucketName string, opts *Options) (*blob.Bucket, error) {
+	drv, err := openBucketGRPC(client, bucketName, opts, false)
+	if err != nil {
+		return nil, err
+	}
+	return blob.NewBucket(drv), nil
+}
+
+// openBucketGRPC returns the driver behind OpenBucketGRPC. owned reports
+// whether the bucket has to close client itself, which is true only when the
+// bucket built the client rather than receiving it from the caller.
+func openBucketGRPC(client *storage.Client, bucketName string, opts *Options, owned bool) (*bucket, error) {
+	if client == nil {
+		return nil, errors.New("gcsblob.OpenBucketGRPC: client is required")
+	}
+	if opts == nil {
+		opts = &Options{}
+	}
+	if opts.Client != nil {
+		return nil, errors.New("gcsblob.OpenBucketGRPC: Options.Client must be nil; pass the client as the first argument")
+	}
+	o := *opts
+	o.Client = client
+	// ctx is unused once a client exists, so it is not part of the signature;
+	// compare secrets/gcpkms.OpenKeeper.
+	drv, err := openBucket(context.Background(), nil, bucketName, &o)
+	if err != nil {
+		return nil, err
+	}
+	if owned {
+		drv.ownedClient = client
+	}
+	return drv, nil
+}
+
 // bucket represents a GCS bucket, which handles read, write and delete operations
 // on objects within it.
 type bucket struct {
 	name   string
 	client *storage.Client
-	opts   *Options
+	// ownedClient is non-nil when this bucket created client itself and must
+	// close it. That happens only for URLs that select the gRPC API, where the
+	// client owns a connection pool that would otherwise leak. Clients supplied
+	// through Options.Client belong to the caller and are left alone.
+	ownedClient *storage.Client
+	opts        *Options
 }
 
 // reader reads a GCS object. It implements driver.Reader.
@@ -438,6 +629,9 @@ func (b *bucket) ErrorCode(err error) gcerrors.ErrorCode {
 }
 
 func (b *bucket) Close() error {
+	if b.ownedClient != nil {
+		return b.ownedClient.Close()
+	}
 	return nil
 }
 
@@ -672,6 +866,23 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key, contentType string, op
 		w.Metadata = opts.Metadata
 		w.MD5 = opts.ContentMD5
 		w.ForceEmptyContentType = opts.DisableContentTypeDetection
+		// Zonal buckets upload with "appendable object" semantics: the object
+		// appears as soon as the first bytes are flushed and stays open for
+		// more writes until someone finalizes it. Closing the Writer does not
+		// finalize it by default, which leaves behind an object exposing only
+		// whatever prefix had been flushed. For a write small enough to fit in
+		// one buffer that is a zero-length object, even though Close returned
+		// no error. Finalize on Close so that a closed blob.Writer always
+		// leaves a complete object, as the blob API promises.
+		//
+		// The storage client reads this field only on the appendable write
+		// path, so it does nothing over JSON/HTTP or plain gRPC. Setting it
+		// unconditionally is deliberate: it also covers callers who turn on
+		// appendable uploads by passing experimental.WithZonalBucketAPIs
+		// through Options.ClientOptions rather than setting UseZonalAPIs.
+		// Callers who do want an object left open for later appends can set
+		// this back to false from WriterOptions.BeforeWrite.
+		w.FinalizeOnClose = true
 		return w
 	}
 

--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -75,7 +75,6 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/storage"
-	"cloud.google.com/go/storage/experimental"
 	"github.com/google/wire"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/googleapi"
@@ -274,7 +273,7 @@ func (o *URLOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.Bucket
 	}
 	var clientOpts []option.ClientOption
 	if params.useZonal {
-		clientOpts = append(clientOpts, experimental.WithZonalBucketAPIs())
+		clientOpts = append(clientOpts, storage.WithAppendableUploads(), storage.WithGRPCBidiReads())
 	}
 	clientOpts = append(clientOpts, opts.ClientOptions...)
 	ts := o.TokenSource
@@ -475,7 +474,8 @@ func httpClientOptions(client *gcp.HTTPClient, emulatorHost string) []option.Cli
 // Rapid Storage (zonal) buckets accept only appendable object uploads, and
 // reject every other write. They need the zonal bucket APIs:
 //
-//	c, cleanup, err := gcsblob.DialGRPC(ctx, ts, experimental.WithZonalBucketAPIs())
+//	c, cleanup, err := gcsblob.DialGRPC(ctx, ts,
+//		storage.WithAppendableUploads(), storage.WithGRPCBidiReads())
 //
 // Do not pass that option for other bucket types, which reject appendable
 // uploads in turn.
@@ -521,7 +521,8 @@ func OpenBucket(ctx context.Context, client *gcp.HTTPClient, bucketName string, 
 // This is the entry point for Rapid Storage (zonal) buckets, which reject every
 // write over JSON/HTTP:
 //
-//	c, cleanup, err := gcsblob.DialGRPC(ctx, ts, experimental.WithZonalBucketAPIs())
+//	c, cleanup, err := gcsblob.DialGRPC(ctx, ts,
+//		storage.WithAppendableUploads(), storage.WithGRPCBidiReads())
 //	if err != nil { ... }
 //	defer cleanup()
 //	b, err := gcsblob.OpenBucketGRPC(c, "my-rapid-bucket", nil)
@@ -878,8 +879,9 @@ func (b *bucket) NewTypedWriter(ctx context.Context, key, contentType string, op
 		// The storage client reads this field only on the appendable write
 		// path, so it does nothing over JSON/HTTP or plain gRPC. Setting it
 		// unconditionally is deliberate: it also covers callers who turn on
-		// appendable uploads by passing experimental.WithZonalBucketAPIs
-		// through Options.ClientOptions rather than setting UseZonalAPIs.
+		// appendable uploads by passing storage.WithAppendableUploads
+		// through Options.ClientOptions rather than using the zonal URL
+		// parameter.
 		// Callers who do want an object left open for later appends can set
 		// this back to false from WriterOptions.BeforeWrite.
 		w.FinalizeOnClose = true

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -116,6 +117,62 @@ func TestConformance(t *testing.T) {
 	drivertest.RunConformanceTests(t, newHarness, []drivertest.AsTest{verifyContentLanguage{}})
 }
 
+func TestOpenBucketGRPC(t *testing.T) {
+	ctx := context.Background()
+	client, cleanup, err := DialGRPC(ctx, nil) // unauthenticated; no RPCs are made here
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	for _, test := range []struct {
+		name       string
+		client     *storage.Client
+		bucketName string
+		opts       *Options
+		wantErr    string
+	}{
+		{name: "ok", client: client, bucketName: "mybucket"},
+		{name: "ok, nil Options", client: client, bucketName: "mybucket", opts: nil},
+		{name: "nil client", bucketName: "mybucket", wantErr: "client is required"},
+		{name: "empty bucket name", client: client, wantErr: "bucketName is required"},
+		{
+			name:       "Options.Client also set",
+			client:     client,
+			bucketName: "mybucket",
+			opts:       &Options{Client: client},
+			wantErr:    "Options.Client must be nil",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := OpenBucketGRPC(test.client, test.bucketName, test.opts)
+			if test.wantErr != "" {
+				if err == nil {
+					t.Fatalf("got nil error, want one containing %q", test.wantErr)
+				}
+				if !strings.Contains(err.Error(), test.wantErr) {
+					t.Errorf("got error %q, want it to contain %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The caller owns the client, so closing the bucket must leave it
+			// usable rather than closing it.
+			if err := b.Close(); err != nil {
+				t.Errorf("Close: %v", err)
+			}
+			if _, err := OpenBucketGRPC(client, "mybucket", nil); err != nil {
+				t.Errorf("client was closed by bucket.Close: %v", err)
+			}
+		})
+	}
+}
+
+// HTTPClient returns nil: without a GoogleAccessID and a signer, SignedURL
+// reports Unimplemented and drivertest skips the checks that would need this.
+// SignedURL is signed client-side and is unaffected by the transport.
 func BenchmarkGcsblob(b *testing.B) {
 	ctx := context.Background()
 	creds, err := gcp.DefaultCredentials(ctx)
@@ -561,6 +618,7 @@ func TestURLOpenerForParams(t *testing.T) {
 		currOpts   Options
 		query      url.Values
 		wantOpts   Options
+		wantParams urlParams
 		wantClient bool
 		wantErr    bool
 	}{
@@ -593,6 +651,7 @@ func TestURLOpenerForParams(t *testing.T) {
 				"access_id": {"-"},
 			},
 			wantOpts:   Options{}, // cleared
+			wantParams: urlParams{anonymous: true},
 			wantClient: true,
 		},
 		{
@@ -614,6 +673,7 @@ func TestURLOpenerForParams(t *testing.T) {
 				"anonymous": {"true"},
 			},
 			wantOpts:   Options{}, // cleared
+			wantParams: urlParams{anonymous: true},
 			wantClient: true,
 		},
 		{
@@ -639,6 +699,61 @@ func TestURLOpenerForParams(t *testing.T) {
 			wantOpts: Options{},
 		},
 		{
+			name: "GRPC",
+			query: url.Values{
+				"grpc": {"true"},
+			},
+			wantOpts:   Options{},
+			wantParams: urlParams{useGRPC: true},
+		},
+		{
+			name: "Invalid value for grpc",
+			query: url.Values{
+				"grpc": {"bad"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Zonal",
+			query: url.Values{
+				"zonal": {"true"},
+			},
+			wantOpts: Options{},
+			// zonal=true implies grpc=true.
+			wantParams: urlParams{useGRPC: true, useZonal: true},
+		},
+		{
+			name: "Zonal with explicit grpc",
+			query: url.Values{
+				"grpc":  {"true"},
+				"zonal": {"true"},
+			},
+			wantOpts:   Options{},
+			wantParams: urlParams{useGRPC: true, useZonal: true},
+		},
+		{
+			name: "Zonal false",
+			query: url.Values{
+				"zonal": {"false"},
+			},
+			wantOpts: Options{},
+		},
+		{
+			name: "Zonal conflicts with grpc=false",
+			query: url.Values{
+				"grpc":  {"false"},
+				"zonal": {"true"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid value for zonal",
+			query: url.Values{
+				"zonal": {"bad"},
+			},
+			wantErr: true,
+		},
+		{
 			name: "AccessID change clears PrivateKey and MakeSignBytes",
 			currOpts: Options{
 				GoogleAccessID: "foo",
@@ -659,7 +774,7 @@ func TestURLOpenerForParams(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			o := &URLOpener{Options: test.currOpts}
-			got, gotClient, err := o.forParams(ctx, test.query)
+			got, gotClient, gotParams, err := o.forParams(ctx, test.query)
 			if (err != nil) != test.wantErr {
 				t.Errorf("got err %v want error %v", err, test.wantErr)
 			}
@@ -668,6 +783,9 @@ func TestURLOpenerForParams(t *testing.T) {
 			}
 			if diff := cmp.Diff(got, &test.wantOpts); diff != "" {
 				t.Errorf("opener.forParams(...) diff (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(gotParams, test.wantParams, cmp.AllowUnexported(urlParams{})); diff != "" {
+				t.Errorf("opener.forParams(...) params diff (-want +got):\n%s", diff)
 			}
 			if test.wantClient != (gotClient != nil) {
 				t.Errorf("opener.forParams client return value was unexpected, got %v want %v", gotClient != nil, test.wantClient)
@@ -705,6 +823,19 @@ func TestOpenBucketFromURL(t *testing.T) {
 		{"gs://mybucket?universe_domain=example.com", false},
 		// OK, universe_domain with empty value.
 		{"gs://mybucket?universe_domain=", false},
+		// OK, using the gRPC API.
+		{"gs://mybucket?grpc=true", false},
+		// Invalid value for grpc.
+		{"gs://mybucket?grpc=bad", true},
+		// OK, using the zonal APIs (required for Rapid Storage buckets).
+		{"gs://mybucket?zonal=true", false},
+		// Invalid value for zonal.
+		{"gs://mybucket?zonal=bad", true},
+		// zonal=true cannot be combined with grpc=false.
+		{"gs://mybucket?zonal=true&grpc=false", true},
+		// OK, gRPC without credentials.
+		{"gs://mybucket?grpc=true&anonymous=true", false},
+		{"gs://mybucket?zonal=true&anonymous=true", false},
 		// Invalid private_key_path.
 		{"gs://mybucket?private_key_path=invalid-path", true},
 		// Invalid parameter.

--- a/blob/gcsblob/gcsblob_test.go
+++ b/blob/gcsblob/gcsblob_test.go
@@ -38,6 +38,7 @@ import (
 	"gocloud.dev/gcp"
 	"gocloud.dev/internal/testing/setup"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 )
 
 const (
@@ -170,9 +171,118 @@ func TestOpenBucketGRPC(t *testing.T) {
 	}
 }
 
+// storageGRPCEndpoint is dialed during --record, and replayed from a golden
+// file otherwise.
+const storageGRPCEndpoint = "storage.googleapis.com:443"
+
+// grpcHarness runs the conformance tests over the Cloud Storage gRPC API,
+// recording to and replaying from golden files the same way newHarness does.
+type grpcHarness struct {
+	client  *storage.Client
+	cleanup func()
+	bucket  string
+}
+
+func newGRPCHarness(zonal bool) func(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
+	return func(ctx context.Context, t *testing.T) (drivertest.Harness, error) {
+		t.Helper()
+		conn, done := setup.NewGCPgRPCConn(ctx, t, storageGRPCEndpoint, "blob")
+		opts := []option.ClientOption{option.WithGRPCConn(conn)}
+		if zonal {
+			opts = append(opts, storage.WithAppendableUploads(), storage.WithGRPCBidiReads())
+		}
+		// The connection carries credentials when recording and is a replayer
+		// otherwise, so this deliberately does not go through DialGRPC.
+		client, err := storage.NewGRPCClient(ctx, opts...)
+		if err != nil {
+			done()
+			return nil, err
+		}
+		return &grpcHarness{
+			client:  client,
+			cleanup: func() { _ = client.Close(); done() },
+			bucket:  bucketName,
+		}, nil
+	}
+}
+
+func (h *grpcHarness) MakeDriver(ctx context.Context) (driver.Bucket, error) {
+	return openBucket(ctx, nil, h.bucket, &Options{Client: h.client})
+}
+
+func (h *grpcHarness) MakeDriverForNonexistentBucket(ctx context.Context) (driver.Bucket, error) {
+	return openBucket(ctx, nil, "bucket-does-not-exist", &Options{Client: h.client})
+}
+
 // HTTPClient returns nil: without a GoogleAccessID and a signer, SignedURL
 // reports Unimplemented and drivertest skips the checks that would need this.
 // SignedURL is signed client-side and is unaffected by the transport.
+func (h *grpcHarness) HTTPClient() *http.Client { return nil }
+
+func (h *grpcHarness) Close() { h.cleanup() }
+
+// TestConformanceGRPC runs the conformance suite over the Cloud Storage gRPC
+// API, replaying from testdata/TestConformanceGRPC.
+//
+// Those golden files are not committed yet, so the test skips unless -record is
+// set. To record them:
+//
+//  1. Point bucketName at a bucket to which you can write.
+//  2. rm -rf blob/gcsblob/testdata/TestConformanceGRPC
+//  3. go test ./blob/gcsblob/ -run 'TestConformanceGRPC$' -record
+//  4. Restore bucketName and drop the skip below.
+//
+// Recording needs Application Default Credentials with write access to that
+// bucket. The bucket name is part of every recorded request, so bucketName and
+// the golden files always have to be regenerated together. Note that it is
+// shared with TestConformance, whose golden files were recorded against the
+// same bucket, so either re-record both or restore bucketName afterwards.
+func TestConformanceGRPC(t *testing.T) {
+	if !*setup.Record {
+		t.Skip("no golden files recorded yet; re-record them as described above and drop this skip")
+	}
+	drivertest.RunConformanceTests(t, newGRPCHarness(false), []drivertest.AsTest{verifyContentLanguage{}})
+}
+
+// TestConformanceGRPCZonal is TestConformanceGRPC with the zonal bucket APIs
+// enabled, which is what a Rapid Storage bucket requires.
+//
+// It is skipped unconditionally. Against a Rapid Storage bucket 55 checks pass
+// and 33 fail, and every failure is a Cloud Storage restriction rather than a
+// driver bug. drivertest cannot currently express "this driver does not support
+// X": the only opt-out is returning gcerrors.Unimplemented, and every place
+// that honors it guards SignedURL, while testCopy treats any error from Copy as
+// a failure.
+//
+// Once specific conformance tests can be disabled, these are the ones to
+// disable, and why:
+//
+//   - TestCopy, TestKeys and TestAs. Rapid Storage does not support object
+//     rewrite, so Copy fails with "Rapid storage class objects do not support
+//     rewrite". Only TestCopy is about copying; TestKeys and TestAs copy
+//     incidentally, and TestKeys accounts for 19 of the 33 failures because it
+//     copies once per key it exercises.
+//     https://docs.cloud.google.com/storage/docs/rapid/rapid-bucket
+//
+//   - TestListDelimiters/backslash and TestListDelimiters/abc. Rapid Storage
+//     requires a hierarchical namespace, and such buckets only support "/" as a
+//     delimiter; anything else fails with "Invalid argument".
+//     TestListDelimiters/fwdslash passes.
+//
+//   - TestWrite/Content_md5_match, TestWrite/Content_md5_did_not_match,_blob_existed,
+//     TestWrite/a_small_text_file_gets_a_ContentType and
+//     TestWrite/write_with_explicit_ContentType_overrides_discovery. These
+//     rewrite one object in a tight loop and hit "exceeded the rate limit for
+//     object mutation operations". That is the general Cloud Storage
+//     per-object mutation limit rather than a Rapid Storage restriction, and it
+//     only appears when the client is close enough to the bucket to trip it:
+//     these four failed from a VM in the bucket's zone but not from a laptop.
+//     They may not need a permanent skip.
+func TestConformanceGRPCZonal(t *testing.T) {
+	t.Skip("Rapid Storage does not support object rewrite or non-\"/\" list delimiters; see the comment above for the tests that need to be skipped")
+	drivertest.RunConformanceTests(t, newGRPCHarness(true), []drivertest.AsTest{verifyContentLanguage{}})
+}
+
 func BenchmarkGcsblob(b *testing.B) {
 	ctx := context.Background()
 	creds, err := gcp.DefaultCredentials(ctx)


### PR DESCRIPTION
This pull request adds support for the Cloud Storage gRPC API to `gcsblob`, and on top of it, support for Rapid Storage (zonal) buckets.

> **Updated after review.** `Options.UseGRPC` and `Options.UseZonalAPIs` are gone, replaced by a `Dial` plus a constructor following `secrets/gcpkms`. **`TestConformanceGRPC` is now a record/replay test.** It passes all 88 checks, but the golden files need recording against your bucket, so CI is red until then; see Testing. Details in "What changed since the review" at the bottom.

## API

```go
func DialGRPC(ctx context.Context, ts gcp.TokenSource, opts ...option.ClientOption) (*storage.Client, func(), error)
func OpenBucketGRPC(client *storage.Client, bucketName string, opts *Options) (*blob.Bucket, error)
```

```go
c, cleanup, err := gcsblob.DialGRPC(ctx, ts,
	storage.WithAppendableUploads(), storage.WithGRPCBidiReads())
if err != nil { ... }
defer cleanup()
b, err := gcsblob.OpenBucketGRPC(c, "my-rapid-bucket", nil)
```

`OpenBucketGRPC` takes no context, matching `gcpkms.OpenKeeper`: once a client exists there is nothing left to cancel. `Options.Client`, which has accepted a `*storage.Client` since v0.44.0, keeps working unchanged.

For callers whose entire configuration is a URL string, and who therefore have nowhere to put a client, there are two query parameters:

| Parameter | Effect |
|---|---|
| `grpc=true` | Uses the gRPC transport. |
| `zonal=true` | Additionally enables the zonal bucket APIs. Implies `grpc=true`. |

```go
b, err := blob.OpenBucket(ctx, "gs://my-rapid-bucket?zonal=true")
```

Combining `zonal=true` with an explicit `grpc=false` is rejected rather than silently overridden. `URLOpener` gains a `TokenSource`, populated by `lazyCredsOpener` from the credentials it already resolves, because a gRPC client cannot reuse an HTTP one.

## Why Rapid Storage needs more than a transport switch

Zonal buckets accept only appendable object uploads. Every ordinary write is rejected, on both transports:

```
gs://bucket?grpc=true   InvalidArgument: This bucket type only supports appendable objects
gs://bucket             googleapi: Error 400: This bucket requires appendable objects
```

An appendable object is uploaded over a bidirectional stream. It becomes visible as soon as the first bytes are flushed and stays open for further writes until something finalizes it. Ordinary uploads, one-shot or resumable, produce an object only once the whole payload has been sent. Zonal buckets support the appendable form and nothing else.

So two things are needed:

1. `storage.WithAppendableUploads()` and `storage.WithGRPCBidiReads()` on the client. The first makes `ObjectHandle.NewWriter` default `Writer.Append` to true, which selects the appendable upload path; the second switches reads to the bidirectional API. These were a single `experimental.WithZonalBucketAPIs()` until storage v1.67.0 split them and graduated both out of `experimental`.
2. `Writer.FinalizeOnClose` on the writer. An appendable object stays open by default, so `Close` leaves an unfinalized object exposing only the bytes that happened to be flushed. For a payload small enough to fit in one buffer that is a **zero-length object, even though `Close` returned no error**.

Reads already worked on both transports without any change.

## Notes for review

**`FinalizeOnClose` is set unconditionally in `NewTypedWriter`.** This looked risky to me too, so I traced it. The field never appears in `http_client.go`, so the JSON/HTTP writer cannot see it. In `grpc_writer.go` the only read is `gRPCAppendBidiWriteBufferSender.send`, and `pickBufferSender` returns that sender only when `Writer.Append` is set. It is dead code on every path `gcsblob` uses today.

**Buckets now close the client they created.** `Close` was a no-op. A gRPC client owns a connection pool, so every `OpenBucketURL` with `grpc`/`zonal` leaked one for the process lifetime. Clients supplied by the caller, through `OpenBucketGRPC` or `Options.Client`, are left alone.

**Emulator handling on the gRPC path is left to the storage library.** Reusing `STORAGE_EMULATOR_HOST` would not work: it is the HTTP endpoint, and a local emulator needs a separate port for gRPC. Passing it to `option.WithEndpoint` alongside `option.WithoutAuthentication` would also still dial over TLS, because skipping credentials does not make the transport plaintext. `defaultGRPCOptions` already reads `STORAGE_EMULATOR_HOST_GRPC`, strips the scheme, dials insecurely and disables client metrics, and those defaults are merged ahead of caller-supplied options. `lazyCredsOpener` checks that variable too.

**gRPC on its own is not a speedup.** From an `n2-standard-4` in `us-central1-c`, 1 KiB objects each read exactly once, n=1000:

| Bucket | JSON/HTTP p50 | JSON/HTTP p99 | gRPC p50 | gRPC p99 |
|---|---|---|---|---|
| Rapid Storage (zonal), `zonal=true` | * | * | **12.0 ms** | **34.5 ms** |
| NAM4 dual-region | 35.4 ms | 69.2 ms | 35.5 ms | 73.2 ms |
| US multi-region | 61.2 ms | 150.9 ms | 59.2 ms | 124.6 ms |

\* Not comparable: a zonal bucket rejects every write over JSON/HTTP.

On the standard buckets plain gRPC is a wash, and on a smaller `e2-standard-4` it was consistently slower, so the docs say to measure before enabling it. The win is the zonal bucket: 2.9x faster than NAM4 and 5.1x faster than multi-region.

## Testing

`go test ./blob/gcsblob/` passes and the existing replay tests are unaffected. New unit tests cover the `grpc` and `zonal` parameters, their invalid values, the `zonal=true` plus `grpc=false` conflict, and `OpenBucketGRPC` including that the caller's client survives `bucket.Close`.

`TestConformanceGRPC` runs the full drivertest suite over gRPC.

It records to and replays from `testdata/TestConformanceGRPC`, the same way `TestConformance` does. Recorded against a bucket I control it passes all 88 checks, over four consecutive offline replays.

**The golden files are not in this PR, so `TestConformanceGRPC` currently fails and CI will be red.** Recording embeds the bucket name in every request, so golden files only replay against the bucket they were made with, and I cannot write to `go-cloud-blob-test-bucket`. Committing mine would not have helped: with `bucketName` pointing at yours they fail to match, and each mismatch waits out a stream-selection timeout, so the suite takes four minutes to fail instead of half a second.

The procedure is in the test's doc comment:

```
1. Point bucketName at a bucket to which you can write.
2. rm -rf blob/gcsblob/testdata/TestConformanceGRPC
3. go test ./blob/gcsblob/ -run 'TestConformanceGRPC$' -record
```

Restricting `-run` keeps it from also re-recording `TestConformance`, which needs a private key for SignedURL. Note `bucketName` is shared with that test, so either re-record both or restore the constant afterwards.

Getting the suite recordable at all needed three fixes to `grpcreplay`, all merged and released in v1.5.0, which master already depends on: [#70](https://github.com/google/go-replayers/pull/70) for the zero-copy read codec, [#71](https://github.com/google/go-replayers/pull/71) for subtests that make no RPCs, and [#72](https://github.com/google/go-replayers/pull/72) for non-deterministic matching of concurrent bidirectional streams.

I also verified against a real Rapid Storage bucket that writes, reads, attributes, range reads and 1 MiB writes all succeed where they fail outright on master, and that objects written through `zonal=true` come back finalized, `size=23` with a non-zero `Finalized`, against `size=0` without the `FinalizeOnClose` line.

### TestConformanceGRPCZonal is skipped

It is present but skipped unconditionally, because it cannot pass. Deleting one `t.Skip` enables it once specific conformance tests can be disabled. Against a Rapid Storage bucket, 55 checks pass and 33 fail, none of them driver bugs:

- **`Rapid storage class objects do not support rewrite`** accounts for three of the five failing groups. Only `TestCopy` is about copying; `TestKeys` and `TestAs` copy incidentally, and `TestKeys` alone contributes 19 failures because it copies once per weird key.
- **Listing with a delimiter other than `/`** fails with `Invalid argument`. That is a hierarchical namespace restriction, which Rapid Storage inherits by requiring HNS, rather than anything to do with zonal buckets or gRPC.
- **`TestWrite` hits the per-object mutation rate limit.** Not a Rapid Storage limit at all, just the general GCS cap, and it only appeared when running from a VM in the bucket's zone, fast enough to trip it. The failure count varied with distance: 27 from a laptop, 33 from in-zone.

`drivertest` cannot express any of this. Its only opt-out is the `Unimplemented` error code, and all six places that honor it guard `SignedURL`; `testCopy` treats any error from `Copy` as a failure. The test's doc comment names the exact subtests to disable and why, so it can be switched on by deleting one `t.Skip` once selective disabling exists.

## What this PR does not do

It does not deliver the sub-millisecond reads Rapid Storage is advertised for.

Sub-millisecond is possible, but under certain conditions. You only get it on later reads of one particular object, from a process that has kept a bidirectional read stream open to that object. The first read of any given object costs 11 to 12 ms no matter which API you use.

Same 1 KiB object, same client, n=1000:

| Read | p50 | min |
|---|---|---|
| Never read before, via `NewReader`. This is what the driver does. | 12.0 ms | 6.7 ms |
| Never read before, by opening a `MultiRangeDownloader` for it | 11.1 ms | 6.3 ms |
| Same object again, on the stream already open | **0.95 ms** | 0.59 ms |
| Same object again, with a `ReadHandle` cached from the earlier read | 4.3 ms | 2.6 ms |

Getting there means keeping state alive between reads. Two ways:

- Cache open [`MultiRangeDownloader`](https://github.com/googleapis/google-cloud-go/blob/storage/v1.64.0/storage/reader.go#L269)s per object on the driver's `bucket`. Reaches the third row. Needs idle expiry, cleanup from `bucket.Close`, and an adapter from [`Add`](https://github.com/googleapis/google-cloud-go/blob/storage/v1.64.0/storage/reader.go#L575)'s callback to `io.Reader`.
- Cache [`ReadHandle`](https://github.com/googleapis/google-cloud-go/blob/storage/v1.64.0/storage/reader.go#L531)s per object. Much smaller, but only reaches the fourth row.

Neither has anywhere to live today. [`driver.Bucket.NewRangeReader`](https://github.com/google/go-cloud/blob/29ba3487e2e12a9a270aea9c74ca99bde8117885/blob/driver/driver.go#L305) hands back a fresh [`driver.Reader`](https://github.com/google/go-cloud/blob/29ba3487e2e12a9a270aea9c74ca99bde8117885/blob/driver/driver.go#L41-L51) per call, and the portable layer [makes a new one for every read](https://github.com/google/go-cloud/blob/29ba3487e2e12a9a270aea9c74ca99bde8117885/blob/blob.go#L1058) and [discards it on a Seek](https://github.com/google/go-cloud/blob/29ba3487e2e12a9a270aea9c74ca99bde8117885/blob/blob.go#L143-L147).

## What changed since the review

- **`Options.UseGRPC` and `Options.UseZonalAPIs` removed.** Replaced by `DialGRPC` and `OpenBucketGRPC`, per your `gcpkms` suggestion.
- **The half-used `gcp.HTTPClient` is gone from the gRPC path.** You were right that it was odd. It was not entirely ignored, its OAuth2 token source was reused, but everything else about it was dropped, and when the transport was not exactly an `*oauth2.Transport` the code silently fell back to `option.WithoutAuthentication`. A caller with a wrapped transport got an anonymous client and 403s at request time. Now a nil token source means unauthenticated explicitly, and a gRPC URL with neither credentials nor `anonymous=true` is an error.
- **Client ownership fixed.** See the note above; `Close` used to leak.
- **Rebased onto master**, which picks up `12ac9a59` and fixes the golangci-lint failure. That failure was never related to this change; it was Go 1.27 against golangci-lint v2.12.
- **`TestConformanceGRPC` and `TestConformanceGRPCZonal` added**, with the caveats above. The zonal one is skipped unconditionally with a comment naming the subtests that need disabling and why, per your suggestion.
- **`TestConformanceGRPC` is now a record/replay test**, passing 88 of 88 when recorded. This needed three `grpcreplay` fixes, all merged and released in v1.5.0. The golden files still need recording against your bucket.
- **Migrated off `experimental.WithZonalBucketAPIs`**, which storage v1.67.0 removed. It is now `storage.WithAppendableUploads()` plus `storage.WithGRPCBidiReads()`, both of which have graduated out of `experimental`, so this PR no longer depends on an experimental package.

Two things I would rather you decide:

1. **Should `Options.Client` be marked deprecated** now that `OpenBucketGRPC` exists? It is released API, added in `ab74300b`, so it cannot be withdrawn, but it is now a second way to do the same thing.
2. **Should the `grpc` and `zonal` URL parameters stay?** You said the URL option is fine, and I have kept them, but they are the part of this PR that adds surface area. The argument for them is that a caller configured purely by a connection string has no other way to reach a Rapid Storage bucket; anyone writing Go already has `OpenBucketGRPC`.
