### PR TITLE
blob/fileblob: don't end a list page before a key that sorts earlier

### DIFF
--- a/blob/fileblob/fileblob.go
+++ b/blob/fileblob/fileblob.go
@@ -536,11 +536,13 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 			return nil
 		}
 		// If we've already got a full page of results, set NextPageToken and stop.
-		// Unless the current object is a directory, in which case there may
-		// still be objects coming that are alphabetically before it (since
-		// we appended the delimiter). In that case, keep going; we'll trim the
-		// extra entries (if any) before returning.
-		if len(result.Objects) == pageSize && !obj.IsDir {
+		// We can only stop if this object is guaranteed to belong after the page,
+		// i.e. it sorts after the last object in it. That isn't always the case:
+		// adding the delimiter can make an object sort before one we've already
+		// added (e.g., the file "a-b" sorts before the "directory" "a/", but is
+		// visited after it), so keep going in that case; we'll trim the extra
+		// entries before returning.
+		if len(result.Objects) == pageSize && !obj.IsDir && obj.Key > result.Objects[pageSize-1].Key {
 			result.NextPageToken = []byte(result.Objects[pageSize-1].Key)
 			return io.EOF
 		}

--- a/blob/fileblob/fileblob_test.go
+++ b/blob/fileblob/fileblob_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -682,5 +683,68 @@ func TestSkipMetadata(t *testing.T) {
 		if err := b.Delete(ctx, "key"); err != nil {
 			t.Errorf("failed to delete: %v", err)
 		}
+	}
+}
+
+// TestListPagedSortsBeforeDirectory checks that paging doesn't skip keys when a
+// file sorts before the "directory" key generated for its sibling directory.
+// For example, "dir-file" sorts before "dir/" because '-' < '/', but the walk
+// visits "dir/" first, so the file can show up after the page is already full.
+func TestListPagedSortsBeforeDirectory(t *testing.T) {
+	tests := []struct {
+		name string
+		keys []string
+	}{
+		{"one sibling", []string{"dir/a", "dir/b", "dir-file", "f"}},
+		{"several siblings", []string{"a/b", "a-c", "a-d"}},
+		{"nested", []string{"x/y/z", "x-w", "x-v"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			b, err := OpenBucket(t.TempDir(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer closeWithErrorCheck(t, b)
+			for _, key := range test.keys {
+				if err := b.WriteAll(ctx, key, []byte("hello"), nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+			opts := &blob.ListOptions{Delimiter: "/"}
+
+			// An unpaged list gives the keys in the order they should appear.
+			var want []string
+			iter := b.List(opts)
+			for {
+				obj, err := iter.Next(ctx)
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				want = append(want, obj.Key)
+			}
+
+			// Paging must not change the set of keys, or their order.
+			for pageSize := 1; pageSize <= len(test.keys); pageSize++ {
+				var got []string
+				for token := blob.FirstPageToken; token != nil; {
+					objs, next, err := b.ListPage(ctx, token, pageSize, opts)
+					if err != nil {
+						t.Fatal(err)
+					}
+					for _, obj := range objs {
+						got = append(got, obj.Key)
+					}
+					token = next
+				}
+				if !slices.Equal(got, want) {
+					t.Errorf("pageSize %d: got %v, want %v", pageSize, got, want)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Found this while poking at fileblob's listing with a delimiter set.

Write "dir/a", "dir/b", "dir-file" and then page through with pageSize=1: you get "dir/" and then an empty page. "dir-file" never shows up at all. A plain List on the same bucket returns "dir-file", "dir/", which is what I'd expect.

The cause is in ListPaged's early bail-out. It walks the tree with WalkDir, which visits the directory "dir" before the sibling file "dir-file", so the collapsed "dir/" key lands in the page first. When "dir-file" comes along the page is already full and it isn't a directory, so the old code stopped the walk there and set the page token to "dir/". The next page skips anything <= that token, and "dir-file" < "dir/" because '-' sorts before '/', so it gets skipped. Anything that sorts before a directory key it was walked after is affected - "foo-baz" next to "foo/", "n+a" next to "n/", and so on.

The fix just narrows when we're allowed to stop: only if the key we're looking at really does sort after the last key in the page. If it doesn't, we keep walking and let the existing trim at the end of the walk sort out the page. That's the same thing the code already does when the entry is a directory.

Test is in fileblob_test.go: it walks a few layouts with the page size from 1 up and checks the paged result matches an unpaged list. It fails on master for all three layouts, passes with the change.

One thing I left alone: an unpaged List can still return keys slightly out of order for exotic names (the one-slot swap a bit below only fixes an adjacent inversion). I didn't want to rewrite that sorting here, but happy to look at it separately if you want. 