### PR TITLE
.github: bump golangci-lint to v2.13.1 for Go 1.27

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,11 +20,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.13.1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,4 +27,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12
+          version: v2.13.1


### PR DESCRIPTION
## Fix golangci-lint crash on Go 1.27

The `golangci-lint` workflow installs Go via `setup-go` with `go-version: stable`, which now resolves to Go 1.27. golangci-lint v2.12.2 is built with Go 1.26, so its embedded `go/types` cannot type-check the Go 1.27 standard library and the run panics:

```
panic: file requires newer Go version go1.27 (application built with go1.26)
```

golangci-lint v2.13.1 is built with Go 1.27, matching the stable toolchain. It adds no new linters to the default set, and the existing code passes with 0 issues.

## Pin workflow actions to commit SHAs

The zizmor mandatory check requires every action reference to be pinned to a full commit SHA rather than a tag. This pins `actions/checkout`, `actions/setup-go`, and `golangci/golangci-lint-action` to the commit each tag resolves to, keeping the tag as a trailing comment.